### PR TITLE
feat(v3): add manifest-based plugin runtime loading and diagnostics

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Sample.Json/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Json/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.sample.json",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Sample.Json.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/Plugins/samples/SkyCD.Plugin.Sample.Menu/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Menu/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.sample.menu",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Sample.Menu.dll",
+  "capabilities": [
+    "menu"
+  ]
+}

--- a/docs/plugins/runtime-loading.md
+++ b/docs/plugins/runtime-loading.md
@@ -1,0 +1,34 @@
+# Plugin Runtime Loading
+
+## Manifest Format (`plugin.json`)
+```json
+{
+  "id": "skycd.plugin.sample.json",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Sample.Json.dll",
+  "capabilities": ["file-format"]
+}
+```
+
+## Discovery Flow
+1. Enumerate configured plugin directories.
+2. Find `plugin.json` recursively.
+3. Validate manifest fields.
+4. Check host compatibility (`hostVersion >= minHostVersion`).
+5. Load assembly (default or isolated `AssemblyLoadContext`).
+6. Discover `IPlugin` implementations and capabilities.
+7. Return discovered plugins + diagnostics.
+
+## Diagnostics
+- Missing directories are warnings.
+- Invalid manifests, missing assemblies, and load failures are errors.
+- Incompatible plugins are skipped with informative diagnostics.
+
+## Unload/Reload Strategy
+- Isolation mode uses collectible `AssemblyLoadContext`.
+- Recommended host behavior for reload:
+  1. Dispose plugin instances (`IAsyncDisposable`)
+  2. Release capability references
+  3. Unload the associated load context
+  4. Trigger GC cycle before reloading

--- a/src/SkyCD.Plugin.Runtime/Loading/PluginDirectoryLoader.cs
+++ b/src/SkyCD.Plugin.Runtime/Loading/PluginDirectoryLoader.cs
@@ -1,0 +1,148 @@
+using System.Reflection;
+using System.Runtime.Loader;
+using SkyCD.Plugin.Runtime.Discovery;
+
+namespace SkyCD.Plugin.Runtime.Loading;
+
+/// <summary>
+/// Loads plugins from configured directories using plugin manifests.
+/// </summary>
+public sealed class PluginDirectoryLoader
+{
+    private readonly PluginManifestReader _manifestReader = new();
+    private readonly PluginDiscoveryService _discoveryService = new();
+
+    public PluginLoadResult LoadFromDirectories(IEnumerable<string> directories, PluginLoadOptions options)
+    {
+        var discoveredPlugins = new List<DiscoveredPlugin>();
+        var diagnostics = new List<PluginLoadDiagnostic>();
+
+        foreach (var directory in directories.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            if (!Directory.Exists(directory))
+            {
+                diagnostics.Add(new PluginLoadDiagnostic
+                {
+                    PluginId = "<directory>",
+                    IsError = false,
+                    Message = $"Plugin directory not found: {directory}"
+                });
+                continue;
+            }
+
+            var manifests = Directory.GetFiles(directory, "plugin.json", SearchOption.AllDirectories);
+            foreach (var manifestPath in manifests)
+            {
+                TryLoadManifest(manifestPath, options, discoveredPlugins, diagnostics);
+            }
+        }
+
+        return new PluginLoadResult
+        {
+            Plugins = discoveredPlugins,
+            Diagnostics = diagnostics
+        };
+    }
+
+    private void TryLoadManifest(
+        string manifestPath,
+        PluginLoadOptions options,
+        ICollection<DiscoveredPlugin> discoveredPlugins,
+        ICollection<PluginLoadDiagnostic> diagnostics)
+    {
+        PluginManifest manifest;
+        try
+        {
+            manifest = _manifestReader.ReadFromFile(manifestPath);
+        }
+        catch (Exception exception)
+        {
+            diagnostics.Add(new PluginLoadDiagnostic
+            {
+                PluginId = "<manifest>",
+                IsError = true,
+                Message = $"Failed to read manifest '{manifestPath}': {exception.Message}"
+            });
+            return;
+        }
+
+        if (!Version.TryParse(manifest.MinHostVersion, out var minHostVersion))
+        {
+            diagnostics.Add(new PluginLoadDiagnostic
+            {
+                PluginId = manifest.Id,
+                IsError = true,
+                Message = $"Invalid MinHostVersion '{manifest.MinHostVersion}'."
+            });
+            return;
+        }
+
+        if (options.HostVersion < minHostVersion)
+        {
+            diagnostics.Add(new PluginLoadDiagnostic
+            {
+                PluginId = manifest.Id,
+                IsError = false,
+                Message = $"Skipped incompatible plugin. Host version {options.HostVersion} < required {minHostVersion}."
+            });
+            return;
+        }
+
+        var assemblyPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(manifestPath)!, manifest.Assembly));
+        if (!File.Exists(assemblyPath))
+        {
+            diagnostics.Add(new PluginLoadDiagnostic
+            {
+                PluginId = manifest.Id,
+                IsError = true,
+                Message = $"Assembly not found: {assemblyPath}"
+            });
+            return;
+        }
+
+        try
+        {
+            Assembly assembly = options.EnableAssemblyIsolation
+                ? new PluginLoadContext().LoadFromAssemblyPath(assemblyPath)
+                : Assembly.LoadFrom(assemblyPath);
+
+            var discovered = _discoveryService.DiscoverFromAssembly(assembly, options.HostVersion);
+            if (discovered.Count == 0)
+            {
+                diagnostics.Add(new PluginLoadDiagnostic
+                {
+                    PluginId = manifest.Id,
+                    IsError = true,
+                    Message = "No compatible plugin entrypoints were discovered."
+                });
+                return;
+            }
+
+            foreach (var plugin in discovered)
+            {
+                discoveredPlugins.Add(plugin);
+            }
+        }
+        catch (Exception exception)
+        {
+            diagnostics.Add(new PluginLoadDiagnostic
+            {
+                PluginId = manifest.Id,
+                IsError = true,
+                Message = $"Load failure: {exception.Message}"
+            });
+        }
+    }
+
+    private sealed class PluginLoadContext : AssemblyLoadContext
+    {
+        public PluginLoadContext() : base(isCollectible: true)
+        {
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            return null;
+        }
+    }
+}

--- a/src/SkyCD.Plugin.Runtime/Loading/PluginLoadDiagnostic.cs
+++ b/src/SkyCD.Plugin.Runtime/Loading/PluginLoadDiagnostic.cs
@@ -1,0 +1,13 @@
+namespace SkyCD.Plugin.Runtime.Loading;
+
+/// <summary>
+/// Captures plugin load warning/error details.
+/// </summary>
+public sealed class PluginLoadDiagnostic
+{
+    public required string PluginId { get; init; }
+
+    public required string Message { get; init; }
+
+    public required bool IsError { get; init; }
+}

--- a/src/SkyCD.Plugin.Runtime/Loading/PluginLoadOptions.cs
+++ b/src/SkyCD.Plugin.Runtime/Loading/PluginLoadOptions.cs
@@ -1,0 +1,11 @@
+namespace SkyCD.Plugin.Runtime.Loading;
+
+/// <summary>
+/// Configurable options for manifest-based plugin loading.
+/// </summary>
+public sealed class PluginLoadOptions
+{
+    public required Version HostVersion { get; init; }
+
+    public bool EnableAssemblyIsolation { get; init; }
+}

--- a/src/SkyCD.Plugin.Runtime/Loading/PluginLoadResult.cs
+++ b/src/SkyCD.Plugin.Runtime/Loading/PluginLoadResult.cs
@@ -1,0 +1,13 @@
+using SkyCD.Plugin.Runtime.Discovery;
+
+namespace SkyCD.Plugin.Runtime.Loading;
+
+/// <summary>
+/// Result of manifest-based plugin loading.
+/// </summary>
+public sealed class PluginLoadResult
+{
+    public IReadOnlyCollection<DiscoveredPlugin> Plugins { get; init; } = [];
+
+    public IReadOnlyCollection<PluginLoadDiagnostic> Diagnostics { get; init; } = [];
+}

--- a/src/SkyCD.Plugin.Runtime/Loading/PluginManifest.cs
+++ b/src/SkyCD.Plugin.Runtime/Loading/PluginManifest.cs
@@ -1,0 +1,17 @@
+namespace SkyCD.Plugin.Runtime.Loading;
+
+/// <summary>
+/// Manifest metadata loaded from plugin.json.
+/// </summary>
+public sealed class PluginManifest
+{
+    public required string Id { get; init; }
+
+    public required string Version { get; init; }
+
+    public required string MinHostVersion { get; init; }
+
+    public required string Assembly { get; init; }
+
+    public IReadOnlyCollection<string> Capabilities { get; init; } = [];
+}

--- a/src/SkyCD.Plugin.Runtime/Loading/PluginManifestReader.cs
+++ b/src/SkyCD.Plugin.Runtime/Loading/PluginManifestReader.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+
+namespace SkyCD.Plugin.Runtime.Loading;
+
+/// <summary>
+/// Reads and validates plugin manifest files.
+/// </summary>
+public sealed class PluginManifestReader
+{
+    public PluginManifest ReadFromFile(string manifestPath)
+    {
+        var json = File.ReadAllText(manifestPath);
+        var manifest = JsonSerializer.Deserialize<PluginManifest>(json, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        if (manifest is null)
+        {
+            throw new InvalidOperationException($"Unable to deserialize manifest '{manifestPath}'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(manifest.Id) ||
+            string.IsNullOrWhiteSpace(manifest.Version) ||
+            string.IsNullOrWhiteSpace(manifest.MinHostVersion) ||
+            string.IsNullOrWhiteSpace(manifest.Assembly))
+        {
+            throw new InvalidOperationException($"Manifest '{manifestPath}' is missing required fields.");
+        }
+
+        return manifest;
+    }
+}

--- a/tests/SkyCD.Plugin.Runtime.Tests/PluginDirectoryLoaderTests.cs
+++ b/tests/SkyCD.Plugin.Runtime.Tests/PluginDirectoryLoaderTests.cs
@@ -1,0 +1,96 @@
+using System.Reflection;
+using System.Text.Json;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+using SkyCD.Plugin.Runtime.Loading;
+
+namespace SkyCD.Plugin.Runtime.Tests;
+
+public sealed class PluginDirectoryLoaderTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"skycd-plugins-{Guid.NewGuid():N}");
+
+    public PluginDirectoryLoaderTests()
+    {
+        Directory.CreateDirectory(_root);
+    }
+
+    [Fact]
+    public void LoadFromDirectories_LoadsPluginFromManifest()
+    {
+        var pluginDir = Path.Combine(_root, "good");
+        Directory.CreateDirectory(pluginDir);
+
+        var manifest = new PluginManifest
+        {
+            Id = "tests.loader",
+            Version = "1.0.0",
+            MinHostVersion = "3.0.0",
+            Assembly = Path.GetFileName(Assembly.GetExecutingAssembly().Location),
+            Capabilities = ["tests"]
+        };
+
+        File.WriteAllText(Path.Combine(pluginDir, "plugin.json"), JsonSerializer.Serialize(manifest));
+        File.Copy(Assembly.GetExecutingAssembly().Location, Path.Combine(pluginDir, manifest.Assembly), overwrite: true);
+
+        var loader = new PluginDirectoryLoader();
+        var result = loader.LoadFromDirectories([_root], new PluginLoadOptions { HostVersion = new Version(3, 0, 0) });
+
+        Assert.Contains(result.Plugins, plugin => plugin.Plugin.Descriptor.Id == "tests.runtime.loader-plugin");
+        Assert.DoesNotContain(result.Diagnostics, diagnostic => diagnostic.IsError);
+    }
+
+    [Fact]
+    public void LoadFromDirectories_SkipsIncompatiblePluginAndReportsDiagnostic()
+    {
+        var pluginDir = Path.Combine(_root, "incompatible");
+        Directory.CreateDirectory(pluginDir);
+
+        var manifest = new PluginManifest
+        {
+            Id = "tests.incompatible",
+            Version = "1.0.0",
+            MinHostVersion = "4.0.0",
+            Assembly = "missing.dll",
+            Capabilities = []
+        };
+
+        File.WriteAllText(Path.Combine(pluginDir, "plugin.json"), JsonSerializer.Serialize(manifest));
+
+        var loader = new PluginDirectoryLoader();
+        var result = loader.LoadFromDirectories([_root], new PluginLoadOptions { HostVersion = new Version(3, 0, 0) });
+
+        Assert.Empty(result.Plugins);
+        Assert.Contains(result.Diagnostics, diagnostic =>
+            diagnostic.PluginId == "tests.incompatible" &&
+            diagnostic.Message.Contains("Skipped incompatible", StringComparison.OrdinalIgnoreCase));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            try
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+
+}
+
+public sealed class LoaderTestPlugin : IPlugin
+{
+    public PluginDescriptor Descriptor => new(
+        "tests.runtime.loader-plugin",
+        "Loader Test Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0));
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/tests/SkyCD.Plugin.Runtime.Tests/PluginDiscoveryServiceTests.cs
+++ b/tests/SkyCD.Plugin.Runtime.Tests/PluginDiscoveryServiceTests.cs
@@ -15,9 +15,9 @@ public class PluginDiscoveryServiceTests
 
         var plugins = discovery.DiscoverFromAssembly(Assembly.GetExecutingAssembly(), new Version(3, 0, 0));
 
-        Assert.Single(plugins);
-        Assert.Contains(plugins[0].Capabilities, capability => capability is IMenuPluginCapability);
-        Assert.Contains(plugins[0].Capabilities, capability => capability is IFileFormatPluginCapability);
+        var target = Assert.Single(plugins, plugin => plugin.Plugin.Descriptor.Id == "tests.plugin");
+        Assert.Contains(target.Capabilities, capability => capability is IMenuPluginCapability);
+        Assert.Contains(target.Capabilities, capability => capability is IFileFormatPluginCapability);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Implements #69 by adding manifest-based plugin loading from configurable directories, host-version compatibility checks, diagnostics, and runtime integration tests.

## Included
- Manifest loading model (`plugin.json`):
  - `PluginManifest`
  - `PluginManifestReader`
- Directory loader:
  - `PluginDirectoryLoader`
  - `PluginLoadOptions`
  - `PluginLoadResult`
  - `PluginLoadDiagnostic`
- Optional isolation path:
  - collectible `AssemblyLoadContext` when isolation is enabled
- Runtime docs:
  - `docs/plugins/runtime-loading.md`
  - includes unload/reload strategy guidance
- Runtime tests:
  - success path: load plugin from disk by manifest
  - failure path: incompatible plugin skipped with diagnostics
- Added sample `plugin.json` files for sample plugins.

## Validation
- `dotnet restore SkyCD.V3.slnx`
- `dotnet build SkyCD.V3.slnx -c Release --no-restore`
- `dotnet test SkyCD.V3.slnx -c Release --no-build`

All passed locally.

Closes #69