### PR TITLE
feat(v3): add safe menu extension points and guarded command execution

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Sample.Menu/SampleMenuPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Menu/SampleMenuPlugin.cs
@@ -1,0 +1,39 @@
+using SkyCD.Plugin.Abstractions.Capabilities.Menu;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Sample.Menu;
+
+public sealed class SampleMenuPlugin : IPlugin, IMenuPluginCapability
+{
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.sample.menu",
+        "Sample Menu Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Example menu contribution plugin.");
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public IReadOnlyCollection<MenuContribution> GetMenuContributions() =>
+    [
+        new MenuContribution("sample.menu.notify", "Sample Notification", "Tools", Order: 100)
+    ];
+
+    public async Task ExecuteMenuCommandAsync(string commandId, MenuCommandContext context, CancellationToken cancellationToken = default)
+    {
+        if (!commandId.Equals("sample.menu.notify", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        if (context.HostApi is null)
+        {
+            throw new InvalidOperationException("Host API is required.");
+        }
+
+        await context.HostApi.NotifyAsync("Sample menu command executed.", cancellationToken);
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -2,6 +2,7 @@
   <Folder Name="/Plugins/" />
   <Folder Name="/Plugins/samples/">
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
+    <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/SkyCD.App/SkyCD.App.csproj" />

--- a/docs/plugins/sdk-contracts.md
+++ b/docs/plugins/sdk-contracts.md
@@ -14,6 +14,7 @@
   - Read/write operations with typed request/response payloads
 - `IMenuPluginCapability`
   - Declares menu contributions and command execution
+  - Uses `MenuCommandContext.HostApi` so plugins call host through explicit public APIs only
 - `IModalPluginCapability`
   - Declares modal descriptors and open handler
 
@@ -21,6 +22,10 @@
 - Runtime scans assemblies for classes implementing `IPlugin`.
 - Compatibility gate: plugin loads only when `HostVersion >= MinHostVersion`.
 - Capabilities are discovered by implemented interfaces deriving from `IPluginCapability`.
+
+## Guardrails
+- Host executes menu commands through `MenuExtensionService` with timeout and exception isolation.
+- Plugin exceptions are converted to result failures and should not crash the host UI thread.
 
 ## Sample Plugin
 - `Plugins/samples/SkyCD.Plugin.Sample.Json`

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Menu/IHostCommandApi.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Menu/IHostCommandApi.cs
@@ -1,0 +1,17 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.Menu;
+
+/// <summary>
+/// Public host API exposed to plugin menu commands.
+/// </summary>
+public interface IHostCommandApi
+{
+    /// <summary>
+    /// Requests navigation to the specified node.
+    /// </summary>
+    Task NavigateToNodeAsync(long nodeId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Requests a non-blocking host notification.
+    /// </summary>
+    Task NotifyAsync(string message, CancellationToken cancellationToken = default);
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Menu/MenuCommandContext.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Menu/MenuCommandContext.cs
@@ -19,4 +19,9 @@ public sealed class MenuCommandContext
     /// Gets optional extension payload from host.
     /// </summary>
     public IReadOnlyDictionary<string, string>? Properties { get; init; }
+
+    /// <summary>
+    /// Gets host actions that plugins are allowed to invoke.
+    /// </summary>
+    public IHostCommandApi? HostApi { get; init; }
 }

--- a/src/SkyCD.Plugin.Host/Menu/MenuCommandExecutionResult.cs
+++ b/src/SkyCD.Plugin.Host/Menu/MenuCommandExecutionResult.cs
@@ -1,0 +1,13 @@
+namespace SkyCD.Plugin.Host.Menu;
+
+/// <summary>
+/// Result envelope for guarded menu command execution.
+/// </summary>
+public sealed class MenuCommandExecutionResult
+{
+    public required bool Success { get; init; }
+
+    public string? Error { get; init; }
+
+    public bool TimedOut { get; init; }
+}

--- a/src/SkyCD.Plugin.Host/Menu/MenuExtensionService.cs
+++ b/src/SkyCD.Plugin.Host/Menu/MenuExtensionService.cs
@@ -1,0 +1,76 @@
+using SkyCD.Plugin.Abstractions.Capabilities.Menu;
+
+namespace SkyCD.Plugin.Host.Menu;
+
+/// <summary>
+/// Host service for menu contribution discovery and guarded command execution.
+/// </summary>
+public sealed class MenuExtensionService(PluginCatalog pluginCatalog)
+{
+    public IReadOnlyList<MenuContribution> GetMenuContributions(string? location = null)
+    {
+        var contributions = pluginCatalog
+            .GetCapabilities<IMenuPluginCapability>()
+            .SelectMany(capability => capability.GetMenuContributions())
+            .AsEnumerable();
+
+        if (!string.IsNullOrWhiteSpace(location))
+        {
+            contributions = contributions.Where(contribution =>
+                contribution.Location.Equals(location, StringComparison.OrdinalIgnoreCase));
+        }
+
+        return contributions
+            .OrderBy(contribution => contribution.Order)
+            .ThenBy(contribution => contribution.Title, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public async Task<MenuCommandExecutionResult> ExecuteAsync(
+        string commandId,
+        MenuCommandContext context,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        var matchingCapability = pluginCatalog
+            .GetCapabilities<IMenuPluginCapability>()
+            .FirstOrDefault(capability =>
+                capability.GetMenuContributions().Any(contribution =>
+                    contribution.CommandId.Equals(commandId, StringComparison.OrdinalIgnoreCase)));
+
+        if (matchingCapability is null)
+        {
+            return new MenuCommandExecutionResult
+            {
+                Success = false,
+                Error = $"Command '{commandId}' was not found."
+            };
+        }
+
+        using var timeoutCts = new CancellationTokenSource(timeout);
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+
+        try
+        {
+            await matchingCapability.ExecuteMenuCommandAsync(commandId, context, linkedCts.Token);
+            return new MenuCommandExecutionResult { Success = true };
+        }
+        catch (OperationCanceledException) when (timeoutCts.IsCancellationRequested)
+        {
+            return new MenuCommandExecutionResult
+            {
+                Success = false,
+                TimedOut = true,
+                Error = $"Command '{commandId}' timed out."
+            };
+        }
+        catch (Exception exception)
+        {
+            return new MenuCommandExecutionResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+}

--- a/tests/SkyCD.Plugin.Host.Tests/FileFormatRoutingServiceTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/FileFormatRoutingServiceTests.cs
@@ -1,7 +1,9 @@
 using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Capabilities.Menu;
 using SkyCD.Plugin.Abstractions.Lifecycle;
 using SkyCD.Plugin.Host;
 using SkyCD.Plugin.Host.FileFormats;
+using SkyCD.Plugin.Host.Menu;
 using SkyCD.Plugin.Runtime.Discovery;
 
 namespace SkyCD.Plugin.Host.Tests;
@@ -20,6 +22,29 @@ public class FileFormatRoutingServiceTests
         Assert.Contains(openFormats, format => format.FormatId == "readonly-json");
         Assert.DoesNotContain(saveFormats, format => format.FormatId == "readonly-json");
         Assert.Contains(saveFormats, format => format.FormatId == "rw-json");
+    }
+
+    [Fact]
+    public async Task MenuExecution_GuardsAgainstPluginErrors()
+    {
+        var pluginCatalog = new PluginCatalog();
+        pluginCatalog.SetPlugins(
+        [
+            new DiscoveredPlugin
+            {
+                Plugin = new ThrowingMenuPlugin(),
+                Capabilities = [new ThrowingMenuPlugin()]
+            }
+        ]);
+
+        var menuService = new MenuExtensionService(pluginCatalog);
+        var result = await menuService.ExecuteAsync(
+            "tests.menu.throw",
+            new MenuCommandContext(),
+            timeout: TimeSpan.FromMilliseconds(200));
+
+        Assert.False(result.Success);
+        Assert.NotNull(result.Error);
     }
 
     [Fact]
@@ -127,6 +152,25 @@ public class FileFormatRoutingServiceTests
             await writer.WriteAsync("ok");
             await writer.FlushAsync(cancellationToken);
             return new FileFormatWriteResult { Success = true };
+        }
+    }
+
+    private sealed class ThrowingMenuPlugin : IPlugin, IMenuPluginCapability
+    {
+        public PluginDescriptor Descriptor => new("tests.menu", "Menu Test", new Version(1, 0, 0), new Version(3, 0, 0));
+        public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public IReadOnlyCollection<MenuContribution> GetMenuContributions() =>
+        [
+            new MenuContribution("tests.menu.throw", "Throw", "Tools")
+        ];
+
+        public Task ExecuteMenuCommandAsync(string commandId, MenuCommandContext context, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("expected test failure");
         }
     }
 }


### PR DESCRIPTION
## Summary
Implements #67 with safe menu extension points, host command APIs, and guarded execution.

## Included
- New plugin contract for host-safe actions:
  - `IHostCommandApi`
  - wired into `MenuCommandContext.HostApi`
- Host menu extension service:
  - `MenuExtensionService` for contribution listing and command execution
  - timeout + exception guardrails
  - typed result `MenuCommandExecutionResult`
- Sample menu plugin:
  - `Plugins/samples/SkyCD.Plugin.Sample.Menu`
  - contributes a Tools menu command and invokes host notification API only
- Updated docs with extension point guardrails.
- Added tests for guarded plugin failure handling.

## Acceptance Criteria Mapping
- Sample plugin adds a menu item in defined location: ✅
- Menu command invokes host behavior via public API (`IHostCommandApi`) only: ✅
- Plugin failures isolated (no crash; error result returned): ✅
- Contract docs updated with extension point catalog: ✅

## Validation
- `dotnet restore SkyCD.V3.slnx`
- `dotnet build SkyCD.V3.slnx -c Release --no-restore`
- `dotnet test SkyCD.V3.slnx -c Release --no-build`

All passed locally.

## PR Base
Stacked on #96.

Closes #67