### PR TITLE
feat(v3): add legacy data migration CLI and docs

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Legacy.Scd/LegacyScdCatalog.cs
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Scd/LegacyScdCatalog.cs
@@ -1,0 +1,13 @@
+namespace SkyCD.Plugin.Legacy.Scd;
+
+public sealed class LegacyScdCatalog
+{
+    public List<LegacyScdEntry> Entries { get; } = [];
+}
+
+public sealed class LegacyScdEntry
+{
+    public required string Path { get; init; }
+
+    public long? SizeBytes { get; init; }
+}

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Scd/LegacyScdPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Scd/LegacyScdPlugin.cs
@@ -1,0 +1,121 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Legacy.Scd;
+
+public sealed class LegacyScdPlugin : IPlugin, IFileFormatPluginCapability
+{
+    private static readonly Regex SizePrefix = new(@"^\[(?<size>[^\]]+)\]\s*(?<path>.+)$", RegexOptions.Compiled);
+
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.legacy.scd",
+        "Legacy SCD Format Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Reads and writes legacy *.scd text catalogs.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor("legacy-scd", "SkyCD Text Format", [".scd"], CanRead: true, CanWrite: true, "text/plain")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public async Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var reader = new StreamReader(request.Source, Encoding.UTF8, leaveOpen: true);
+            var catalog = new LegacyScdCatalog();
+            string? line;
+            var processed = 0;
+
+            while ((line = await reader.ReadLineAsync(cancellationToken)) is not null)
+            {
+                processed++;
+                if (string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith("#", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var trimmed = line.Trim();
+                var sizeMatch = SizePrefix.Match(trimmed);
+                if (sizeMatch.Success)
+                {
+                    var size = TryParseLegacySize(sizeMatch.Groups["size"].Value);
+                    catalog.Entries.Add(new LegacyScdEntry
+                    {
+                        Path = sizeMatch.Groups["path"].Value.Trim(),
+                        SizeBytes = size
+                    });
+                }
+                else
+                {
+                    catalog.Entries.Add(new LegacyScdEntry { Path = trimmed });
+                }
+
+                request.Progress?.Report(Math.Min(100, processed % 100));
+            }
+
+            request.Progress?.Report(100);
+            return new FileFormatReadResult { Success = true, Payload = catalog };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatReadResult { Success = false, Error = exception.Message };
+        }
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request.Payload is not LegacyScdCatalog catalog)
+        {
+            return new FileFormatWriteResult { Success = false, Error = "Payload must be LegacyScdCatalog." };
+        }
+
+        try
+        {
+            using var writer = new StreamWriter(request.Target, Encoding.UTF8, leaveOpen: true);
+            for (var i = 0; i < catalog.Entries.Count; i++)
+            {
+                var entry = catalog.Entries[i];
+                var line = entry.SizeBytes is > 0
+                    ? $"[{FormatLegacySize(entry.SizeBytes.Value)}] {entry.Path}"
+                    : entry.Path;
+                await writer.WriteLineAsync(line.AsMemory(), cancellationToken);
+                request.Progress?.Report((int)((i + 1d) / catalog.Entries.Count * 100d));
+            }
+
+            await writer.FlushAsync(cancellationToken);
+            request.Progress?.Report(100);
+            return new FileFormatWriteResult { Success = true };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatWriteResult { Success = false, Error = exception.Message };
+        }
+    }
+
+    private static long? TryParseLegacySize(string raw)
+    {
+        var value = raw.Trim().ToUpperInvariant();
+        if (value.EndsWith("KB") && double.TryParse(value[..^2], out var kb)) return (long)(kb * 1024d);
+        if (value.EndsWith("MB") && double.TryParse(value[..^2], out var mb)) return (long)(mb * 1024d * 1024d);
+        if (value.EndsWith("GB") && double.TryParse(value[..^2], out var gb)) return (long)(gb * 1024d * 1024d * 1024d);
+        if (long.TryParse(value, out var bytes)) return bytes;
+        return null;
+    }
+
+    private static string FormatLegacySize(long bytes)
+    {
+        if (bytes >= 1024L * 1024L * 1024L) return $"{bytes / (1024d * 1024d * 1024d):0.##}GB";
+        if (bytes >= 1024L * 1024L) return $"{bytes / (1024d * 1024d):0.##}MB";
+        if (bytes >= 1024L) return $"{bytes / 1024d:0.##}KB";
+        return bytes.ToString();
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Scd/SkyCD.Plugin.Legacy.Scd.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Scd/SkyCD.Plugin.Legacy.Scd.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Scd/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Scd/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.legacy.scd",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Legacy.Scd.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/Plugins/" />
   <Folder Name="/Plugins/samples/">
+    <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Scd/SkyCD.Plugin.Legacy.Scd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj" />
   </Folder>
@@ -18,6 +19,7 @@
     <Project Path="tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj" />
     <Project Path="tests/SkyCD.Domain.Tests/SkyCD.Domain.Tests.csproj" />
     <Project Path="tests/SkyCD.Infrastructure.Tests/SkyCD.Infrastructure.Tests.csproj" />
+    <Project Path="tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj" />
     <Project Path="tests/SkyCD.Migration.Tests/SkyCD.Migration.Tests.csproj" />
     <Project Path="tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj" />
     <Project Path="tests/SkyCD.Plugin.Runtime.Tests/SkyCD.Plugin.Runtime.Tests.csproj" />

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -18,7 +18,11 @@
     <Project Path="tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj" />
     <Project Path="tests/SkyCD.Domain.Tests/SkyCD.Domain.Tests.csproj" />
     <Project Path="tests/SkyCD.Infrastructure.Tests/SkyCD.Infrastructure.Tests.csproj" />
+    <Project Path="tests/SkyCD.Migration.Tests/SkyCD.Migration.Tests.csproj" />
     <Project Path="tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj" />
     <Project Path="tests/SkyCD.Plugin.Runtime.Tests/SkyCD.Plugin.Runtime.Tests.csproj" />
+  </Folder>
+  <Folder Name="/tools/">
+    <Project Path="tools/SkyCD.Migration.Cli/SkyCD.Migration.Cli.csproj" />
   </Folder>
 </Solution>

--- a/docs/migration/legacy-plugin-compatibility.md
+++ b/docs/migration/legacy-plugin-compatibility.md
@@ -1,0 +1,11 @@
+# Legacy Plugin Compatibility Matrix (v2 -> v3)
+
+| Legacy Plugin | Legacy Extension(s) | v3 Status | Notes |
+|---|---|---|---|
+| TextFormat | `.scd` | Planned | Re-implemented as v3 file-format plugin (#71) |
+| CompressedTextFormat | `.cscd` | Planned | Re-implemented as v3 file-format plugin (#72) |
+| SkyCDNativeFormat | `.ascd` | Planned | Re-implemented as v3 file-format plugin (#73) |
+
+## Binary Compatibility
+- v2 `.NET Framework` plugin binaries are **not** loaded in v3 runtime.
+- Migration path: port plugin to `SkyCD.Plugin.Abstractions` and provide `plugin.json` manifest.

--- a/docs/migration/v2-to-v3.md
+++ b/docs/migration/v2-to-v3.md
@@ -1,0 +1,30 @@
+# SkyCD Migration Guide: v2 to v3
+
+## Overview
+SkyCD v3 uses a new C#/.NET 10 architecture with EF Core + SQLite schema. Legacy v2 data can be migrated from `data.db`.
+
+## What is Migrated
+- `list` table records grouped by `AID` -> one v3 `Catalog` per group
+- `Type` mapping:
+  - `scdFile` -> `File`
+  - anything else -> `Folder`
+- `Properties` -> `MetadataJson`
+- `Size` -> `SizeBytes` for file nodes
+
+## CLI Command
+```powershell
+dotnet run --project tools/SkyCD.Migration.Cli -- --legacy-db <path-to-v2-data.db> --target-db <path-to-v3.db>
+```
+
+### Dry Run
+```powershell
+dotnet run --project tools/SkyCD.Migration.Cli -- --legacy-db <path> --target-db <path> --dry-run
+```
+
+## Logs and Errors
+- Validation/import issues are printed to stderr as actionable messages.
+- Invalid rows are skipped while valid catalogs continue importing.
+
+## Legacy Plugin Compatibility
+- Legacy binary plugins are not loaded directly.
+- Re-implement format support using v3 plugin SDK and manifests (`plugin.json`).

--- a/tests/SkyCD.LegacyFormats.Tests/LegacyScdPluginTests.cs
+++ b/tests/SkyCD.LegacyFormats.Tests/LegacyScdPluginTests.cs
@@ -1,0 +1,59 @@
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Legacy.Scd;
+
+namespace SkyCD.LegacyFormats.Tests;
+
+public class LegacyScdPluginTests
+{
+    [Fact]
+    public async Task ReadAsync_ParsesLegacyScdSample()
+    {
+        var plugin = new LegacyScdPlugin();
+        var samplePath = Path.Combine(AppContext.BaseDirectory, "fixtures", "gamez.scd");
+        var bytes = await File.ReadAllBytesAsync(samplePath);
+        await using var stream = new MemoryStream(bytes);
+
+        var result = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-scd",
+            Source = stream,
+            FileName = "gamez.scd"
+        });
+
+        Assert.True(result.Success);
+        var payload = Assert.IsType<LegacyScdCatalog>(result.Payload);
+        Assert.NotEmpty(payload.Entries);
+    }
+
+    [Fact]
+    public async Task WriteAsync_RoundTripsCatalog()
+    {
+        var plugin = new LegacyScdPlugin();
+        var catalog = new LegacyScdCatalog();
+        catalog.Entries.Add(new LegacyScdEntry { Path = @"[Disk]\Folder\File.txt", SizeBytes = 1200 });
+        catalog.Entries.Add(new LegacyScdEntry { Path = @"[Disk]\Readme.md" });
+
+        await using var writeStream = new MemoryStream();
+        var write = await plugin.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "legacy-scd",
+            Target = writeStream,
+            Payload = catalog
+        });
+
+        Assert.True(write.Success);
+        writeStream.Position = 0;
+
+        var read = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-scd",
+            Source = writeStream
+        });
+
+        Assert.True(read.Success);
+        var parsed = Assert.IsType<LegacyScdCatalog>(read.Payload);
+        Assert.Equal(2, parsed.Entries.Count);
+        Assert.Equal(@"[Disk]\Folder\File.txt", parsed.Entries[0].Path);
+    }
+}

--- a/tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj
+++ b/tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Legacy.Scd\SkyCD.Plugin.Legacy.Scd.csproj" />
+    <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\SkyCD\Samples\gamez.scd" Link="fixtures\gamez.scd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/tests/SkyCD.Migration.Tests/LegacyDbImporterTests.cs
+++ b/tests/SkyCD.Migration.Tests/LegacyDbImporterTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using SkyCD.Infrastructure.Persistence;
+using SkyCD.Migration.Cli;
+
+namespace SkyCD.Migration.Tests;
+
+public sealed class LegacyDbImporterTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), $"skycd-migration-{Guid.NewGuid():N}");
+
+    public LegacyDbImporterTests()
+    {
+        Directory.CreateDirectory(_root);
+    }
+
+    [Fact]
+    public async Task ImportAsync_ImportsLegacyRowsIntoTargetSchema()
+    {
+        var legacyPath = Path.Combine(_root, "legacy.db");
+        var targetPath = Path.Combine(_root, "target.db");
+
+        await SeedLegacyDatabaseAsync(legacyPath);
+
+        var importer = new LegacyDbImporter();
+        var result = await importer.ImportAsync(legacyPath, targetPath, dryRun: false);
+
+        Assert.Equal(1, result.ImportedCatalogs);
+        Assert.Equal(2, result.ImportedNodes);
+        Assert.Empty(result.Errors);
+
+        await using var context = new SkyCdDbContext(
+            new DbContextOptionsBuilder<SkyCdDbContext>()
+                .UseSqlite($"Data Source={targetPath}")
+                .Options);
+
+        var catalogCount = await context.Catalogs.CountAsync();
+        var nodeCount = await context.CatalogNodes.CountAsync();
+        Assert.Equal(1, catalogCount);
+        Assert.Equal(2, nodeCount);
+    }
+
+    private static async Task SeedLegacyDatabaseAsync(string dbPath)
+    {
+        await using var connection = new SqliteConnection($"Data Source={dbPath}");
+        await connection.OpenAsync();
+
+        await using var create = connection.CreateCommand();
+        create.CommandText = """
+            CREATE TABLE list (
+              ID INTEGER,
+              Name TEXT,
+              ParentID INTEGER,
+              Type TEXT,
+              Properties TEXT,
+              Size INTEGER,
+              AID TEXT
+            );
+            """;
+        await create.ExecuteNonQueryAsync();
+
+        await using var insert1 = connection.CreateCommand();
+        insert1.CommandText = """
+            INSERT INTO list (ID, Name, ParentID, Type, Properties, Size, AID)
+            VALUES (1, 'Root', -1, 'scdUnknown', '{}', NULL, 'legacy-a');
+            """;
+        await insert1.ExecuteNonQueryAsync();
+
+        await using var insert2 = connection.CreateCommand();
+        insert2.CommandText = """
+            INSERT INTO list (ID, Name, ParentID, Type, Properties, Size, AID)
+            VALUES (2, 'File.txt', 1, 'scdFile', '{"ext":"txt"}', 120, 'legacy-a');
+            """;
+        await insert2.ExecuteNonQueryAsync();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            try
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+            catch (IOException)
+            {
+            }
+        }
+    }
+}

--- a/tests/SkyCD.Migration.Tests/SkyCD.Migration.Tests.csproj
+++ b/tests/SkyCD.Migration.Tests/SkyCD.Migration.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\SkyCD.Migration.Cli\SkyCD.Migration.Cli.csproj" />
+    <ProjectReference Include="..\..\src\SkyCD.Infrastructure\SkyCD.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/SkyCD.Migration.Cli/LegacyDbImporter.cs
+++ b/tools/SkyCD.Migration.Cli/LegacyDbImporter.cs
@@ -1,0 +1,115 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using SkyCD.Domain.Catalogs;
+using SkyCD.Infrastructure.Persistence;
+
+namespace SkyCD.Migration.Cli;
+
+public sealed class LegacyDbImporter
+{
+    public async Task<LegacyImportResult> ImportAsync(string legacyPath, string targetPath, bool dryRun, CancellationToken cancellationToken = default)
+    {
+        var targetConnection = $"Data Source={targetPath}";
+        await using var targetContext = new SkyCdDbContext(
+            new DbContextOptionsBuilder<SkyCdDbContext>()
+                .UseSqlite(targetConnection)
+                .Options);
+
+        await targetContext.Database.MigrateAsync(cancellationToken);
+
+        await using var legacyConnection = new SqliteConnection($"Data Source={legacyPath};Mode=ReadOnly");
+        await legacyConnection.OpenAsync(cancellationToken);
+
+        var rows = await ReadLegacyRowsAsync(legacyConnection, cancellationToken);
+        if (rows.Count == 0)
+        {
+            return new LegacyImportResult(0, 0, []);
+        }
+
+        var groupedByAid = rows.GroupBy(row => row.Aid).ToList();
+        var importedCatalogs = 0;
+        var importedNodes = 0;
+        var errors = new List<string>();
+
+        foreach (var aidGroup in groupedByAid)
+        {
+            var catalog = new Catalog
+            {
+                Name = $"Imported Legacy Catalog ({aidGroup.Key})",
+                SchemaVersion = 1,
+                CreatedUtc = DateTimeOffset.UtcNow,
+                UpdatedUtc = DateTimeOffset.UtcNow
+            };
+
+            foreach (var row in aidGroup)
+            {
+                var kind = row.Type.Equals("scdFile", StringComparison.OrdinalIgnoreCase)
+                    ? CatalogNodeKind.File
+                    : CatalogNodeKind.Folder;
+
+                catalog.Nodes.Add(new CatalogNode
+                {
+                    Id = row.Id,
+                    CatalogId = catalog.Id,
+                    ParentId = row.ParentId < 0 ? null : row.ParentId,
+                    Kind = kind,
+                    Name = string.IsNullOrWhiteSpace(row.Name) ? $"Unnamed-{row.Id}" : row.Name,
+                    SizeBytes = kind == CatalogNodeKind.File ? row.Size : null,
+                    MetadataJson = row.Properties
+                });
+                importedNodes++;
+            }
+
+            var validationErrors = CatalogValidator.Validate(catalog);
+            if (validationErrors.Count > 0)
+            {
+                errors.AddRange(validationErrors.Select(error => $"Catalog '{catalog.Name}': {error}"));
+                continue;
+            }
+
+            if (!dryRun)
+            {
+                await targetContext.Catalogs.AddAsync(catalog, cancellationToken);
+                await targetContext.SaveChangesAsync(cancellationToken);
+            }
+
+            importedCatalogs++;
+        }
+
+        return new LegacyImportResult(importedCatalogs, importedNodes, errors);
+    }
+
+    private static async Task<IReadOnlyList<LegacyRow>> ReadLegacyRowsAsync(SqliteConnection connection, CancellationToken cancellationToken)
+    {
+        var rows = new List<LegacyRow>();
+
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT ID, Name, ParentID, Type, Properties, Size, AID FROM list ORDER BY AID, ID";
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            rows.Add(new LegacyRow(
+                reader.GetInt64(0),
+                reader.IsDBNull(1) ? string.Empty : reader.GetString(1),
+                reader.IsDBNull(2) ? -1 : reader.GetInt64(2),
+                reader.IsDBNull(3) ? string.Empty : reader.GetString(3),
+                reader.IsDBNull(4) ? null : reader.GetString(4),
+                reader.IsDBNull(5) ? (long?)null : reader.GetInt64(5),
+                reader.IsDBNull(6) ? "default" : reader.GetValue(6).ToString() ?? "default"));
+        }
+
+        return rows;
+    }
+}
+
+public sealed record LegacyImportResult(int ImportedCatalogs, int ImportedNodes, IReadOnlyCollection<string> Errors);
+
+public sealed record LegacyRow(
+    long Id,
+    string Name,
+    long ParentId,
+    string Type,
+    string? Properties,
+    long? Size,
+    string Aid);

--- a/tools/SkyCD.Migration.Cli/Program.cs
+++ b/tools/SkyCD.Migration.Cli/Program.cs
@@ -1,0 +1,68 @@
+using SkyCD.Migration.Cli;
+
+const string usage = """
+SkyCD Migration CLI
+
+Usage:
+  dotnet run --project tools/SkyCD.Migration.Cli -- --legacy-db <path> --target-db <path> [--dry-run]
+""";
+
+var argsMap = ParseArgs(args);
+
+if (!argsMap.TryGetValue("--legacy-db", out var legacyPath) ||
+    !argsMap.TryGetValue("--target-db", out var targetPath))
+{
+    Console.WriteLine(usage);
+    return 1;
+}
+
+var dryRun = argsMap.ContainsKey("--dry-run");
+
+if (!File.Exists(legacyPath))
+{
+    Console.Error.WriteLine($"Legacy DB not found: {legacyPath}");
+    return 2;
+}
+
+var importer = new LegacyDbImporter();
+var result = await importer.ImportAsync(legacyPath, targetPath, dryRun);
+
+if (result.Errors.Count > 0)
+{
+    Console.Error.WriteLine("Migration completed with validation/import errors:");
+    foreach (var error in result.Errors)
+    {
+        Console.Error.WriteLine($"  - {error}");
+    }
+}
+
+Console.WriteLine(dryRun
+    ? $"Dry-run complete. Prepared {result.ImportedCatalogs} catalogs and {result.ImportedNodes} nodes."
+    : $"Import complete. Imported {result.ImportedCatalogs} catalogs and {result.ImportedNodes} nodes.");
+
+return 0;
+
+static Dictionary<string, string> ParseArgs(string[] args)
+{
+    var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    for (var i = 0; i < args.Length; i++)
+    {
+        var key = args[i];
+        if (!key.StartsWith("--", StringComparison.Ordinal))
+        {
+            continue;
+        }
+
+        if (i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal))
+        {
+            map[key] = args[i + 1];
+            i++;
+        }
+        else
+        {
+            map[key] = "true";
+        }
+    }
+
+    return map;
+}

--- a/tools/SkyCD.Migration.Cli/SkyCD.Migration.Cli.csproj
+++ b/tools/SkyCD.Migration.Cli/SkyCD.Migration.Cli.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SkyCD.Infrastructure\SkyCD.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\SkyCD.Domain\SkyCD.Domain.csproj" />
+    <ProjectReference Include="..\..\src\SkyCD.Application\SkyCD.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
Implements #70 with a migration CLI to import legacy `data.db` (`list` table) into v3 EF Core SQLite schema, plus migration docs and compatibility matrix.

## Included
- New migration tool:
  - `tools/SkyCD.Migration.Cli`
  - command: `--legacy-db`, `--target-db`, optional `--dry-run`
  - validates and imports grouped legacy catalogs by `AID`
- Import engine:
  - `LegacyDbImporter` with typed result and error reporting
- Integration tests:
  - `tests/SkyCD.Migration.Tests`
  - verifies end-to-end import from seeded legacy DB to v3 schema
- Migration docs:
  - `docs/migration/v2-to-v3.md`
  - `docs/migration/legacy-plugin-compatibility.md`

## Acceptance Criteria Mapping
- Legacy sample import path provided and tested end-to-end: ✅
- Migration limitations and compatibility documented: ✅
- Conversion errors are actionable: ✅
- Guide added under `docs/migration/v2-to-v3.md`: ✅

## Validation
- `dotnet restore SkyCD.V3.slnx`
- `dotnet build SkyCD.V3.slnx -c Release --no-restore`
- `dotnet test SkyCD.V3.slnx -c Release --no-build`

All passed locally.

Closes #70