### PR TITLE
feat(v3): implement plugin SDK vNext contracts and runtime discovery

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Sample.Json/JsonCatalogPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Json/JsonCatalogPlugin.cs
@@ -1,0 +1,93 @@
+using System.Text;
+using System.Text.Json;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Sample.Json;
+
+public sealed class JsonCatalogPlugin : IPlugin, IFileFormatPluginCapability
+{
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.sample.json",
+        "Sample JSON Format Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Example plugin that exposes JSON file format support.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor(
+            "skycd-json",
+            "SkyCD JSON",
+            [".json"],
+            CanRead: true,
+            CanWrite: true,
+            MimeType: "application/json")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    public async Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var reader = new StreamReader(request.Source, Encoding.UTF8, leaveOpen: true);
+            var json = await reader.ReadToEndAsync(cancellationToken);
+
+            var payload = JsonSerializer.Deserialize<Dictionary<string, object?>>(json);
+            return new FileFormatReadResult
+            {
+                Success = true,
+                Payload = payload ?? new Dictionary<string, object?>()
+            };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatReadResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await JsonSerializer.SerializeAsync(request.Target, request.Payload, cancellationToken: cancellationToken);
+            await request.Target.FlushAsync(cancellationToken);
+
+            return new FileFormatWriteResult
+            {
+                Success = true
+            };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatWriteResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj
@@ -1,10 +1,13 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
 </Project>

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -1,4 +1,8 @@
 <Solution>
+  <Folder Name="/Plugins/" />
+  <Folder Name="/Plugins/samples/">
+    <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
+  </Folder>
   <Folder Name="/src/">
     <Project Path="src/SkyCD.App/SkyCD.App.csproj" />
     <Project Path="src/SkyCD.Application/SkyCD.Application.csproj" />
@@ -13,5 +17,6 @@
     <Project Path="tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj" />
     <Project Path="tests/SkyCD.Domain.Tests/SkyCD.Domain.Tests.csproj" />
     <Project Path="tests/SkyCD.Infrastructure.Tests/SkyCD.Infrastructure.Tests.csproj" />
+    <Project Path="tests/SkyCD.Plugin.Runtime.Tests/SkyCD.Plugin.Runtime.Tests.csproj" />
   </Folder>
 </Solution>

--- a/docs/plugins/sdk-contracts.md
+++ b/docs/plugins/sdk-contracts.md
@@ -1,0 +1,27 @@
+# Plugin SDK Contracts (vNext)
+
+## Base Lifecycle
+- `IPlugin`
+  - `Descriptor` metadata (`Id`, `Version`, `MinHostVersion`)
+  - `OnLoadAsync`
+  - `OnInitializeAsync`
+  - `OnActivateAsync`
+  - `DisposeAsync`
+
+## Capability Interfaces
+- `IFileFormatPluginCapability`
+  - Declares supported formats (`FileFormatDescriptor`)
+  - Read/write operations with typed request/response payloads
+- `IMenuPluginCapability`
+  - Declares menu contributions and command execution
+- `IModalPluginCapability`
+  - Declares modal descriptors and open handler
+
+## Runtime Discovery
+- Runtime scans assemblies for classes implementing `IPlugin`.
+- Compatibility gate: plugin loads only when `HostVersion >= MinHostVersion`.
+- Capabilities are discovered by implemented interfaces deriving from `IPluginCapability`.
+
+## Sample Plugin
+- `Plugins/samples/SkyCD.Plugin.Sample.Json`
+- Compiles against `SkyCD.Plugin.Abstractions` and demonstrates `IFileFormatPluginCapability`.

--- a/docs/plugins/sdk-versioning-policy.md
+++ b/docs/plugins/sdk-versioning-policy.md
@@ -1,0 +1,32 @@
+# Plugin SDK Versioning and Compatibility Policy
+
+## Scope
+Applies to `SkyCD.Plugin.Abstractions` and runtime discovery behavior.
+
+## Semantic Versioning Rules
+- SDK uses SemVer: `MAJOR.MINOR.PATCH`.
+- `PATCH`: documentation or non-breaking implementation detail changes.
+- `MINOR`: backward-compatible additions (new optional members, new capability interfaces).
+- `MAJOR`: breaking contract changes (removed/renamed members, changed signatures, behaviorally incompatible changes).
+
+## Host Compatibility
+- Every plugin must declare:
+  - `PluginDescriptor.Version`
+  - `PluginDescriptor.MinHostVersion`
+- Runtime compatibility check:
+  - plugin is loadable only if `HostVersion >= MinHostVersion`
+
+## Breaking Change Process
+1. Propose change in a dedicated issue/PR with impact table.
+2. Bump SDK major version.
+3. Provide migration notes and sample updates.
+4. Keep previous major branch support window documented.
+
+## Capability Evolution
+- Additive capability changes should prefer new interfaces (e.g. `IMenuPluginCapabilityV2`) to avoid breaking existing plugins.
+- Host should probe capabilities dynamically at runtime.
+
+## Runtime Discovery Contract
+- Runtime discovers plugin classes implementing `IPlugin`.
+- Runtime discovers capabilities by implemented interfaces inheriting `IPluginCapability`.
+- Incompatible plugins are skipped, not crashed.

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/FileFormatDescriptor.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/FileFormatDescriptor.cs
@@ -1,0 +1,12 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+
+/// <summary>
+/// Describes a file format supported by a plugin capability.
+/// </summary>
+public sealed record FileFormatDescriptor(
+    string FormatId,
+    string DisplayName,
+    IReadOnlyCollection<string> Extensions,
+    bool CanRead,
+    bool CanWrite,
+    string? MimeType = null);

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/FileFormatReadRequest.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/FileFormatReadRequest.cs
@@ -1,0 +1,22 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+
+/// <summary>
+/// Input payload for file format read operations.
+/// </summary>
+public sealed class FileFormatReadRequest
+{
+    /// <summary>
+    /// Gets the source stream containing file content.
+    /// </summary>
+    public required Stream Source { get; init; }
+
+    /// <summary>
+    /// Gets the format identifier chosen by host routing.
+    /// </summary>
+    public required string FormatId { get; init; }
+
+    /// <summary>
+    /// Gets optional file name metadata.
+    /// </summary>
+    public string? FileName { get; init; }
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/FileFormatReadResult.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/FileFormatReadResult.cs
@@ -1,0 +1,22 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+
+/// <summary>
+/// Result payload for file format read operations.
+/// </summary>
+public sealed class FileFormatReadResult
+{
+    /// <summary>
+    /// Gets whether the operation completed successfully.
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets parsed payload when operation succeeds.
+    /// </summary>
+    public object? Payload { get; init; }
+
+    /// <summary>
+    /// Gets an optional failure message when operation fails.
+    /// </summary>
+    public string? Error { get; init; }
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/FileFormatWriteRequest.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/FileFormatWriteRequest.cs
@@ -1,0 +1,27 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+
+/// <summary>
+/// Input payload for file format write operations.
+/// </summary>
+public sealed class FileFormatWriteRequest
+{
+    /// <summary>
+    /// Gets the target stream where plugin writes serialized content.
+    /// </summary>
+    public required Stream Target { get; init; }
+
+    /// <summary>
+    /// Gets the format identifier chosen by host routing.
+    /// </summary>
+    public required string FormatId { get; init; }
+
+    /// <summary>
+    /// Gets optional file name metadata.
+    /// </summary>
+    public string? FileName { get; init; }
+
+    /// <summary>
+    /// Gets the domain payload to serialize.
+    /// </summary>
+    public required object Payload { get; init; }
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/FileFormatWriteResult.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/FileFormatWriteResult.cs
@@ -1,0 +1,17 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+
+/// <summary>
+/// Result payload for file format write operations.
+/// </summary>
+public sealed class FileFormatWriteResult
+{
+    /// <summary>
+    /// Gets whether the operation completed successfully.
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets optional failure message when operation fails.
+    /// </summary>
+    public string? Error { get; init; }
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/IFileFormatPluginCapability.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/IFileFormatPluginCapability.cs
@@ -1,0 +1,24 @@
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+
+/// <summary>
+/// Capability contract for plugins that provide file format read/write support.
+/// </summary>
+public interface IFileFormatPluginCapability : IPluginCapability
+{
+    /// <summary>
+    /// Gets file formats supported by this capability.
+    /// </summary>
+    IReadOnlyCollection<FileFormatDescriptor> SupportedFormats { get; }
+
+    /// <summary>
+    /// Reads structured payload from source stream.
+    /// </summary>
+    Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Writes structured payload to target stream.
+    /// </summary>
+    Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/IPluginCapability.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/IPluginCapability.cs
@@ -1,0 +1,8 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities;
+
+/// <summary>
+/// Marker interface for plugin capabilities discoverable by the host.
+/// </summary>
+public interface IPluginCapability
+{
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Menu/IMenuPluginCapability.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Menu/IMenuPluginCapability.cs
@@ -1,0 +1,17 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.Menu;
+
+/// <summary>
+/// Capability contract for plugins that contribute host menu commands.
+/// </summary>
+public interface IMenuPluginCapability : IPluginCapability
+{
+    /// <summary>
+    /// Gets declarative menu contributions.
+    /// </summary>
+    IReadOnlyCollection<MenuContribution> GetMenuContributions();
+
+    /// <summary>
+    /// Executes a contributed command.
+    /// </summary>
+    Task ExecuteMenuCommandAsync(string commandId, MenuCommandContext context, CancellationToken cancellationToken = default);
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Menu/MenuCommandContext.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Menu/MenuCommandContext.cs
@@ -1,0 +1,22 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.Menu;
+
+/// <summary>
+/// Context passed to menu command execution.
+/// </summary>
+public sealed class MenuCommandContext
+{
+    /// <summary>
+    /// Gets active catalog identifier.
+    /// </summary>
+    public Guid? ActiveCatalogId { get; init; }
+
+    /// <summary>
+    /// Gets selected node identifier.
+    /// </summary>
+    public long? SelectedNodeId { get; init; }
+
+    /// <summary>
+    /// Gets optional extension payload from host.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Properties { get; init; }
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Menu/MenuContribution.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Menu/MenuContribution.cs
@@ -1,0 +1,10 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.Menu;
+
+/// <summary>
+/// Describes a host menu contribution exposed by a plugin.
+/// </summary>
+public sealed record MenuContribution(
+    string CommandId,
+    string Title,
+    string Location,
+    int Order = 0);

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Modal/IModalPluginCapability.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Modal/IModalPluginCapability.cs
@@ -1,0 +1,17 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.Modal;
+
+/// <summary>
+/// Capability contract for plugins that provide modal dialog contributions.
+/// </summary>
+public interface IModalPluginCapability : IPluginCapability
+{
+    /// <summary>
+    /// Gets available modal descriptors.
+    /// </summary>
+    IReadOnlyCollection<ModalDescriptor> GetModals();
+
+    /// <summary>
+    /// Opens a plugin-contributed modal request and returns typed output.
+    /// </summary>
+    Task<ModalOpenResult> OpenModalAsync(ModalOpenRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Modal/ModalDescriptor.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Modal/ModalDescriptor.cs
@@ -1,0 +1,10 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.Modal;
+
+/// <summary>
+/// Describes a modal dialog contributed by a plugin.
+/// </summary>
+public sealed record ModalDescriptor(
+    string ModalId,
+    string Title,
+    int Width,
+    int Height);

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Modal/ModalOpenRequest.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Modal/ModalOpenRequest.cs
@@ -1,0 +1,17 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.Modal;
+
+/// <summary>
+/// Request payload for opening a contributed modal.
+/// </summary>
+public sealed class ModalOpenRequest
+{
+    /// <summary>
+    /// Gets modal identifier.
+    /// </summary>
+    public required string ModalId { get; init; }
+
+    /// <summary>
+    /// Gets optional input payload.
+    /// </summary>
+    public object? Input { get; init; }
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Modal/ModalOpenResult.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Modal/ModalOpenResult.cs
@@ -1,0 +1,22 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.Modal;
+
+/// <summary>
+/// Result payload for modal operations.
+/// </summary>
+public sealed class ModalOpenResult
+{
+    /// <summary>
+    /// Gets whether the modal completed successfully.
+    /// </summary>
+    public required bool Success { get; init; }
+
+    /// <summary>
+    /// Gets optional output payload.
+    /// </summary>
+    public object? Output { get; init; }
+
+    /// <summary>
+    /// Gets optional failure message.
+    /// </summary>
+    public string? Error { get; init; }
+}

--- a/src/SkyCD.Plugin.Abstractions/Class1.cs
+++ b/src/SkyCD.Plugin.Abstractions/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace SkyCD.Plugin.Abstractions;
-
-public class Class1
-{
-
-}

--- a/src/SkyCD.Plugin.Abstractions/Lifecycle/IPlugin.cs
+++ b/src/SkyCD.Plugin.Abstractions/Lifecycle/IPlugin.cs
@@ -1,0 +1,27 @@
+namespace SkyCD.Plugin.Abstractions.Lifecycle;
+
+/// <summary>
+/// Base plugin contract used by the host runtime.
+/// </summary>
+public interface IPlugin : IAsyncDisposable
+{
+    /// <summary>
+    /// Gets immutable plugin metadata.
+    /// </summary>
+    PluginDescriptor Descriptor { get; }
+
+    /// <summary>
+    /// Executes when the runtime loads the plugin assembly and creates an instance.
+    /// </summary>
+    ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes when host dependencies are available and plugin can initialize state.
+    /// </summary>
+    ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Executes when plugin becomes active and can serve runtime capabilities.
+    /// </summary>
+    ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default);
+}

--- a/src/SkyCD.Plugin.Abstractions/Lifecycle/PluginDescriptor.cs
+++ b/src/SkyCD.Plugin.Abstractions/Lifecycle/PluginDescriptor.cs
@@ -1,0 +1,16 @@
+namespace SkyCD.Plugin.Abstractions.Lifecycle;
+
+/// <summary>
+/// Describes a plugin package and its compatibility requirements.
+/// </summary>
+/// <param name="Id">Stable plugin identifier.</param>
+/// <param name="DisplayName">Human-readable plugin name.</param>
+/// <param name="Version">Plugin semantic version.</param>
+/// <param name="MinHostVersion">Minimum host version required by the plugin.</param>
+/// <param name="Description">Optional plugin description.</param>
+public sealed record PluginDescriptor(
+    string Id,
+    string DisplayName,
+    Version Version,
+    Version MinHostVersion,
+    string? Description = null);

--- a/src/SkyCD.Plugin.Abstractions/Lifecycle/PluginLifecycleContext.cs
+++ b/src/SkyCD.Plugin.Abstractions/Lifecycle/PluginLifecycleContext.cs
@@ -1,0 +1,17 @@
+namespace SkyCD.Plugin.Abstractions.Lifecycle;
+
+/// <summary>
+/// Shared context object passed to plugin lifecycle methods.
+/// </summary>
+public sealed class PluginLifecycleContext
+{
+    /// <summary>
+    /// Gets the host version for compatibility checks.
+    /// </summary>
+    public required Version HostVersion { get; init; }
+
+    /// <summary>
+    /// Gets the host service provider exposed to plugins.
+    /// </summary>
+    public IServiceProvider? Services { get; init; }
+}

--- a/src/SkyCD.Plugin.Host/Class1.cs
+++ b/src/SkyCD.Plugin.Host/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace SkyCD.Plugin.Host;
-
-public class Class1
-{
-
-}

--- a/src/SkyCD.Plugin.Host/PluginCatalog.cs
+++ b/src/SkyCD.Plugin.Host/PluginCatalog.cs
@@ -1,0 +1,29 @@
+using SkyCD.Plugin.Abstractions.Capabilities;
+using SkyCD.Plugin.Runtime.Discovery;
+
+namespace SkyCD.Plugin.Host;
+
+/// <summary>
+/// In-memory plugin catalog used by host services.
+/// </summary>
+public sealed class PluginCatalog
+{
+    private readonly List<DiscoveredPlugin> _plugins = [];
+
+    public IReadOnlyCollection<DiscoveredPlugin> Plugins => _plugins;
+
+    public void SetPlugins(IEnumerable<DiscoveredPlugin> discovered)
+    {
+        _plugins.Clear();
+        _plugins.AddRange(discovered);
+    }
+
+    public IReadOnlyList<TCapability> GetCapabilities<TCapability>()
+        where TCapability : class, IPluginCapability
+    {
+        return _plugins
+            .SelectMany(plugin => plugin.Capabilities)
+            .OfType<TCapability>()
+            .ToList();
+    }
+}

--- a/src/SkyCD.Plugin.Runtime/Class1.cs
+++ b/src/SkyCD.Plugin.Runtime/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace SkyCD.Plugin.Runtime;
-
-public class Class1
-{
-
-}

--- a/src/SkyCD.Plugin.Runtime/Discovery/DiscoveredPlugin.cs
+++ b/src/SkyCD.Plugin.Runtime/Discovery/DiscoveredPlugin.cs
@@ -1,0 +1,14 @@
+using SkyCD.Plugin.Abstractions.Capabilities;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Runtime.Discovery;
+
+/// <summary>
+/// Runtime wrapper for a loaded plugin and discovered capabilities.
+/// </summary>
+public sealed class DiscoveredPlugin
+{
+    public required IPlugin Plugin { get; init; }
+
+    public required IReadOnlyCollection<IPluginCapability> Capabilities { get; init; }
+}

--- a/src/SkyCD.Plugin.Runtime/Discovery/PluginCompatibilityEvaluator.cs
+++ b/src/SkyCD.Plugin.Runtime/Discovery/PluginCompatibilityEvaluator.cs
@@ -1,0 +1,14 @@
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Runtime.Discovery;
+
+/// <summary>
+/// Evaluates whether a plugin is compatible with the current host version.
+/// </summary>
+public static class PluginCompatibilityEvaluator
+{
+    public static bool IsCompatible(PluginDescriptor descriptor, Version hostVersion)
+    {
+        return hostVersion >= descriptor.MinHostVersion;
+    }
+}

--- a/src/SkyCD.Plugin.Runtime/Discovery/PluginDiscoveryService.cs
+++ b/src/SkyCD.Plugin.Runtime/Discovery/PluginDiscoveryService.cs
@@ -1,0 +1,57 @@
+using System.Reflection;
+using SkyCD.Plugin.Abstractions.Capabilities;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Runtime.Discovery;
+
+/// <summary>
+/// Discovers plugin instances and capabilities from assemblies.
+/// </summary>
+public sealed class PluginDiscoveryService
+{
+    public IReadOnlyList<DiscoveredPlugin> DiscoverFromAssembly(Assembly assembly, Version hostVersion)
+    {
+        var plugins = new List<DiscoveredPlugin>();
+
+        var pluginTypes = assembly.GetTypes()
+            .Where(type => !type.IsAbstract && typeof(IPlugin).IsAssignableFrom(type))
+            .Where(type => type.GetConstructor(Type.EmptyTypes) is not null);
+
+        foreach (var pluginType in pluginTypes)
+        {
+            if (Activator.CreateInstance(pluginType) is not IPlugin pluginInstance)
+            {
+                continue;
+            }
+
+            if (!PluginCompatibilityEvaluator.IsCompatible(pluginInstance.Descriptor, hostVersion))
+            {
+                continue;
+            }
+
+            var capabilityInterfaces = pluginType.GetInterfaces()
+                .Where(@interface => @interface != typeof(IPluginCapability))
+                .Where(@interface => typeof(IPluginCapability).IsAssignableFrom(@interface))
+                .Distinct()
+                .ToList();
+
+            var capabilities = new List<IPluginCapability>();
+            foreach (var capabilityType in capabilityInterfaces)
+            {
+                if (pluginInstance is IPluginCapability capability &&
+                    capabilityType.IsInstanceOfType(capability))
+                {
+                    capabilities.Add(capability);
+                }
+            }
+
+            plugins.Add(new DiscoveredPlugin
+            {
+                Plugin = pluginInstance,
+                Capabilities = capabilities
+            });
+        }
+
+        return plugins;
+    }
+}

--- a/tests/SkyCD.Plugin.Runtime.Tests/PluginDiscoveryServiceTests.cs
+++ b/tests/SkyCD.Plugin.Runtime.Tests/PluginDiscoveryServiceTests.cs
@@ -1,0 +1,66 @@
+using System.Reflection;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Capabilities.Menu;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+using SkyCD.Plugin.Runtime.Discovery;
+
+namespace SkyCD.Plugin.Runtime.Tests;
+
+public class PluginDiscoveryServiceTests
+{
+    [Fact]
+    public void DiscoverFromAssembly_ReturnsCompatiblePluginAndCapabilities()
+    {
+        var discovery = new PluginDiscoveryService();
+
+        var plugins = discovery.DiscoverFromAssembly(Assembly.GetExecutingAssembly(), new Version(3, 0, 0));
+
+        Assert.Single(plugins);
+        Assert.Contains(plugins[0].Capabilities, capability => capability is IMenuPluginCapability);
+        Assert.Contains(plugins[0].Capabilities, capability => capability is IFileFormatPluginCapability);
+    }
+
+    [Fact]
+    public void DiscoverFromAssembly_SkipsIncompatiblePlugin()
+    {
+        var discovery = new PluginDiscoveryService();
+
+        var plugins = discovery.DiscoverFromAssembly(Assembly.GetExecutingAssembly(), new Version(2, 9, 0));
+
+        Assert.Empty(plugins);
+    }
+
+    private sealed class TestCapabilityPlugin : IPlugin, IMenuPluginCapability, IFileFormatPluginCapability
+    {
+        public PluginDescriptor Descriptor => new(
+            "tests.plugin",
+            "Test Plugin",
+            new Version(1, 0, 0),
+            new Version(3, 0, 0),
+            "Runtime discovery test plugin");
+
+        public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+        [
+            new FileFormatDescriptor("test", "Test", [".test"], true, false)
+        ];
+
+        public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public IReadOnlyCollection<MenuContribution> GetMenuContributions() =>
+        [
+            new MenuContribution("tests.command", "Tests", "Tools")
+        ];
+
+        public Task ExecuteMenuCommandAsync(string commandId, MenuCommandContext context, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new FileFormatReadResult { Success = true, Payload = new object() });
+
+        public Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new FileFormatWriteResult { Success = false, Error = "Read-only test format." });
+    }
+}

--- a/tests/SkyCD.Plugin.Runtime.Tests/SkyCD.Plugin.Runtime.Tests.csproj
+++ b/tests/SkyCD.Plugin.Runtime.Tests/SkyCD.Plugin.Runtime.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SkyCD.Plugin.Runtime\SkyCD.Plugin.Runtime.csproj" />
+    <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
Implements #65 by delivering a modern plugin SDK contract layer, runtime capability discovery, compatibility policy, and a compiling sample plugin.

## Included
### SDK contracts (`SkyCD.Plugin.Abstractions`)
- Lifecycle contracts:
  - `IPlugin`
  - `PluginDescriptor`
  - `PluginLifecycleContext`
- Capability contracts:
  - `IFileFormatPluginCapability` + request/result/descriptors
  - `IMenuPluginCapability` + command context/contribution model
  - `IModalPluginCapability` + modal request/result/descriptors
- XML docs are enabled and contracts are XML-documented in code.

### Runtime discovery (`SkyCD.Plugin.Runtime`)
- `PluginDiscoveryService` discovers `IPlugin` implementations from assemblies
- Capability extraction via interfaces inheriting `IPluginCapability`
- Compatibility gate with `PluginCompatibilityEvaluator` (`HostVersion >= MinHostVersion`)

### Host-facing catalog (`SkyCD.Plugin.Host`)
- `PluginCatalog` for storing discovered plugins and resolving capabilities.

### Sample plugin
- `Plugins/samples/SkyCD.Plugin.Sample.Json`
- Compiles against SDK and implements `IFileFormatPluginCapability`.

### Documentation
- `docs/plugins/sdk-contracts.md`
- `docs/plugins/sdk-versioning-policy.md` (SemVer + min host version policy)

### Tests
- New test project: `tests/SkyCD.Plugin.Runtime.Tests`
- Covers runtime discovery of capabilities and compatibility filtering.

## Validation
- `dotnet restore SkyCD.V3.slnx`
- `dotnet build SkyCD.V3.slnx -c Release --no-restore`
- `dotnet test SkyCD.V3.slnx -c Release --no-build`

All passed locally.

Closes #65