### PR TITLE
feat(migration): resolve #71 #73 #87 #74 #89 in sequence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,15 +8,57 @@ registries:
     password: ${{secrets.PACKAGES_PAT}}
 
 updates:
-- package-ecosystem: nuget
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 25
-  registries: 
+  - package-ecosystem: nuget
+    directory: "/"
+    registries:
       - skycd
-      
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: monthly
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:00"
+      timezone: "Europe/Vilnius"
+    open-pull-requests-limit: 8
+    labels:
+      - dependencies
+      - type:platform
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dotnet-core:
+        applies-to: version-updates
+        patterns:
+          - "Microsoft.*"
+          - "System.*"
+      test-stack:
+        applies-to: version-updates
+        patterns:
+          - "xunit*"
+          - "Microsoft.NET.Test.Sdk"
+          - "coverlet*"
+      security-nuget:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:30"
+      timezone: "Europe/Vilnius"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - type:platform
+    commit-message:
+      prefix: "chore(ci-deps)"
+    groups:
+      actions-routine:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/LegacyAscdCatalog.cs
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/LegacyAscdCatalog.cs
@@ -1,0 +1,25 @@
+namespace SkyCD.Plugin.Legacy.Ascd;
+
+public sealed class LegacyAscdCatalog
+{
+    public string HeaderVersion { get; init; } = "1.0";
+
+    public List<LegacyAscdEntry> Entries { get; } = [];
+}
+
+public sealed class LegacyAscdEntry
+{
+    public required string Id { get; init; }
+
+    public required string Name { get; init; }
+
+    public required string ParentId { get; init; }
+
+    public required string Type { get; init; }
+
+    public string PropertiesXml { get; init; } = string.Empty;
+
+    public long SizeBytes { get; init; }
+
+    public string ApplicationId { get; init; } = "<?Application_ID?>";
+}

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/LegacyAscdPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/LegacyAscdPlugin.cs
@@ -1,0 +1,294 @@
+using System.IO.Compression;
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Legacy.Ascd;
+
+public sealed class LegacyAscdPlugin : IPlugin, IFileFormatPluginCapability
+{
+    private const string FormatHeaderPrefix = "# format: skycd-nf";
+    private const string InsertPrefix = "INSERT INTO list";
+
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.legacy.ascd",
+        "Legacy ASCD Format Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Reads and writes legacy *.ascd compressed catalogs using safe statement parsing.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor("legacy-ascd", "SkyCD Advanced Format", [".ascd"], CanRead: true, CanWrite: true, "application/octet-stream")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public async Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var compressed = new DeflateStream(request.Source, CompressionMode.Decompress, leaveOpen: true);
+            using var reader = new StreamReader(compressed, Encoding.UTF8, leaveOpen: true);
+
+            var lineNumber = 0;
+            string? header = null;
+            while ((header = await reader.ReadLineAsync(cancellationToken)) is not null)
+            {
+                lineNumber++;
+                if (!string.IsNullOrWhiteSpace(header))
+                {
+                    break;
+                }
+            }
+
+            if (header is null || !TryParseHeaderVersion(header, out var version))
+            {
+                return new FileFormatReadResult
+                {
+                    Success = false,
+                    Error = "Missing or invalid header. Expected '# format: skycd-nf <version>'."
+                };
+            }
+
+            var catalog = new LegacyAscdCatalog { HeaderVersion = version };
+            string? line;
+            var processed = 0;
+            while ((line = await reader.ReadLineAsync(cancellationToken)) is not null)
+            {
+                lineNumber++;
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                if (!TryParseInsertStatement(line.Trim(), out var entry, out var error))
+                {
+                    return new FileFormatReadResult
+                    {
+                        Success = false,
+                        Error = $"Line {lineNumber}: {error}"
+                    };
+                }
+
+                catalog.Entries.Add(entry);
+                processed++;
+                request.Progress?.Report(Math.Min(99, processed % 100));
+            }
+
+            request.Progress?.Report(100);
+            return new FileFormatReadResult
+            {
+                Success = true,
+                Payload = catalog
+            };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatReadResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request.Payload is not LegacyAscdCatalog catalog)
+        {
+            return new FileFormatWriteResult
+            {
+                Success = false,
+                Error = "Payload must be LegacyAscdCatalog."
+            };
+        }
+
+        try
+        {
+            using var compressed = new DeflateStream(request.Target, CompressionMode.Compress, leaveOpen: true);
+            using var writer = new StreamWriter(compressed, Encoding.UTF8, leaveOpen: true);
+
+            var version = string.IsNullOrWhiteSpace(catalog.HeaderVersion) ? "1.0" : catalog.HeaderVersion.Trim();
+            await writer.WriteLineAsync($"{FormatHeaderPrefix} {version}");
+
+            for (var index = 0; index < catalog.Entries.Count; index++)
+            {
+                var entry = catalog.Entries[index];
+                var line = BuildInsertStatement(entry);
+                await writer.WriteLineAsync(line.AsMemory(), cancellationToken);
+
+                request.Progress?.Report((int)((index + 1d) / Math.Max(1, catalog.Entries.Count) * 100d));
+            }
+
+            await writer.FlushAsync(cancellationToken);
+            request.Progress?.Report(100);
+            return new FileFormatWriteResult { Success = true };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatWriteResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    private static bool TryParseHeaderVersion(string headerLine, out string version)
+    {
+        var trimmed = headerLine.Trim();
+        if (!trimmed.StartsWith(FormatHeaderPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            version = string.Empty;
+            return false;
+        }
+
+        version = trimmed.Length == FormatHeaderPrefix.Length
+            ? "1.0"
+            : trimmed[FormatHeaderPrefix.Length..].Trim();
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            version = "1.0";
+        }
+
+        return true;
+    }
+
+    private static bool TryParseInsertStatement(string line, out LegacyAscdEntry entry, out string error)
+    {
+        if (!line.StartsWith(InsertPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            entry = default!;
+            error = "Unsupported statement. Only INSERT INTO list is accepted.";
+            return false;
+        }
+
+        var valuesTokenIndex = line.IndexOf("VALUES", StringComparison.OrdinalIgnoreCase);
+        if (valuesTokenIndex < 0)
+        {
+            entry = default!;
+            error = "Missing VALUES clause.";
+            return false;
+        }
+
+        var openParen = line.IndexOf('(', valuesTokenIndex);
+        var closeParen = line.LastIndexOf(')');
+        if (openParen < 0 || closeParen <= openParen || closeParen != line.Length - 1)
+        {
+            entry = default!;
+            error = "Only a single VALUES(...) statement is supported.";
+            return false;
+        }
+
+        if (!TryParseQuotedValues(line, openParen + 1, closeParen - 1, out var values, out error))
+        {
+            entry = default!;
+            return false;
+        }
+
+        if (values.Count != 7)
+        {
+            entry = default!;
+            error = $"Expected 7 values but found {values.Count}.";
+            return false;
+        }
+
+        entry = new LegacyAscdEntry
+        {
+            Id = values[0],
+            Name = values[1],
+            ParentId = values[2],
+            Type = values[3],
+            PropertiesXml = values[4],
+            SizeBytes = TryParseSize(values[5]),
+            ApplicationId = values[6]
+        };
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool TryParseQuotedValues(string text, int startIndex, int endIndex, out List<string> values, out string error)
+    {
+        values = [];
+        var index = startIndex;
+
+        while (index <= endIndex)
+        {
+            while (index <= endIndex && char.IsWhiteSpace(text[index]))
+            {
+                index++;
+            }
+
+            if (index > endIndex || text[index] != '\'')
+            {
+                error = "Expected quoted SQL literal.";
+                return false;
+            }
+
+            index++;
+            var builder = new StringBuilder();
+            var closed = false;
+            while (index <= endIndex)
+            {
+                var ch = text[index];
+                if (ch == '\'')
+                {
+                    if (index + 1 <= endIndex && text[index + 1] == '\'')
+                    {
+                        builder.Append('\'');
+                        index += 2;
+                        continue;
+                    }
+
+                    closed = true;
+                    index++;
+                    break;
+                }
+
+                builder.Append(ch);
+                index++;
+            }
+
+            if (!closed)
+            {
+                error = "Unterminated quoted SQL literal.";
+                return false;
+            }
+
+            values.Add(builder.ToString());
+
+            while (index <= endIndex && char.IsWhiteSpace(text[index]))
+            {
+                index++;
+            }
+
+            if (index <= endIndex)
+            {
+                if (text[index] != ',')
+                {
+                    error = "Expected comma delimiter between SQL values.";
+                    return false;
+                }
+
+                index++;
+            }
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    private static string BuildInsertStatement(LegacyAscdEntry entry)
+    {
+        return $"INSERT INTO list (`ID`, `Name`, `ParentID`, `Type`, `Properties`,`Size`, `AID`) VALUES ('{EscapeSqlLiteral(entry.Id)}', '{EscapeSqlLiteral(entry.Name)}', '{EscapeSqlLiteral(entry.ParentId)}', '{EscapeSqlLiteral(entry.Type)}', '{EscapeSqlLiteral(entry.PropertiesXml)}', '{entry.SizeBytes}', '{EscapeSqlLiteral(entry.ApplicationId)}')";
+    }
+
+    private static string EscapeSqlLiteral(string value) => value.Replace("'", "''", StringComparison.Ordinal);
+
+    private static long TryParseSize(string raw) =>
+        long.TryParse(raw, out var parsed) ? parsed : 0L;
+}

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/SkyCD.Plugin.Legacy.Ascd.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/SkyCD.Plugin.Legacy.Ascd.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.legacy.ascd",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Legacy.Ascd.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/Plugins/" />
   <Folder Name="/Plugins/samples/">
+    <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Ascd/SkyCD.Plugin.Legacy.Ascd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Cscd/SkyCD.Plugin.Legacy.Cscd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Scd/SkyCD.Plugin.Legacy.Scd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />

--- a/docs/architecture/legacy-code-archival-strategy.md
+++ b/docs/architecture/legacy-code-archival-strategy.md
@@ -1,0 +1,33 @@
+# Legacy Code Archival Strategy (v3)
+
+## Status
+Accepted
+
+## Context
+The repository still contains legacy VB.NET/WinForms sources alongside the v3 codebase. During migration, contributors need strict boundaries so new work does not drift back into legacy paths.
+
+## Decision
+- Keep legacy code in the repository for reference and rollback support.
+- Move legacy implementation under a dedicated `legacy/` tree rather than leaving it at repository root.
+- Treat `legacy/` as read-only except for archival/cleanup operations.
+- All new feature work for v3 must be implemented in projects reachable from `SkyCD.V3.slnx`.
+
+## Contributor Guardrails
+Do:
+- Use `SkyCD.V3.slnx` as the primary solution for build/test and new development.
+- Implement new file-format behavior via v3 plugins and SDK abstractions.
+- Update migration docs when legacy parity behavior changes.
+
+Do not:
+- Add new features to legacy VB.NET/WinForms projects.
+- Introduce v3 dependencies from legacy code into active runtime paths.
+- Make CI depend on building legacy code as part of v3 quality gates.
+
+## Rollback and Support Policy
+- Legacy sources remain available for forensic comparison and controlled migration fixes.
+- Production/runtime support targets v3 code paths only.
+- Rollback strategy is branch/tag based; legacy runtime deployment is not part of v3 release support.
+
+## Follow-up Linked Tasks
+- #90 Move legacy VB.NET solution/projects into `legacy/` and fix references.
+- #91 Clean repository root and CI to enforce v3-only build path.

--- a/docs/architecture/v3-migration.md
+++ b/docs/architecture/v3-migration.md
@@ -15,6 +15,9 @@ Use a **parallel rewrite** with a controlled compatibility bridge for legacy fil
 ### Non-goal
 - No binary compatibility promise for legacy .NET Framework plugins.
 
+### Related Architecture Decisions
+- [Legacy Code Archival Strategy](legacy-code-archival-strategy.md)
+
 ## 3. Target Repository Structure
 ```text
 /

--- a/docs/legal/dependency-update-policy.md
+++ b/docs/legal/dependency-update-policy.md
@@ -1,0 +1,34 @@
+# Dependency Update Policy
+
+This policy defines how automated dependency update pull requests are handled in v3.
+
+## Automation Scope
+- Dependabot is enabled for:
+- NuGet (`package-ecosystem: nuget`).
+- GitHub Actions (`package-ecosystem: github-actions`).
+- All update PRs target `main` and are validated by CI workflows on pull request events.
+
+## Cadence and Noise Control
+- Routine updates run weekly.
+- Open PR limits are enforced to avoid queue flooding.
+- Routine updates are grouped by stack: .NET runtime/platform packages, test tooling packages, and GitHub Actions dependencies.
+
+## Security Updates
+- Security updates are separated from routine updates using Dependabot security groups.
+- Security PRs are intentionally broad (`*`) to avoid delaying vulnerable package remediation.
+
+## Metadata Rules
+- Dependabot PRs must include:
+- `dependencies` label.
+- `type:platform` label.
+- Conventional commit-style prefix (`chore(deps)` or `chore(ci-deps)`).
+
+## License Guardrails (BSD-2)
+- Every dependency update PR must pass the license compliance gate defined in:
+- [dependency-license-policy.json](dependency-license-policy.json)
+- [.github/workflows/v3-ci.yml](../../.github/workflows/v3-ci.yml)
+- Packages violating policy are blocked until approved policy changes are merged.
+
+## Changelog Policy
+- Routine dependency PRs do not require changelog entries.
+- Security updates and major-version updates must include a short impact summary in the PR body.

--- a/docs/migration/legacy-format-parity-tracker.md
+++ b/docs/migration/legacy-format-parity-tracker.md
@@ -1,0 +1,27 @@
+# Legacy File-Format Parity Tracker
+
+This tracker records migration parity status for legacy file formats and related dependencies.
+
+## Dependency Chain
+- [x] #65 Plugin SDK vNext contracts and lifecycle
+- [x] #66 File format plugin contracts
+- [x] #69 Plugin loading runtime
+- [x] #71 `*.scd` migration plugin
+- [x] #72 `*.cscd` migration plugin
+- [x] #73 `*.ascd` migration plugin
+- [ ] #70 Migration tooling/docs consume finalized plugins
+
+## Parity Matrix
+| Extension | Plugin Package | Read | Write | Fixture Coverage | Notes |
+|---|---|---|---|---|---|
+| `.scd` | `SkyCD.Plugin.Legacy.Scd` | Yes | Yes | `gamez.scd` parse + round-trip | Text comments/blank lines are ignored |
+| `.cscd` | `SkyCD.Plugin.Legacy.Cscd` | Yes | Yes | synthetic compressed round-trip | Shares `.scd` text model with deflate wrapper |
+| `.ascd` | `SkyCD.Plugin.Legacy.Ascd` | Yes | Yes | `My Documents.ascd`, `ftpz.ascd`, round-trip | Safe parser accepts only `skycd-nf` + `INSERT INTO list` shape |
+
+## Host Integration Status
+- Legacy file format handling is routed through `IFileFormatPluginCapability` in plugin host.
+- No host hardcoded extension-specific parser logic is required for `.scd`, `.cscd`, or `.ascd`.
+
+## Known Limitations
+- `.ascd` files containing SQL statements outside the supported insert shape are rejected.
+- `.scd/.cscd` output formatting may differ while preserving entry data semantics.

--- a/docs/migration/legacy-plugin-compatibility.md
+++ b/docs/migration/legacy-plugin-compatibility.md
@@ -2,10 +2,15 @@
 
 | Legacy Plugin | Legacy Extension(s) | v3 Status | Notes |
 |---|---|---|---|
-| TextFormat | `.scd` | Planned | Re-implemented as v3 file-format plugin (#71) |
-| CompressedTextFormat | `.cscd` | Planned | Re-implemented as v3 file-format plugin (#72) |
-| SkyCDNativeFormat | `.ascd` | Planned | Re-implemented as v3 file-format plugin (#73) |
+| TextFormat | `.scd` | Implemented | v3 plugin `SkyCD.Plugin.Legacy.Scd` with read/write + fixture round-trip tests (#71) |
+| CompressedTextFormat | `.cscd` | Implemented | v3 plugin `SkyCD.Plugin.Legacy.Cscd` with compressed round-trip tests (#72) |
+| SkyCDNativeFormat | `.ascd` | Implemented | v3 plugin `SkyCD.Plugin.Legacy.Ascd` with safe parser, header validation, and security tests (#73) |
 
 ## Binary Compatibility
 - v2 `.NET Framework` plugin binaries are **not** loaded in v3 runtime.
 - Migration path: port plugin to `SkyCD.Plugin.Abstractions` and provide `plugin.json` manifest.
+
+## Known Compatibility Limits
+- `.scd` output normalizes size formatting (`KB/MB/GB`) and skips comment/empty lines.
+- `.ascd` importer only accepts `# format: skycd-nf <version>` plus `INSERT INTO list ... VALUES (...)` statements.
+- `.ascd` payload is parsed as data only; no SQL execution, additional SQL statements, or script batches are supported.

--- a/tests/SkyCD.LegacyFormats.Tests/LegacyAscdPluginTests.cs
+++ b/tests/SkyCD.LegacyFormats.Tests/LegacyAscdPluginTests.cs
@@ -1,0 +1,134 @@
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Legacy.Ascd;
+
+namespace SkyCD.LegacyFormats.Tests;
+
+public class LegacyAscdPluginTests
+{
+    [Fact]
+    public async Task ReadAsync_ParsesLegacyFixtures()
+    {
+        var plugin = new LegacyAscdPlugin();
+        var fixtures = new[] { "my-documents.ascd", "ftpz.ascd" };
+
+        foreach (var fixture in fixtures)
+        {
+            var fixturePath = Path.Combine(AppContext.BaseDirectory, "fixtures", fixture);
+            var bytes = await File.ReadAllBytesAsync(fixturePath);
+            await using var source = new MemoryStream(bytes);
+
+            var result = await plugin.ReadAsync(new FileFormatReadRequest
+            {
+                FormatId = "legacy-ascd",
+                Source = source,
+                FileName = fixture
+            });
+
+            Assert.True(result.Success, result.Error);
+            var payload = Assert.IsType<LegacyAscdCatalog>(result.Payload);
+            Assert.NotEmpty(payload.Entries);
+            Assert.All(payload.Entries, entry =>
+            {
+                Assert.False(string.IsNullOrWhiteSpace(entry.Id));
+                Assert.False(string.IsNullOrWhiteSpace(entry.Name));
+                Assert.False(string.IsNullOrWhiteSpace(entry.Type));
+            });
+        }
+    }
+
+    [Fact]
+    public async Task ReadThenWriteThenReadAsync_RoundTripsEntries()
+    {
+        var plugin = new LegacyAscdPlugin();
+        var fixturePath = Path.Combine(AppContext.BaseDirectory, "fixtures", "my-documents.ascd");
+        var bytes = await File.ReadAllBytesAsync(fixturePath);
+        await using var source = new MemoryStream(bytes);
+
+        var firstRead = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-ascd",
+            Source = source,
+            FileName = "my-documents.ascd"
+        });
+
+        Assert.True(firstRead.Success, firstRead.Error);
+        var payload = Assert.IsType<LegacyAscdCatalog>(firstRead.Payload);
+
+        await using var target = new MemoryStream();
+        var write = await plugin.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "legacy-ascd",
+            Target = target,
+            Payload = payload,
+            FileName = "my-documents.ascd"
+        });
+
+        Assert.True(write.Success, write.Error);
+
+        target.Position = 0;
+        var secondRead = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-ascd",
+            Source = target,
+            FileName = "my-documents.ascd"
+        });
+
+        Assert.True(secondRead.Success, secondRead.Error);
+        var reparsed = Assert.IsType<LegacyAscdCatalog>(secondRead.Payload);
+        Assert.Equal(payload.Entries.Count, reparsed.Entries.Count);
+        Assert.Equal(payload.Entries[0].Name, reparsed.Entries[0].Name);
+        Assert.Equal(payload.Entries[0].SizeBytes, reparsed.Entries[0].SizeBytes);
+    }
+
+    [Fact]
+    public async Task ReadAsync_RejectsInvalidHeader()
+    {
+        var plugin = new LegacyAscdPlugin();
+        var invalidText = "INSERT INTO list (`ID`, `Name`, `ParentID`, `Type`, `Properties`,`Size`, `AID`) VALUES ('0', 'Root', '-1', 'scdFolder', '', '0', '<?Application_ID?>')";
+        var compressed = CompressText(invalidText);
+        await using var source = new MemoryStream(compressed);
+
+        var result = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-ascd",
+            Source = source
+        });
+
+        Assert.False(result.Success);
+        Assert.Contains("header", result.Error ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReadAsync_RejectsUnexpectedSqlPayload()
+    {
+        var plugin = new LegacyAscdPlugin();
+        var payload =
+            """
+            # format: skycd-nf 1.0
+            INSERT INTO list (`ID`, `Name`, `ParentID`, `Type`, `Properties`,`Size`, `AID`) VALUES ('0', 'Root', '-1', 'scdFolder', '', '0', '<?Application_ID?>'); DROP TABLE list;
+            """;
+        var compressed = CompressText(payload);
+        await using var source = new MemoryStream(compressed);
+
+        var result = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-ascd",
+            Source = source
+        });
+
+        Assert.False(result.Success);
+        Assert.Contains("single VALUES", result.Error ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static byte[] CompressText(string text)
+    {
+        using var output = new MemoryStream();
+        using (var compressed = new System.IO.Compression.DeflateStream(output, System.IO.Compression.CompressionMode.Compress, leaveOpen: true))
+        using (var writer = new StreamWriter(compressed))
+        {
+            writer.Write(text);
+        }
+
+        return output.ToArray();
+    }
+}

--- a/tests/SkyCD.LegacyFormats.Tests/LegacyScdPluginTests.cs
+++ b/tests/SkyCD.LegacyFormats.Tests/LegacyScdPluginTests.cs
@@ -56,4 +56,48 @@ public class LegacyScdPluginTests
         Assert.Equal(2, parsed.Entries.Count);
         Assert.Equal(@"[Disk]\Folder\File.txt", parsed.Entries[0].Path);
     }
+
+    [Fact]
+    public async Task ReadThenWriteThenReadAsync_RoundTripsFixtureEntries()
+    {
+        var plugin = new LegacyScdPlugin();
+        var samplePath = Path.Combine(AppContext.BaseDirectory, "fixtures", "gamez.scd");
+        var sourceBytes = await File.ReadAllBytesAsync(samplePath);
+        await using var source = new MemoryStream(sourceBytes);
+
+        var firstRead = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-scd",
+            Source = source,
+            FileName = "gamez.scd"
+        });
+
+        Assert.True(firstRead.Success);
+        var parsed = Assert.IsType<LegacyScdCatalog>(firstRead.Payload);
+        Assert.NotEmpty(parsed.Entries);
+
+        await using var serialized = new MemoryStream();
+        var write = await plugin.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "legacy-scd",
+            Target = serialized,
+            Payload = parsed,
+            FileName = "gamez.scd"
+        });
+
+        Assert.True(write.Success);
+
+        serialized.Position = 0;
+        var secondRead = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-scd",
+            Source = serialized,
+            FileName = "gamez.scd"
+        });
+
+        Assert.True(secondRead.Success);
+        var reparsed = Assert.IsType<LegacyScdCatalog>(secondRead.Payload);
+        Assert.Equal(parsed.Entries.Count, reparsed.Entries.Count);
+        Assert.Equal(parsed.Entries[0].Path, reparsed.Entries[0].Path);
+    }
 }

--- a/tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj
+++ b/tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Legacy.Ascd\SkyCD.Plugin.Legacy.Ascd.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Legacy.Cscd\SkyCD.Plugin.Legacy.Cscd.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Legacy.Scd\SkyCD.Plugin.Legacy.Scd.csproj" />
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
@@ -26,6 +27,12 @@
 
   <ItemGroup>
     <None Include="..\..\SkyCD\Samples\gamez.scd" Link="fixtures\gamez.scd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\SkyCD\Samples\My Documents.ascd" Link="fixtures\my-documents.ascd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\SkyCD\Samples\ftpz.ascd" Link="fixtures\ftpz.ascd">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
## Summary
- #71: strengthens legacy `*.scd` fixture round-trip coverage and confirms plugin-manifest-based support
- #73: adds `SkyCD.Plugin.Legacy.Ascd` with safe `skycd-nf` parser/writer, header detection, and security tests
- #87: updates Dependabot config for NuGet + Actions with grouping, security separation, labels, and policy docs
- #74: adds legacy format parity tracker and updates compatibility matrix/status/limitations
- #89: adds architecture decision doc for legacy archival strategy and contributor guardrails

## Validation
- `dotnet test SkyCD.V3.slnx --configuration Debug`

Closes #71
Closes #73
Closes #87
Closes #74
Closes #89