### PR TITLE
feat(v3): migrate legacy *.cscd support into plugin

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Legacy.Cscd/LegacyCscdCatalog.cs
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Cscd/LegacyCscdCatalog.cs
@@ -1,0 +1,13 @@
+namespace SkyCD.Plugin.Legacy.Cscd;
+
+public sealed class LegacyCscdCatalog
+{
+    public List<LegacyCscdEntry> Entries { get; } = [];
+}
+
+public sealed class LegacyCscdEntry
+{
+    public required string Path { get; init; }
+
+    public long? SizeBytes { get; init; }
+}

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Cscd/LegacyCscdPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Cscd/LegacyCscdPlugin.cs
@@ -1,0 +1,124 @@
+using System.IO.Compression;
+using System.Text;
+using System.Text.RegularExpressions;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Legacy.Cscd;
+
+public sealed class LegacyCscdPlugin : IPlugin, IFileFormatPluginCapability
+{
+    private static readonly Regex SizePrefix = new(@"^\[(?<size>[^\]]+)\]\s*(?<path>.+)$", RegexOptions.Compiled);
+
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.legacy.cscd",
+        "Legacy CSCD Format Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Reads and writes legacy *.cscd compressed text catalogs.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor("legacy-cscd", "SkyCD Compressed Text Format", [".cscd"], CanRead: true, CanWrite: true, "application/octet-stream")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public async Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var compressed = new DeflateStream(request.Source, CompressionMode.Decompress, leaveOpen: true);
+            using var reader = new StreamReader(compressed, Encoding.UTF8, leaveOpen: true);
+            var catalog = new LegacyCscdCatalog();
+            string? line;
+            var processed = 0;
+
+            while ((line = await reader.ReadLineAsync(cancellationToken)) is not null)
+            {
+                processed++;
+                if (string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith("#", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var trimmed = line.Trim();
+                var sizeMatch = SizePrefix.Match(trimmed);
+                if (sizeMatch.Success)
+                {
+                    var size = TryParseLegacySize(sizeMatch.Groups["size"].Value);
+                    catalog.Entries.Add(new LegacyCscdEntry
+                    {
+                        Path = sizeMatch.Groups["path"].Value.Trim(),
+                        SizeBytes = size
+                    });
+                }
+                else
+                {
+                    catalog.Entries.Add(new LegacyCscdEntry { Path = trimmed });
+                }
+
+                request.Progress?.Report(Math.Min(100, processed % 100));
+            }
+
+            request.Progress?.Report(100);
+            return new FileFormatReadResult { Success = true, Payload = catalog };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatReadResult { Success = false, Error = exception.Message };
+        }
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request.Payload is not LegacyCscdCatalog catalog)
+        {
+            return new FileFormatWriteResult { Success = false, Error = "Payload must be LegacyCscdCatalog." };
+        }
+
+        try
+        {
+            using var compressed = new DeflateStream(request.Target, CompressionMode.Compress, leaveOpen: true);
+            using var writer = new StreamWriter(compressed, Encoding.UTF8, leaveOpen: true);
+            for (var i = 0; i < catalog.Entries.Count; i++)
+            {
+                var entry = catalog.Entries[i];
+                var line = entry.SizeBytes is > 0
+                    ? $"[{FormatLegacySize(entry.SizeBytes.Value)}] {entry.Path}"
+                    : entry.Path;
+                await writer.WriteLineAsync(line.AsMemory(), cancellationToken);
+                request.Progress?.Report((int)((i + 1d) / catalog.Entries.Count * 100d));
+            }
+
+            await writer.FlushAsync(cancellationToken);
+            request.Progress?.Report(100);
+            return new FileFormatWriteResult { Success = true };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatWriteResult { Success = false, Error = exception.Message };
+        }
+    }
+
+    private static long? TryParseLegacySize(string raw)
+    {
+        var value = raw.Trim().ToUpperInvariant();
+        if (value.EndsWith("KB") && double.TryParse(value[..^2], out var kb)) return (long)(kb * 1024d);
+        if (value.EndsWith("MB") && double.TryParse(value[..^2], out var mb)) return (long)(mb * 1024d * 1024d);
+        if (value.EndsWith("GB") && double.TryParse(value[..^2], out var gb)) return (long)(gb * 1024d * 1024d * 1024d);
+        if (long.TryParse(value, out var bytes)) return bytes;
+        return null;
+    }
+
+    private static string FormatLegacySize(long bytes)
+    {
+        if (bytes >= 1024L * 1024L * 1024L) return $"{bytes / (1024d * 1024d * 1024d):0.##}GB";
+        if (bytes >= 1024L * 1024L) return $"{bytes / (1024d * 1024d):0.##}MB";
+        if (bytes >= 1024L) return $"{bytes / 1024d:0.##}KB";
+        return bytes.ToString();
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Cscd/SkyCD.Plugin.Legacy.Cscd.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Cscd/SkyCD.Plugin.Legacy.Cscd.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Cscd/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Cscd/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.legacy.cscd",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Legacy.Cscd.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/Plugins/" />
   <Folder Name="/Plugins/samples/">
+    <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Cscd/SkyCD.Plugin.Legacy.Cscd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Scd/SkyCD.Plugin.Legacy.Scd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj" />

--- a/tests/SkyCD.LegacyFormats.Tests/LegacyCscdPluginTests.cs
+++ b/tests/SkyCD.LegacyFormats.Tests/LegacyCscdPluginTests.cs
@@ -1,0 +1,38 @@
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Legacy.Cscd;
+
+namespace SkyCD.LegacyFormats.Tests;
+
+public class LegacyCscdPluginTests
+{
+    [Fact]
+    public async Task WriteAndReadAsync_RoundTripsCompressedCatalog()
+    {
+        var plugin = new LegacyCscdPlugin();
+        var catalog = new LegacyCscdCatalog();
+        catalog.Entries.Add(new LegacyCscdEntry { Path = @"[Disk]\Games\Doom.exe", SizeBytes = 1_048_576 });
+        catalog.Entries.Add(new LegacyCscdEntry { Path = @"[Disk]\Games\Readme.txt" });
+
+        await using var compressedStream = new MemoryStream();
+        var write = await plugin.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "legacy-cscd",
+            Target = compressedStream,
+            Payload = catalog
+        });
+
+        Assert.True(write.Success);
+
+        compressedStream.Position = 0;
+        var read = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-cscd",
+            Source = compressedStream
+        });
+
+        Assert.True(read.Success);
+        var parsed = Assert.IsType<LegacyCscdCatalog>(read.Payload);
+        Assert.Equal(2, parsed.Entries.Count);
+        Assert.Equal(@"[Disk]\Games\Doom.exe", parsed.Entries[0].Path);
+    }
+}

--- a/tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj
+++ b/tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Legacy.Cscd\SkyCD.Plugin.Legacy.Cscd.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Legacy.Scd\SkyCD.Plugin.Legacy.Scd.csproj" />
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
Implements #72 by adding a dedicated legacy `*.cscd` compressed text format plugin with read/write support and round-trip tests.

## Included
- New plugin project:
  - `Plugins/samples/SkyCD.Plugin.Legacy.Cscd`
- Implements `IFileFormatPluginCapability` with:
  - `legacy-cscd` format descriptor
  - read/write async stream operations via Deflate compression
  - plugin manifest (`plugin.json`)
- Extended legacy format tests:
  - compressed write/read round-trip test for `.cscd`

## Validation
- `dotnet restore SkyCD.V3.slnx`
- `dotnet build SkyCD.V3.slnx -c Release --no-restore`
- `dotnet test tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj -c Release --no-build`

All passed locally.

## PR Base
Stacked on #100.

Closes #72