### PR TITLE
feat(v3): migrate legacy *.scd support into plugin

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Legacy.Scd/LegacyScdCatalog.cs
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Scd/LegacyScdCatalog.cs
@@ -1,0 +1,13 @@
+namespace SkyCD.Plugin.Legacy.Scd;
+
+public sealed class LegacyScdCatalog
+{
+    public List<LegacyScdEntry> Entries { get; } = [];
+}
+
+public sealed class LegacyScdEntry
+{
+    public required string Path { get; init; }
+
+    public long? SizeBytes { get; init; }
+}

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Scd/LegacyScdPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Scd/LegacyScdPlugin.cs
@@ -1,0 +1,121 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Legacy.Scd;
+
+public sealed class LegacyScdPlugin : IPlugin, IFileFormatPluginCapability
+{
+    private static readonly Regex SizePrefix = new(@"^\[(?<size>[^\]]+)\]\s*(?<path>.+)$", RegexOptions.Compiled);
+
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.legacy.scd",
+        "Legacy SCD Format Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Reads and writes legacy *.scd text catalogs.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor("legacy-scd", "SkyCD Text Format", [".scd"], CanRead: true, CanWrite: true, "text/plain")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public async Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var reader = new StreamReader(request.Source, Encoding.UTF8, leaveOpen: true);
+            var catalog = new LegacyScdCatalog();
+            string? line;
+            var processed = 0;
+
+            while ((line = await reader.ReadLineAsync(cancellationToken)) is not null)
+            {
+                processed++;
+                if (string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith("#", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var trimmed = line.Trim();
+                var sizeMatch = SizePrefix.Match(trimmed);
+                if (sizeMatch.Success)
+                {
+                    var size = TryParseLegacySize(sizeMatch.Groups["size"].Value);
+                    catalog.Entries.Add(new LegacyScdEntry
+                    {
+                        Path = sizeMatch.Groups["path"].Value.Trim(),
+                        SizeBytes = size
+                    });
+                }
+                else
+                {
+                    catalog.Entries.Add(new LegacyScdEntry { Path = trimmed });
+                }
+
+                request.Progress?.Report(Math.Min(100, processed % 100));
+            }
+
+            request.Progress?.Report(100);
+            return new FileFormatReadResult { Success = true, Payload = catalog };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatReadResult { Success = false, Error = exception.Message };
+        }
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request.Payload is not LegacyScdCatalog catalog)
+        {
+            return new FileFormatWriteResult { Success = false, Error = "Payload must be LegacyScdCatalog." };
+        }
+
+        try
+        {
+            using var writer = new StreamWriter(request.Target, Encoding.UTF8, leaveOpen: true);
+            for (var i = 0; i < catalog.Entries.Count; i++)
+            {
+                var entry = catalog.Entries[i];
+                var line = entry.SizeBytes is > 0
+                    ? $"[{FormatLegacySize(entry.SizeBytes.Value)}] {entry.Path}"
+                    : entry.Path;
+                await writer.WriteLineAsync(line.AsMemory(), cancellationToken);
+                request.Progress?.Report((int)((i + 1d) / catalog.Entries.Count * 100d));
+            }
+
+            await writer.FlushAsync(cancellationToken);
+            request.Progress?.Report(100);
+            return new FileFormatWriteResult { Success = true };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatWriteResult { Success = false, Error = exception.Message };
+        }
+    }
+
+    private static long? TryParseLegacySize(string raw)
+    {
+        var value = raw.Trim().ToUpperInvariant();
+        if (value.EndsWith("KB") && double.TryParse(value[..^2], out var kb)) return (long)(kb * 1024d);
+        if (value.EndsWith("MB") && double.TryParse(value[..^2], out var mb)) return (long)(mb * 1024d * 1024d);
+        if (value.EndsWith("GB") && double.TryParse(value[..^2], out var gb)) return (long)(gb * 1024d * 1024d * 1024d);
+        if (long.TryParse(value, out var bytes)) return bytes;
+        return null;
+    }
+
+    private static string FormatLegacySize(long bytes)
+    {
+        if (bytes >= 1024L * 1024L * 1024L) return $"{bytes / (1024d * 1024d * 1024d):0.##}GB";
+        if (bytes >= 1024L * 1024L) return $"{bytes / (1024d * 1024d):0.##}MB";
+        if (bytes >= 1024L) return $"{bytes / 1024d:0.##}KB";
+        return bytes.ToString();
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Scd/SkyCD.Plugin.Legacy.Scd.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Scd/SkyCD.Plugin.Legacy.Scd.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Scd/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Scd/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.legacy.scd",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Legacy.Scd.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/Plugins/" />
   <Folder Name="/Plugins/samples/">
+    <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Scd/SkyCD.Plugin.Legacy.Scd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj" />
   </Folder>
@@ -18,6 +19,7 @@
     <Project Path="tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj" />
     <Project Path="tests/SkyCD.Domain.Tests/SkyCD.Domain.Tests.csproj" />
     <Project Path="tests/SkyCD.Infrastructure.Tests/SkyCD.Infrastructure.Tests.csproj" />
+    <Project Path="tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj" />
     <Project Path="tests/SkyCD.Migration.Tests/SkyCD.Migration.Tests.csproj" />
     <Project Path="tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj" />
     <Project Path="tests/SkyCD.Plugin.Runtime.Tests/SkyCD.Plugin.Runtime.Tests.csproj" />

--- a/tests/SkyCD.LegacyFormats.Tests/LegacyScdPluginTests.cs
+++ b/tests/SkyCD.LegacyFormats.Tests/LegacyScdPluginTests.cs
@@ -1,0 +1,59 @@
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Legacy.Scd;
+
+namespace SkyCD.LegacyFormats.Tests;
+
+public class LegacyScdPluginTests
+{
+    [Fact]
+    public async Task ReadAsync_ParsesLegacyScdSample()
+    {
+        var plugin = new LegacyScdPlugin();
+        var samplePath = Path.Combine(AppContext.BaseDirectory, "fixtures", "gamez.scd");
+        var bytes = await File.ReadAllBytesAsync(samplePath);
+        await using var stream = new MemoryStream(bytes);
+
+        var result = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-scd",
+            Source = stream,
+            FileName = "gamez.scd"
+        });
+
+        Assert.True(result.Success);
+        var payload = Assert.IsType<LegacyScdCatalog>(result.Payload);
+        Assert.NotEmpty(payload.Entries);
+    }
+
+    [Fact]
+    public async Task WriteAsync_RoundTripsCatalog()
+    {
+        var plugin = new LegacyScdPlugin();
+        var catalog = new LegacyScdCatalog();
+        catalog.Entries.Add(new LegacyScdEntry { Path = @"[Disk]\Folder\File.txt", SizeBytes = 1200 });
+        catalog.Entries.Add(new LegacyScdEntry { Path = @"[Disk]\Readme.md" });
+
+        await using var writeStream = new MemoryStream();
+        var write = await plugin.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "legacy-scd",
+            Target = writeStream,
+            Payload = catalog
+        });
+
+        Assert.True(write.Success);
+        writeStream.Position = 0;
+
+        var read = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-scd",
+            Source = writeStream
+        });
+
+        Assert.True(read.Success);
+        var parsed = Assert.IsType<LegacyScdCatalog>(read.Payload);
+        Assert.Equal(2, parsed.Entries.Count);
+        Assert.Equal(@"[Disk]\Folder\File.txt", parsed.Entries[0].Path);
+    }
+}

--- a/tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj
+++ b/tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Legacy.Scd\SkyCD.Plugin.Legacy.Scd.csproj" />
+    <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\SkyCD\Samples\gamez.scd" Link="fixtures\gamez.scd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
Implements #71 by adding a dedicated legacy `*.scd` file-format plugin with read/write support and round-trip tests.

## Included
- New plugin project:
  - `Plugins/samples/SkyCD.Plugin.Legacy.Scd`
- Implements `IFileFormatPluginCapability` with:
  - `legacy-scd` format descriptor
  - read/write async stream operations
  - read/write capability flags (`CanRead=true`, `CanWrite=true`)
  - plugin manifest (`plugin.json`)
- Added legacy format tests:
  - parses existing fixture `SkyCD/Samples/gamez.scd`
  - validates write/read round-trip

## Validation
- `dotnet restore SkyCD.V3.slnx`
- `dotnet build SkyCD.V3.slnx -c Release --no-restore`
- `dotnet test tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj -c Release --no-build`

All passed locally.

## PR Base
Stacked on #99.

Closes #71