### PR TITLE
chore(v3): migrate to BSD-2-Clause and enforce dependency license compliance

### DIFF
--- a/.github/workflows/v3-ci.yml
+++ b/.github/workflows/v3-ci.yml
@@ -32,3 +32,39 @@ jobs:
 
       - name: Test v3 solution
         run: dotnet test SkyCD.V3.slnx --configuration Release --no-build --verbosity normal
+
+  license-compliance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install CycloneDX tool
+        shell: pwsh
+        run: |
+          dotnet tool update --global CycloneDX --version 6.1.1
+          "$env:HOME/.dotnet/tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Generate CycloneDX SBOM (JSON)
+        run: |
+          dotnet-CycloneDX SkyCD.V3.slnx --output artifacts/licenses --filename bom.json --output-format Json --exclude-test-projects
+
+      - name: Validate dependency license policy
+        shell: pwsh
+        run: |
+          ./tools/scripts/ci/check-license-compliance.ps1 `
+            -SbomPath artifacts/licenses/bom.json `
+            -PolicyPath docs/legal/dependency-license-policy.json `
+            -ReportPath artifacts/licenses/license-compliance.json
+
+      - name: Upload license artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: license-artifacts
+          path: artifacts/licenses/

--- a/LICENSE
+++ b/LICENSE
@@ -1,26 +1,23 @@
-Copyright (c) 2004, MekDrop 
-All rights reserved. 
+Copyright (c) 2004, MekDrop
+All rights reserved.
 
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions are met: 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
- * Redistributions of source code must retain the above copyright notice, 
-   this list of conditions and the following disclaimer. 
- * Redistributions in binary form must reproduce the above copyright 
-   notice, this list of conditions and the following disclaimer in the 
-   documentation and/or other materials provided with the distribution. 
- * Neither the name of SkyCD nor the names of its contributors may be used 
-   to endorse or promote products derived from this software without 
-   specific prior written permission. 
+1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
-POSSIBILITY OF SUCH DAMAGE. 
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-[![Download SkyCD](https://img.shields.io/sourceforge/dt/skycd.svg)](https://sourceforge.net/projects/skycd/files/latest/download) [![License](https://img.shields.io/github/license/SkyCD/SkyCD.svg)](License.txt)
+[![Download SkyCD](https://img.shields.io/sourceforge/dt/skycd.svg)](https://sourceforge.net/projects/skycd/files/latest/download) [![License](https://img.shields.io/github/license/SkyCD/SkyCD.svg)](LICENSE)
 # SkyCD
 SkyCD is a program for indexing your files in CDs and CDs also. All indexing information is saved in text files, so anyone can edit or view with existing text editor/viewer. You can also send these files to your friends & they will know what CD you have.
+
+License: BSD-2-Clause.
 
 ![](https://a.fsdn.com/con/app/proj/skycd/screenshots/94408.jpg)
 

--- a/docs/legal/dependency-license-policy.json
+++ b/docs/legal/dependency-license-policy.json
@@ -1,0 +1,38 @@
+{
+  "allowedLicenseIds": [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+    "Zlib"
+  ],
+  "blockedLicenseIds": [
+    "AGPL-1.0",
+    "AGPL-1.0-only",
+    "AGPL-1.0-or-later",
+    "AGPL-3.0",
+    "AGPL-3.0-only",
+    "AGPL-3.0-or-later",
+    "CC-BY-NC-4.0",
+    "GPL-2.0",
+    "GPL-2.0-only",
+    "GPL-2.0-or-later",
+    "GPL-3.0",
+    "GPL-3.0-only",
+    "GPL-3.0-or-later",
+    "LGPL-2.1",
+    "LGPL-2.1-only",
+    "LGPL-2.1-or-later",
+    "LGPL-3.0",
+    "LGPL-3.0-only",
+    "LGPL-3.0-or-later",
+    "SSPL-1.0"
+  ],
+  "failOnUnknownLicense": true,
+  "allowedUnknownLicensePackages": [
+    "Avalonia.Angle.Windows.Natives",
+    "AvaloniaUI.DiagnosticsSupport"
+  ]
+}

--- a/docs/legal/dependency-policy.md
+++ b/docs/legal/dependency-policy.md
@@ -1,0 +1,45 @@
+# Dependency License Policy
+
+## Purpose
+Define a repeatable dependency license compliance process for SkyCD v3.
+
+## Scope
+- Applies to NuGet dependencies used by the v3 solution (`SkyCD.V3.slnx`).
+- Applies to direct and transitive dependencies discovered in the generated SBOM.
+
+## Source of Truth
+- Policy file: `docs/legal/dependency-license-policy.json`
+- Compliance report artifact: `artifacts/licenses/license-compliance.json`
+- SBOM artifact: `artifacts/licenses/bom.json`
+
+## Allowed License Families
+- `MIT`
+- `Apache-2.0`
+- `BSD-2-Clause`
+- `BSD-3-Clause`
+- `ISC`
+- `MPL-2.0`
+- `Zlib`
+
+## Blocked License Families
+- All `GPL`, `LGPL`, `AGPL` variants
+- `SSPL-1.0`
+- `CC-BY-NC-4.0`
+
+## Unknown Licenses
+- Unknown or missing licenses are treated as non-compliant (`failOnUnknownLicense=true`).
+- Package-specific exceptions are permitted in `allowedUnknownLicensePackages` with explicit rationale.
+
+### Current Unknown-License Exceptions
+- `Avalonia.Angle.Windows.Natives` (upstream metadata does not publish SPDX expression)
+- `AvaloniaUI.DiagnosticsSupport` (upstream metadata does not publish SPDX expression)
+
+## Exception Process
+1. Open an issue tagged `type:legal` describing package name/version and business need.
+2. Provide upstream license evidence (official package metadata or project LICENSE file).
+3. If approved, update `dependency-license-policy.json` in a dedicated PR with rationale.
+
+## CI Enforcement
+- CI generates a CycloneDX JSON SBOM.
+- CI evaluates each component license against this policy.
+- Build fails when blocked or unknown licenses are detected.

--- a/tools/scripts/ci/check-license-compliance.ps1
+++ b/tools/scripts/ci/check-license-compliance.ps1
@@ -1,0 +1,149 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$SbomPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$PolicyPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ReportPath
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $SbomPath)) {
+    throw "SBOM file not found: $SbomPath"
+}
+
+if (-not (Test-Path $PolicyPath)) {
+    throw "Policy file not found: $PolicyPath"
+}
+
+$sbom = Get-Content $SbomPath -Raw | ConvertFrom-Json -Depth 100
+$policy = Get-Content $PolicyPath -Raw | ConvertFrom-Json -Depth 20
+
+$allowed = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$blocked = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+foreach ($id in $policy.allowedLicenseIds) { [void]$allowed.Add([string]$id) }
+foreach ($id in $policy.blockedLicenseIds) { [void]$blocked.Add([string]$id) }
+
+$allowedUnknownPackages = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+foreach ($pkg in @($policy.allowedUnknownLicensePackages)) { [void]$allowedUnknownPackages.Add([string]$pkg) }
+
+function Resolve-LicenseTokens {
+    param([string]$LicenseValue)
+
+    if ([string]::IsNullOrWhiteSpace($LicenseValue)) {
+        return @()
+    }
+
+    # Split SPDX expressions conservatively by AND/OR and trim wrappers.
+    $tokens = $LicenseValue -split '\s+OR\s+|\s+AND\s+|\(|\)' |
+        ForEach-Object { $_.Trim() } |
+        Where-Object { $_ -ne "" }
+
+    return $tokens
+}
+
+$results = @()
+$nonCompliant = @()
+
+$components = @($sbom.components)
+foreach ($component in $components) {
+    $licenseValues = @()
+
+    foreach ($licenseEntry in @($component.licenses)) {
+        if ($null -ne $licenseEntry.license.id) {
+            $licenseValues += [string]$licenseEntry.license.id
+            continue
+        }
+
+        if ($null -ne $licenseEntry.license.name) {
+            $licenseValues += [string]$licenseEntry.license.name
+            continue
+        }
+
+        if ($null -ne $licenseEntry.expression) {
+            $licenseValues += [string]$licenseEntry.expression
+            continue
+        }
+    }
+
+    $status = "Compliant"
+    $reasons = @()
+
+    if ($licenseValues.Count -eq 0) {
+        $status = "Unknown"
+        $reasons += "No license metadata."
+    }
+    else {
+        $allTokens = @()
+        foreach ($licenseValue in $licenseValues) {
+            $tokens = Resolve-LicenseTokens -LicenseValue $licenseValue
+            if ($tokens.Count -eq 0) {
+                $allTokens += $licenseValue
+            }
+            else {
+                $allTokens += $tokens
+            }
+        }
+
+        foreach ($token in $allTokens) {
+            if ($blocked.Contains($token)) {
+                $status = "Blocked"
+                $reasons += "Blocked license '$token'."
+            }
+            elseif (-not $allowed.Contains($token)) {
+                if ($status -eq "Compliant") {
+                    $status = "Unknown"
+                }
+                $reasons += "Unknown/unapproved license '$token'."
+            }
+        }
+    }
+
+    $item = [PSCustomObject]@{
+        Name = [string]$component.name
+        Version = [string]$component.version
+        Licenses = $licenseValues
+        Status = $status
+        Reasons = $reasons
+    }
+
+    $results += $item
+
+    $isUnknownException = $status -eq "Unknown" -and $allowedUnknownPackages.Contains([string]$component.name)
+
+    if ($isUnknownException) {
+        $item.Status = "CompliantByException"
+        $item.Reasons = @("Unknown license allowed by policy exception for package '$($component.name)'.")
+        continue
+    }
+
+    if ($status -eq "Blocked" -or ($status -eq "Unknown" -and $policy.failOnUnknownLicense)) {
+        $nonCompliant += $item
+    }
+}
+
+$summary = [PSCustomObject]@{
+    GeneratedUtc = (Get-Date).ToUniversalTime().ToString("o")
+    ComponentsScanned = $results.Count
+    NonCompliantCount = $nonCompliant.Count
+    FailOnUnknownLicense = [bool]$policy.failOnUnknownLicense
+    Results = $results
+}
+
+$reportDir = Split-Path -Parent $ReportPath
+if ($reportDir -and -not (Test-Path $reportDir)) {
+    New-Item -ItemType Directory -Path $reportDir -Force | Out-Null
+}
+
+$summary | ConvertTo-Json -Depth 100 | Set-Content -Path $ReportPath -Encoding UTF8
+
+if ($nonCompliant.Count -gt 0) {
+    Write-Error ("License compliance failed. Non-compliant components: " + $nonCompliant.Count)
+    exit 1
+}
+
+Write-Host "License compliance check passed for $($results.Count) components."


### PR DESCRIPTION
## Summary
Implements #64 by migrating repository licensing to BSD-2-Clause and adding automated dependency license compliance checks.

## Changes
- Replaced root `LICENSE` text with BSD-2-Clause.
- Updated `README.md` license link/statement to BSD-2-Clause.
- Added dependency license policy docs:
  - `docs/legal/dependency-policy.md`
  - `docs/legal/dependency-license-policy.json`
- Added CI compliance script:
  - `tools/scripts/ci/check-license-compliance.ps1`
- Extended v3 CI workflow:
  - Generate CycloneDX JSON SBOM (`artifacts/licenses/bom.json`)
  - Evaluate licenses against policy
  - Emit machine-readable report (`artifacts/licenses/license-compliance.json`)
  - Upload artifacts
  - Fail build on blocked/unknown licenses (except explicit policy exceptions)

## Validation
- `dotnet restore SkyCD.V3.slnx`
- `dotnet build SkyCD.V3.slnx -c Release --no-restore`
- `dotnet test SkyCD.V3.slnx -c Release --no-build`
- `dotnet-CycloneDX SkyCD.V3.slnx --output artifacts/licenses --filename bom.json --output-format Json --exclude-test-projects`
- `./tools/scripts/ci/check-license-compliance.ps1 -SbomPath artifacts/licenses/bom.json -PolicyPath docs/legal/dependency-license-policy.json -ReportPath artifacts/licenses/license-compliance.json`

All passed locally.

Closes #64