### PR TITLE
feat(v3): implement file-format routing with capability gating

### DIFF
--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -17,6 +17,7 @@
     <Project Path="tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj" />
     <Project Path="tests/SkyCD.Domain.Tests/SkyCD.Domain.Tests.csproj" />
     <Project Path="tests/SkyCD.Infrastructure.Tests/SkyCD.Infrastructure.Tests.csproj" />
+    <Project Path="tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj" />
     <Project Path="tests/SkyCD.Plugin.Runtime.Tests/SkyCD.Plugin.Runtime.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/FileFormatReadRequest.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/FileFormatReadRequest.cs
@@ -19,4 +19,9 @@ public sealed class FileFormatReadRequest
     /// Gets optional file name metadata.
     /// </summary>
     public string? FileName { get; init; }
+
+    /// <summary>
+    /// Gets optional progress reporter (0-100).
+    /// </summary>
+    public IProgress<int>? Progress { get; init; }
 }

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/FileFormatWriteRequest.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/FileFormats/FileFormatWriteRequest.cs
@@ -24,4 +24,9 @@ public sealed class FileFormatWriteRequest
     /// Gets the domain payload to serialize.
     /// </summary>
     public required object Payload { get; init; }
+
+    /// <summary>
+    /// Gets optional progress reporter (0-100).
+    /// </summary>
+    public IProgress<int>? Progress { get; init; }
 }

--- a/src/SkyCD.Plugin.Host/FileFormats/FileFormatRoute.cs
+++ b/src/SkyCD.Plugin.Host/FileFormats/FileFormatRoute.cs
@@ -1,0 +1,15 @@
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+
+namespace SkyCD.Plugin.Host.FileFormats;
+
+/// <summary>
+/// Host-facing representation of an available plugin file format route.
+/// </summary>
+public sealed record FileFormatRoute(
+    string PluginId,
+    string FormatId,
+    string DisplayName,
+    IReadOnlyCollection<string> Extensions,
+    bool CanRead,
+    bool CanWrite,
+    string? MimeType);

--- a/src/SkyCD.Plugin.Host/FileFormats/FileFormatRoutingException.cs
+++ b/src/SkyCD.Plugin.Host/FileFormats/FileFormatRoutingException.cs
@@ -1,0 +1,8 @@
+namespace SkyCD.Plugin.Host.FileFormats;
+
+/// <summary>
+/// Typed routing exception for host-level file format operations.
+/// </summary>
+public sealed class FileFormatRoutingException(string message) : Exception(message)
+{
+}

--- a/src/SkyCD.Plugin.Host/FileFormats/FileFormatRoutingService.cs
+++ b/src/SkyCD.Plugin.Host/FileFormats/FileFormatRoutingService.cs
@@ -1,0 +1,95 @@
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+
+namespace SkyCD.Plugin.Host.FileFormats;
+
+/// <summary>
+/// Resolves plugin file format routes and enforces read/write capability gates.
+/// </summary>
+public sealed class FileFormatRoutingService(PluginCatalog pluginCatalog)
+{
+    public IReadOnlyList<FileFormatRoute> GetOpenFormats()
+    {
+        return GetRoutesInternal()
+            .Where(route => route.CanRead)
+            .ToList();
+    }
+
+    public IReadOnlyList<FileFormatRoute> GetSaveFormats()
+    {
+        return GetRoutesInternal()
+            .Where(route => route.CanWrite)
+            .ToList();
+    }
+
+    public async Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        var capability = ResolveCapability(request.FormatId);
+        var format = ResolveFormat(capability, request.FormatId);
+
+        if (!format.CanRead)
+        {
+            throw new FileFormatRoutingException($"Format '{request.FormatId}' is not readable.");
+        }
+
+        var result = await capability.ReadAsync(request, cancellationToken);
+        if (!result.Success)
+        {
+            throw new FileFormatRoutingException(result.Error ?? "Read operation failed.");
+        }
+
+        return result;
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        var capability = ResolveCapability(request.FormatId);
+        var format = ResolveFormat(capability, request.FormatId);
+
+        if (!format.CanWrite)
+        {
+            throw new FileFormatRoutingException($"Format '{request.FormatId}' is read-only.");
+        }
+
+        var result = await capability.WriteAsync(request, cancellationToken);
+        if (!result.Success)
+        {
+            throw new FileFormatRoutingException(result.Error ?? "Write operation failed.");
+        }
+
+        return result;
+    }
+
+    private IReadOnlyList<FileFormatRoute> GetRoutesInternal()
+    {
+        return pluginCatalog.Plugins
+            .SelectMany(plugin =>
+                plugin.Capabilities.OfType<IFileFormatPluginCapability>()
+                    .SelectMany(capability =>
+                        capability.SupportedFormats.Select(format => new FileFormatRoute(
+                            plugin.Plugin.Descriptor.Id,
+                            format.FormatId,
+                            format.DisplayName,
+                            format.Extensions,
+                            format.CanRead,
+                            format.CanWrite,
+                            format.MimeType))))
+            .OrderBy(route => route.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private IFileFormatPluginCapability ResolveCapability(string formatId)
+    {
+        var capability = pluginCatalog.GetCapabilities<IFileFormatPluginCapability>()
+            .FirstOrDefault(candidate => candidate.SupportedFormats.Any(format =>
+                format.FormatId.Equals(formatId, StringComparison.OrdinalIgnoreCase)));
+
+        return capability ?? throw new FileFormatRoutingException($"No plugin capability found for format '{formatId}'.");
+    }
+
+    private static FileFormatDescriptor ResolveFormat(IFileFormatPluginCapability capability, string formatId)
+    {
+        return capability.SupportedFormats
+            .FirstOrDefault(format => format.FormatId.Equals(formatId, StringComparison.OrdinalIgnoreCase))
+            ?? throw new FileFormatRoutingException($"Format descriptor not found for '{formatId}'.");
+    }
+}

--- a/tests/SkyCD.Plugin.Host.Tests/FileFormatRoutingServiceTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/FileFormatRoutingServiceTests.cs
@@ -1,0 +1,132 @@
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+using SkyCD.Plugin.Host;
+using SkyCD.Plugin.Host.FileFormats;
+using SkyCD.Plugin.Runtime.Discovery;
+
+namespace SkyCD.Plugin.Host.Tests;
+
+public class FileFormatRoutingServiceTests
+{
+    [Fact]
+    public void GetOpenAndSaveFormats_RespectsCapabilities()
+    {
+        var pluginCatalog = CreateCatalog(new TestReadOnlyPlugin(), new TestReadWritePlugin());
+        var service = new FileFormatRoutingService(pluginCatalog);
+
+        var openFormats = service.GetOpenFormats();
+        var saveFormats = service.GetSaveFormats();
+
+        Assert.Contains(openFormats, format => format.FormatId == "readonly-json");
+        Assert.DoesNotContain(saveFormats, format => format.FormatId == "readonly-json");
+        Assert.Contains(saveFormats, format => format.FormatId == "rw-json");
+    }
+
+    [Fact]
+    public async Task WriteAsync_Throws_ForReadOnlyFormat()
+    {
+        var pluginCatalog = CreateCatalog(new TestReadOnlyPlugin());
+        var service = new FileFormatRoutingService(pluginCatalog);
+
+        using var stream = new MemoryStream();
+        var request = new FileFormatWriteRequest
+        {
+            FormatId = "readonly-json",
+            Target = stream,
+            Payload = new { Value = "x" }
+        };
+
+        await Assert.ThrowsAsync<FileFormatRoutingException>(() => service.WriteAsync(request));
+    }
+
+    [Fact]
+    public async Task ReadAndWriteAsync_UsesResolvedFormatHandlers()
+    {
+        var pluginCatalog = CreateCatalog(new TestReadWritePlugin());
+        var service = new FileFormatRoutingService(pluginCatalog);
+
+        using var writeStream = new MemoryStream();
+        var writeResult = await service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "rw-json",
+            Target = writeStream,
+            Payload = new { Value = "ok" }
+        });
+        Assert.True(writeResult.Success);
+
+        writeStream.Position = 0;
+        var readResult = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "rw-json",
+            Source = writeStream
+        });
+
+        Assert.True(readResult.Success);
+        Assert.Equal("ok", readResult.Payload?.ToString());
+    }
+
+    private static PluginCatalog CreateCatalog(params IFileFormatPluginCapability[] capabilities)
+    {
+        var catalog = new PluginCatalog();
+        var discovered = capabilities.Select(capability => new DiscoveredPlugin
+        {
+            Plugin = (IPlugin)capability,
+            Capabilities = [capability]
+        });
+
+        catalog.SetPlugins(discovered);
+        return catalog;
+    }
+
+    private sealed class TestReadOnlyPlugin : IPlugin, IFileFormatPluginCapability
+    {
+        public PluginDescriptor Descriptor => new("tests.readonly", "ReadOnly", new Version(1, 0, 0), new Version(3, 0, 0));
+
+        public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+        [
+            new FileFormatDescriptor("readonly-json", "Read Only JSON", [".json"], CanRead: true, CanWrite: false)
+        ];
+
+        public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new FileFormatReadResult { Success = true, Payload = "readonly" });
+
+        public Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default) =>
+            Task.FromResult(new FileFormatWriteResult { Success = false, Error = "not allowed" });
+    }
+
+    private sealed class TestReadWritePlugin : IPlugin, IFileFormatPluginCapability
+    {
+        public PluginDescriptor Descriptor => new("tests.readwrite", "ReadWrite", new Version(1, 0, 0), new Version(3, 0, 0));
+
+        public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+        [
+            new FileFormatDescriptor("rw-json", "Read/Write JSON", [".json"], CanRead: true, CanWrite: true)
+        ];
+
+        public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+        {
+            request.Source.Position = 0;
+            using var reader = new StreamReader(request.Source, leaveOpen: true);
+            var text = reader.ReadToEnd();
+            return Task.FromResult(new FileFormatReadResult { Success = true, Payload = text });
+        }
+
+        public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+        {
+            using var writer = new StreamWriter(request.Target, leaveOpen: true);
+            await writer.WriteAsync("ok");
+            await writer.FlushAsync(cancellationToken);
+            return new FileFormatWriteResult { Success = true };
+        }
+    }
+}

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SkyCD.Plugin.Host\SkyCD.Plugin.Host.csproj" />
+    <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
Implements #66 by adding host-level file format routing with explicit read/write capability gating and typed routing errors.

## Included
- Added progress support to file format requests:
  - `FileFormatReadRequest.Progress`
  - `FileFormatWriteRequest.Progress`
- Added host routing layer:
  - `FileFormatRoutingService`
  - `FileFormatRoute`
  - `FileFormatRoutingException`
- Added host tests:
  - format listing for open/save
  - read-only write protection
  - format resolution for read/write operations

## Acceptance Criteria Mapping
- Host can list supported open/save formats from loaded plugins: ✅
- Read-only plugin blocked from write operations in API: ✅
- Errors surfaced via typed model/exception (`FileFormatRoutingException`): ✅
- Automated tests for capability gating + format resolution: ✅

## Validation
- `dotnet restore SkyCD.V3.slnx`
- `dotnet test SkyCD.V3.slnx -c Release`

All passed locally.

Closes #66