### PR TITLE
feat(legacy): migrate *.ascd as secure v3 plugin (#73)

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/LegacyAscdCatalog.cs
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/LegacyAscdCatalog.cs
@@ -1,0 +1,25 @@
+namespace SkyCD.Plugin.Legacy.Ascd;
+
+public sealed class LegacyAscdCatalog
+{
+    public string HeaderVersion { get; init; } = "1.0";
+
+    public List<LegacyAscdEntry> Entries { get; } = [];
+}
+
+public sealed class LegacyAscdEntry
+{
+    public required string Id { get; init; }
+
+    public required string Name { get; init; }
+
+    public required string ParentId { get; init; }
+
+    public required string Type { get; init; }
+
+    public string PropertiesXml { get; init; } = string.Empty;
+
+    public long SizeBytes { get; init; }
+
+    public string ApplicationId { get; init; } = "<?Application_ID?>";
+}

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/LegacyAscdPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/LegacyAscdPlugin.cs
@@ -1,0 +1,294 @@
+using System.IO.Compression;
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Legacy.Ascd;
+
+public sealed class LegacyAscdPlugin : IPlugin, IFileFormatPluginCapability
+{
+    private const string FormatHeaderPrefix = "# format: skycd-nf";
+    private const string InsertPrefix = "INSERT INTO list";
+
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.legacy.ascd",
+        "Legacy ASCD Format Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Reads and writes legacy *.ascd compressed catalogs using safe statement parsing.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor("legacy-ascd", "SkyCD Advanced Format", [".ascd"], CanRead: true, CanWrite: true, "application/octet-stream")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public async Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var compressed = new DeflateStream(request.Source, CompressionMode.Decompress, leaveOpen: true);
+            using var reader = new StreamReader(compressed, Encoding.UTF8, leaveOpen: true);
+
+            var lineNumber = 0;
+            string? header = null;
+            while ((header = await reader.ReadLineAsync(cancellationToken)) is not null)
+            {
+                lineNumber++;
+                if (!string.IsNullOrWhiteSpace(header))
+                {
+                    break;
+                }
+            }
+
+            if (header is null || !TryParseHeaderVersion(header, out var version))
+            {
+                return new FileFormatReadResult
+                {
+                    Success = false,
+                    Error = "Missing or invalid header. Expected '# format: skycd-nf <version>'."
+                };
+            }
+
+            var catalog = new LegacyAscdCatalog { HeaderVersion = version };
+            string? line;
+            var processed = 0;
+            while ((line = await reader.ReadLineAsync(cancellationToken)) is not null)
+            {
+                lineNumber++;
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                if (!TryParseInsertStatement(line.Trim(), out var entry, out var error))
+                {
+                    return new FileFormatReadResult
+                    {
+                        Success = false,
+                        Error = $"Line {lineNumber}: {error}"
+                    };
+                }
+
+                catalog.Entries.Add(entry);
+                processed++;
+                request.Progress?.Report(Math.Min(99, processed % 100));
+            }
+
+            request.Progress?.Report(100);
+            return new FileFormatReadResult
+            {
+                Success = true,
+                Payload = catalog
+            };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatReadResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        if (request.Payload is not LegacyAscdCatalog catalog)
+        {
+            return new FileFormatWriteResult
+            {
+                Success = false,
+                Error = "Payload must be LegacyAscdCatalog."
+            };
+        }
+
+        try
+        {
+            using var compressed = new DeflateStream(request.Target, CompressionMode.Compress, leaveOpen: true);
+            using var writer = new StreamWriter(compressed, Encoding.UTF8, leaveOpen: true);
+
+            var version = string.IsNullOrWhiteSpace(catalog.HeaderVersion) ? "1.0" : catalog.HeaderVersion.Trim();
+            await writer.WriteLineAsync($"{FormatHeaderPrefix} {version}");
+
+            for (var index = 0; index < catalog.Entries.Count; index++)
+            {
+                var entry = catalog.Entries[index];
+                var line = BuildInsertStatement(entry);
+                await writer.WriteLineAsync(line.AsMemory(), cancellationToken);
+
+                request.Progress?.Report((int)((index + 1d) / Math.Max(1, catalog.Entries.Count) * 100d));
+            }
+
+            await writer.FlushAsync(cancellationToken);
+            request.Progress?.Report(100);
+            return new FileFormatWriteResult { Success = true };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatWriteResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    private static bool TryParseHeaderVersion(string headerLine, out string version)
+    {
+        var trimmed = headerLine.Trim();
+        if (!trimmed.StartsWith(FormatHeaderPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            version = string.Empty;
+            return false;
+        }
+
+        version = trimmed.Length == FormatHeaderPrefix.Length
+            ? "1.0"
+            : trimmed[FormatHeaderPrefix.Length..].Trim();
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            version = "1.0";
+        }
+
+        return true;
+    }
+
+    private static bool TryParseInsertStatement(string line, out LegacyAscdEntry entry, out string error)
+    {
+        if (!line.StartsWith(InsertPrefix, StringComparison.OrdinalIgnoreCase))
+        {
+            entry = default!;
+            error = "Unsupported statement. Only INSERT INTO list is accepted.";
+            return false;
+        }
+
+        var valuesTokenIndex = line.IndexOf("VALUES", StringComparison.OrdinalIgnoreCase);
+        if (valuesTokenIndex < 0)
+        {
+            entry = default!;
+            error = "Missing VALUES clause.";
+            return false;
+        }
+
+        var openParen = line.IndexOf('(', valuesTokenIndex);
+        var closeParen = line.LastIndexOf(')');
+        if (openParen < 0 || closeParen <= openParen || closeParen != line.Length - 1)
+        {
+            entry = default!;
+            error = "Only a single VALUES(...) statement is supported.";
+            return false;
+        }
+
+        if (!TryParseQuotedValues(line, openParen + 1, closeParen - 1, out var values, out error))
+        {
+            entry = default!;
+            return false;
+        }
+
+        if (values.Count != 7)
+        {
+            entry = default!;
+            error = $"Expected 7 values but found {values.Count}.";
+            return false;
+        }
+
+        entry = new LegacyAscdEntry
+        {
+            Id = values[0],
+            Name = values[1],
+            ParentId = values[2],
+            Type = values[3],
+            PropertiesXml = values[4],
+            SizeBytes = TryParseSize(values[5]),
+            ApplicationId = values[6]
+        };
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool TryParseQuotedValues(string text, int startIndex, int endIndex, out List<string> values, out string error)
+    {
+        values = [];
+        var index = startIndex;
+
+        while (index <= endIndex)
+        {
+            while (index <= endIndex && char.IsWhiteSpace(text[index]))
+            {
+                index++;
+            }
+
+            if (index > endIndex || text[index] != '\'')
+            {
+                error = "Expected quoted SQL literal.";
+                return false;
+            }
+
+            index++;
+            var builder = new StringBuilder();
+            var closed = false;
+            while (index <= endIndex)
+            {
+                var ch = text[index];
+                if (ch == '\'')
+                {
+                    if (index + 1 <= endIndex && text[index + 1] == '\'')
+                    {
+                        builder.Append('\'');
+                        index += 2;
+                        continue;
+                    }
+
+                    closed = true;
+                    index++;
+                    break;
+                }
+
+                builder.Append(ch);
+                index++;
+            }
+
+            if (!closed)
+            {
+                error = "Unterminated quoted SQL literal.";
+                return false;
+            }
+
+            values.Add(builder.ToString());
+
+            while (index <= endIndex && char.IsWhiteSpace(text[index]))
+            {
+                index++;
+            }
+
+            if (index <= endIndex)
+            {
+                if (text[index] != ',')
+                {
+                    error = "Expected comma delimiter between SQL values.";
+                    return false;
+                }
+
+                index++;
+            }
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    private static string BuildInsertStatement(LegacyAscdEntry entry)
+    {
+        return $"INSERT INTO list (`ID`, `Name`, `ParentID`, `Type`, `Properties`,`Size`, `AID`) VALUES ('{EscapeSqlLiteral(entry.Id)}', '{EscapeSqlLiteral(entry.Name)}', '{EscapeSqlLiteral(entry.ParentId)}', '{EscapeSqlLiteral(entry.Type)}', '{EscapeSqlLiteral(entry.PropertiesXml)}', '{entry.SizeBytes}', '{EscapeSqlLiteral(entry.ApplicationId)}')";
+    }
+
+    private static string EscapeSqlLiteral(string value) => value.Replace("'", "''", StringComparison.Ordinal);
+
+    private static long TryParseSize(string raw) =>
+        long.TryParse(raw, out var parsed) ? parsed : 0L;
+}

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/SkyCD.Plugin.Legacy.Ascd.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/SkyCD.Plugin.Legacy.Ascd.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Legacy.Ascd/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.legacy.ascd",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Legacy.Ascd.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Folder Name="/Plugins/" />
   <Folder Name="/Plugins/samples/">
+    <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Ascd/SkyCD.Plugin.Legacy.Ascd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Cscd/SkyCD.Plugin.Legacy.Cscd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Scd/SkyCD.Plugin.Legacy.Scd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />

--- a/tests/SkyCD.LegacyFormats.Tests/LegacyAscdPluginTests.cs
+++ b/tests/SkyCD.LegacyFormats.Tests/LegacyAscdPluginTests.cs
@@ -1,0 +1,134 @@
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Legacy.Ascd;
+
+namespace SkyCD.LegacyFormats.Tests;
+
+public class LegacyAscdPluginTests
+{
+    [Fact]
+    public async Task ReadAsync_ParsesLegacyFixtures()
+    {
+        var plugin = new LegacyAscdPlugin();
+        var fixtures = new[] { "my-documents.ascd", "ftpz.ascd" };
+
+        foreach (var fixture in fixtures)
+        {
+            var fixturePath = Path.Combine(AppContext.BaseDirectory, "fixtures", fixture);
+            var bytes = await File.ReadAllBytesAsync(fixturePath);
+            await using var source = new MemoryStream(bytes);
+
+            var result = await plugin.ReadAsync(new FileFormatReadRequest
+            {
+                FormatId = "legacy-ascd",
+                Source = source,
+                FileName = fixture
+            });
+
+            Assert.True(result.Success, result.Error);
+            var payload = Assert.IsType<LegacyAscdCatalog>(result.Payload);
+            Assert.NotEmpty(payload.Entries);
+            Assert.All(payload.Entries, entry =>
+            {
+                Assert.False(string.IsNullOrWhiteSpace(entry.Id));
+                Assert.False(string.IsNullOrWhiteSpace(entry.Name));
+                Assert.False(string.IsNullOrWhiteSpace(entry.Type));
+            });
+        }
+    }
+
+    [Fact]
+    public async Task ReadThenWriteThenReadAsync_RoundTripsEntries()
+    {
+        var plugin = new LegacyAscdPlugin();
+        var fixturePath = Path.Combine(AppContext.BaseDirectory, "fixtures", "my-documents.ascd");
+        var bytes = await File.ReadAllBytesAsync(fixturePath);
+        await using var source = new MemoryStream(bytes);
+
+        var firstRead = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-ascd",
+            Source = source,
+            FileName = "my-documents.ascd"
+        });
+
+        Assert.True(firstRead.Success, firstRead.Error);
+        var payload = Assert.IsType<LegacyAscdCatalog>(firstRead.Payload);
+
+        await using var target = new MemoryStream();
+        var write = await plugin.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "legacy-ascd",
+            Target = target,
+            Payload = payload,
+            FileName = "my-documents.ascd"
+        });
+
+        Assert.True(write.Success, write.Error);
+
+        target.Position = 0;
+        var secondRead = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-ascd",
+            Source = target,
+            FileName = "my-documents.ascd"
+        });
+
+        Assert.True(secondRead.Success, secondRead.Error);
+        var reparsed = Assert.IsType<LegacyAscdCatalog>(secondRead.Payload);
+        Assert.Equal(payload.Entries.Count, reparsed.Entries.Count);
+        Assert.Equal(payload.Entries[0].Name, reparsed.Entries[0].Name);
+        Assert.Equal(payload.Entries[0].SizeBytes, reparsed.Entries[0].SizeBytes);
+    }
+
+    [Fact]
+    public async Task ReadAsync_RejectsInvalidHeader()
+    {
+        var plugin = new LegacyAscdPlugin();
+        var invalidText = "INSERT INTO list (`ID`, `Name`, `ParentID`, `Type`, `Properties`,`Size`, `AID`) VALUES ('0', 'Root', '-1', 'scdFolder', '', '0', '<?Application_ID?>')";
+        var compressed = CompressText(invalidText);
+        await using var source = new MemoryStream(compressed);
+
+        var result = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-ascd",
+            Source = source
+        });
+
+        Assert.False(result.Success);
+        Assert.Contains("header", result.Error ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReadAsync_RejectsUnexpectedSqlPayload()
+    {
+        var plugin = new LegacyAscdPlugin();
+        var payload =
+            """
+            # format: skycd-nf 1.0
+            INSERT INTO list (`ID`, `Name`, `ParentID`, `Type`, `Properties`,`Size`, `AID`) VALUES ('0', 'Root', '-1', 'scdFolder', '', '0', '<?Application_ID?>'); DROP TABLE list;
+            """;
+        var compressed = CompressText(payload);
+        await using var source = new MemoryStream(compressed);
+
+        var result = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "legacy-ascd",
+            Source = source
+        });
+
+        Assert.False(result.Success);
+        Assert.Contains("single VALUES", result.Error ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static byte[] CompressText(string text)
+    {
+        using var output = new MemoryStream();
+        using (var compressed = new System.IO.Compression.DeflateStream(output, System.IO.Compression.CompressionMode.Compress, leaveOpen: true))
+        using (var writer = new StreamWriter(compressed))
+        {
+            writer.Write(text);
+        }
+
+        return output.ToArray();
+    }
+}

--- a/tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj
+++ b/tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Legacy.Ascd\SkyCD.Plugin.Legacy.Ascd.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Legacy.Cscd\SkyCD.Plugin.Legacy.Cscd.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Legacy.Scd\SkyCD.Plugin.Legacy.Scd.csproj" />
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
@@ -26,6 +27,12 @@
 
   <ItemGroup>
     <None Include="..\..\SkyCD\Samples\gamez.scd" Link="fixtures\gamez.scd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\SkyCD\Samples\My Documents.ascd" Link="fixtures\my-documents.ascd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\SkyCD\Samples\ftpz.ascd" Link="fixtures\ftpz.ascd">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
## Summary
- adds `SkyCD.Plugin.Legacy.Ascd` implementing v3 file-format contracts
- supports deflate payloads with `# format: skycd-nf` header/version detection
- parses SQL-like payload as data only (no SQL execution path)
- adds fixture parsing, round-trip, invalid-header, and hostile payload tests

## Validation
- `dotnet test tests/SkyCD.LegacyFormats.Tests/SkyCD.LegacyFormats.Tests.csproj`

Closes #73