### PR TITLE
feat(v3): define catalog domain model and schema contract

### DIFF
--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -11,5 +11,6 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj" />
+    <Project Path="tests/SkyCD.Domain.Tests/SkyCD.Domain.Tests.csproj" />
   </Folder>
 </Solution>

--- a/docs/domain/catalog-model.md
+++ b/docs/domain/catalog-model.md
@@ -1,0 +1,110 @@
+# SkyCD v3 Catalog Model
+
+## Purpose
+Define the canonical file collection model for v3 and provide EF Core mapping guidance for SQLite persistence work in #63.
+
+## Model Summary
+- `Catalog`
+  - Root aggregate for one indexed collection.
+  - Tracks `SchemaVersion` for forward migration.
+- `CatalogNode`
+  - Represents both folders and files in one hierarchy.
+  - Self-reference via `ParentId`.
+  - `Kind` differentiates folder vs file.
+- `CatalogTag`
+  - Key/value metadata attached to a catalog.
+
+## Entity Definitions
+### Catalog
+- `Id: Guid` (PK)
+- `Name: string` (required, max 256)
+- `SchemaVersion: int` (required, starts at `1`)
+- `CreatedUtc: DateTimeOffset` (required)
+- `UpdatedUtc: DateTimeOffset` (required)
+- `Nodes: ICollection<CatalogNode>`
+- `Tags: ICollection<CatalogTag>`
+
+### CatalogNode
+- `Id: long` (PK)
+- `CatalogId: Guid` (FK -> Catalog)
+- `ParentId: long?` (nullable FK -> CatalogNode)
+- `Kind: CatalogNodeKind` (`Folder`, `File`)
+- `Name: string` (required, max 512)
+- `SizeBytes: long?` (only for `File`)
+- `MimeType: string?` (optional)
+- `LastModifiedUtc: DateTimeOffset?` (optional)
+- `MetadataJson: string?` (optional extension payload)
+
+### CatalogTag
+- `Id: long` (PK)
+- `CatalogId: Guid` (FK -> Catalog)
+- `Name: string` (required, max 128)
+- `Value: string` (required, max 1024)
+
+## Relationship/Cardinality Table
+| From | To | Cardinality | Notes |
+|---|---|---|---|
+| Catalog | CatalogNode | 1:N | Cascade delete |
+| CatalogNode | CatalogNode (Parent->Children) | 1:N | Root nodes have `ParentId = null` |
+| Catalog | CatalogTag | 1:N | Cascade delete |
+
+## EF Core Mapping Notes (for #63)
+- Use `DbContext` entity sets: `Catalogs`, `Nodes`, `Tags`.
+- Configure `CatalogNode.Kind` as numeric enum storage.
+- Add index on `(CatalogId, ParentId)` for hierarchy queries.
+- Add index on `(CatalogId, Kind)` for quick file/folder filtering.
+- Add unique constraint on `(CatalogId, ParentId, Name, Kind)` to reduce accidental duplicates.
+- Configure `SizeBytes` nullable; enforce folder/file constraints in domain validation and tests.
+
+## Versioning Strategy
+- `SchemaVersion` is persisted per catalog.
+- `1` is the baseline schema for v3 rollout.
+- Any breaking data shape change increments schema version.
+- Migrations must include both:
+  - DB migration steps (EF migration in #63)
+  - domain/DTO compatibility notes in docs
+
+## Legacy Field Mapping (v2 -> v3)
+| Legacy Field | v3 Target | Rule |
+|---|---|---|
+| `ID` | `CatalogNode.Id` | Preserve where possible during import |
+| `Name` | `CatalogNode.Name` | Direct map |
+| `ParentID` | `CatalogNode.ParentId` | Direct map, convert invalid parents to root + warning |
+| `Type` | `CatalogNode.Kind` | `scdFile` -> `File`, all others -> `Folder` |
+| `Properties` | `CatalogNode.MetadataJson` | Preserve serialized value |
+| `Size` | `CatalogNode.SizeBytes` | For file nodes only; otherwise null |
+| `AID` | `Catalog.Id` | Map imported collection scope to a single `Catalog` identity |
+
+## Validation Rules
+- Catalog name is required.
+- `SchemaVersion > 0`.
+- Node name is required.
+- `Folder` nodes must have `SizeBytes = null`.
+- `File` nodes cannot have negative `SizeBytes`.
+
+## Plugin DTO Examples
+### Catalog summary payload
+```json
+{
+  "catalogId": "9c3bc0dc-b0dd-4e0e-8efd-97353d6d1f14",
+  "name": "Archive 2026",
+  "schemaVersion": 1,
+  "createdUtc": "2026-04-18T12:00:00Z",
+  "updatedUtc": "2026-04-18T12:00:00Z"
+}
+```
+
+### Node payload
+```json
+{
+  "id": 42,
+  "catalogId": "9c3bc0dc-b0dd-4e0e-8efd-97353d6d1f14",
+  "parentId": 7,
+  "kind": "File",
+  "name": "manual.pdf",
+  "sizeBytes": 1048576,
+  "mimeType": "application/pdf",
+  "lastModifiedUtc": "2026-04-12T09:41:00Z",
+  "metadataJson": "{\"sha256\":\"...\"}"
+}
+```

--- a/src/SkyCD.Domain/Catalogs/Catalog.cs
+++ b/src/SkyCD.Domain/Catalogs/Catalog.cs
@@ -1,0 +1,18 @@
+namespace SkyCD.Domain.Catalogs;
+
+public sealed class Catalog
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public string Name { get; set; } = string.Empty;
+
+    public int SchemaVersion { get; set; } = 1;
+
+    public DateTimeOffset CreatedUtc { get; set; } = DateTimeOffset.UtcNow;
+
+    public DateTimeOffset UpdatedUtc { get; set; } = DateTimeOffset.UtcNow;
+
+    public ICollection<CatalogNode> Nodes { get; } = new List<CatalogNode>();
+
+    public ICollection<CatalogTag> Tags { get; } = new List<CatalogTag>();
+}

--- a/src/SkyCD.Domain/Catalogs/CatalogNode.cs
+++ b/src/SkyCD.Domain/Catalogs/CatalogNode.cs
@@ -1,0 +1,30 @@
+namespace SkyCD.Domain.Catalogs;
+
+public sealed class CatalogNode
+{
+    public long Id { get; set; }
+
+    public Guid CatalogId { get; set; }
+
+    public Catalog? Catalog { get; set; }
+
+    public long? ParentId { get; set; }
+
+    public CatalogNode? Parent { get; set; }
+
+    public ICollection<CatalogNode> Children { get; } = new List<CatalogNode>();
+
+    public CatalogNodeKind Kind { get; set; } = CatalogNodeKind.Folder;
+
+    public string Name { get; set; } = string.Empty;
+
+    public long? SizeBytes { get; set; }
+
+    public string? MimeType { get; set; }
+
+    public DateTimeOffset? LastModifiedUtc { get; set; }
+
+    public string? MetadataJson { get; set; }
+
+    public bool IsRoot => ParentId is null;
+}

--- a/src/SkyCD.Domain/Catalogs/CatalogNodeKind.cs
+++ b/src/SkyCD.Domain/Catalogs/CatalogNodeKind.cs
@@ -1,0 +1,7 @@
+namespace SkyCD.Domain.Catalogs;
+
+public enum CatalogNodeKind : byte
+{
+    Folder = 1,
+    File = 2
+}

--- a/src/SkyCD.Domain/Catalogs/CatalogTag.cs
+++ b/src/SkyCD.Domain/Catalogs/CatalogTag.cs
@@ -1,0 +1,14 @@
+namespace SkyCD.Domain.Catalogs;
+
+public sealed class CatalogTag
+{
+    public long Id { get; set; }
+
+    public Guid CatalogId { get; set; }
+
+    public Catalog? Catalog { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public string Value { get; set; } = string.Empty;
+}

--- a/src/SkyCD.Domain/Catalogs/CatalogValidator.cs
+++ b/src/SkyCD.Domain/Catalogs/CatalogValidator.cs
@@ -1,0 +1,44 @@
+namespace SkyCD.Domain.Catalogs;
+
+public static class CatalogValidator
+{
+    public static IReadOnlyList<string> Validate(Catalog catalog)
+    {
+        var errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(catalog.Name))
+        {
+            errors.Add("Catalog.Name is required.");
+        }
+
+        if (catalog.SchemaVersion <= 0)
+        {
+            errors.Add("Catalog.SchemaVersion must be greater than zero.");
+        }
+
+        foreach (var node in catalog.Nodes)
+        {
+            ValidateNode(node, errors);
+        }
+
+        return errors;
+    }
+
+    private static void ValidateNode(CatalogNode node, ICollection<string> errors)
+    {
+        if (string.IsNullOrWhiteSpace(node.Name))
+        {
+            errors.Add($"CatalogNode[{node.Id}].Name is required.");
+        }
+
+        if (node.Kind == CatalogNodeKind.File && node.SizeBytes is < 0)
+        {
+            errors.Add($"CatalogNode[{node.Id}].SizeBytes cannot be negative for file nodes.");
+        }
+
+        if (node.Kind == CatalogNodeKind.Folder && node.SizeBytes is not null)
+        {
+            errors.Add($"CatalogNode[{node.Id}].SizeBytes must be null for folder nodes.");
+        }
+    }
+}

--- a/src/SkyCD.Domain/Class1.cs
+++ b/src/SkyCD.Domain/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace SkyCD.Domain;
-
-public class Class1
-{
-
-}

--- a/tests/SkyCD.Domain.Tests/CatalogValidatorTests.cs
+++ b/tests/SkyCD.Domain.Tests/CatalogValidatorTests.cs
@@ -1,0 +1,66 @@
+using SkyCD.Domain.Catalogs;
+
+namespace SkyCD.Domain.Tests;
+
+public class CatalogValidatorTests
+{
+    [Fact]
+    public void Validate_ReturnsNoErrors_ForValidCatalog()
+    {
+        var catalog = new Catalog
+        {
+            Name = "Main catalog",
+            SchemaVersion = 1
+        };
+
+        catalog.Nodes.Add(new CatalogNode
+        {
+            Id = 1,
+            CatalogId = catalog.Id,
+            Kind = CatalogNodeKind.Folder,
+            Name = "Root",
+            ParentId = null
+        });
+
+        catalog.Nodes.Add(new CatalogNode
+        {
+            Id = 2,
+            CatalogId = catalog.Id,
+            Kind = CatalogNodeKind.File,
+            Name = "movie.mkv",
+            ParentId = 1,
+            SizeBytes = 1024
+        });
+
+        var errors = CatalogValidator.Validate(catalog);
+
+        Assert.Empty(errors);
+    }
+
+    [Fact]
+    public void Validate_ReturnsErrors_ForInvalidCatalog()
+    {
+        var catalog = new Catalog
+        {
+            Name = "",
+            SchemaVersion = 0
+        };
+
+        catalog.Nodes.Add(new CatalogNode
+        {
+            Id = 1,
+            CatalogId = catalog.Id,
+            Kind = CatalogNodeKind.Folder,
+            Name = "",
+            SizeBytes = 12
+        });
+
+        var errors = CatalogValidator.Validate(catalog);
+
+        Assert.NotEmpty(errors);
+        Assert.Contains(errors, error => error.Contains("Catalog.Name"));
+        Assert.Contains(errors, error => error.Contains("Catalog.SchemaVersion"));
+        Assert.Contains(errors, error => error.Contains("CatalogNode[1].Name"));
+        Assert.Contains(errors, error => error.Contains("CatalogNode[1].SizeBytes"));
+    }
+}

--- a/tests/SkyCD.Domain.Tests/SkyCD.Domain.Tests.csproj
+++ b/tests/SkyCD.Domain.Tests/SkyCD.Domain.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SkyCD.Domain\SkyCD.Domain.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
Implements #62 by defining the v3 catalog domain model and documenting the storage-friendly schema contract.

### Included
- New domain entities in `SkyCD.Domain`:
  - `Catalog`
  - `CatalogNode`
  - `CatalogTag`
  - `CatalogNodeKind`
  - `CatalogValidator`
- New model documentation:
  - `docs/domain/catalog-model.md`
- New domain tests:
  - `tests/SkyCD.Domain.Tests`
  - validation tests for valid/invalid catalog shapes

## Acceptance Criteria Mapping
- Model documented in `docs/domain/catalog-model.md`: ✅
- EF Core mapping notes included (entity graph + cardinality): ✅
- Versioning strategy defined: ✅
- Legacy-to-new mapping table included: ✅
- Example JSON/DTO payloads for plugin APIs included: ✅

## Validation
- `dotnet restore SkyCD.V3.slnx`
- `dotnet build SkyCD.V3.slnx -c Release --no-restore`
- `dotnet test SkyCD.V3.slnx -c Release --no-build`

All passed locally.

Closes #62