### PR TITLE
chore(deps): configure Dependabot NuGet + Actions policy (#87)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,15 +8,57 @@ registries:
     password: ${{secrets.PACKAGES_PAT}}
 
 updates:
-- package-ecosystem: nuget
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 25
-  registries: 
+  - package-ecosystem: nuget
+    directory: "/"
+    registries:
       - skycd
-      
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: monthly
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:00"
+      timezone: "Europe/Vilnius"
+    open-pull-requests-limit: 8
+    labels:
+      - dependencies
+      - type:platform
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dotnet-core:
+        applies-to: version-updates
+        patterns:
+          - "Microsoft.*"
+          - "System.*"
+      test-stack:
+        applies-to: version-updates
+        patterns:
+          - "xunit*"
+          - "Microsoft.NET.Test.Sdk"
+          - "coverlet*"
+      security-nuget:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "05:30"
+      timezone: "Europe/Vilnius"
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - type:platform
+    commit-message:
+      prefix: "chore(ci-deps)"
+    groups:
+      actions-routine:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/docs/legal/dependency-update-policy.md
+++ b/docs/legal/dependency-update-policy.md
@@ -1,0 +1,34 @@
+# Dependency Update Policy
+
+This policy defines how automated dependency update pull requests are handled in v3.
+
+## Automation Scope
+- Dependabot is enabled for:
+- NuGet (`package-ecosystem: nuget`).
+- GitHub Actions (`package-ecosystem: github-actions`).
+- All update PRs target `main` and are validated by CI workflows on pull request events.
+
+## Cadence and Noise Control
+- Routine updates run weekly.
+- Open PR limits are enforced to avoid queue flooding.
+- Routine updates are grouped by stack: .NET runtime/platform packages, test tooling packages, and GitHub Actions dependencies.
+
+## Security Updates
+- Security updates are separated from routine updates using Dependabot security groups.
+- Security PRs are intentionally broad (`*`) to avoid delaying vulnerable package remediation.
+
+## Metadata Rules
+- Dependabot PRs must include:
+- `dependencies` label.
+- `type:platform` label.
+- Conventional commit-style prefix (`chore(deps)` or `chore(ci-deps)`).
+
+## License Guardrails (BSD-2)
+- Every dependency update PR must pass the license compliance gate defined in:
+- [dependency-license-policy.json](dependency-license-policy.json)
+- [.github/workflows/v3-ci.yml](../../.github/workflows/v3-ci.yml)
+- Packages violating policy are blocked until approved policy changes are merged.
+
+## Changelog Policy
+- Routine dependency PRs do not require changelog entries.
+- Security updates and major-version updates must include a short impact summary in the PR body.


### PR DESCRIPTION
## Summary
- updates `.github/dependabot.yml` for NuGet and GitHub Actions cadence, grouping, and labels
- separates routine and security update groups
- documents dependency update policy and BSD-2 license guardrails

## Validation
- configuration/doc changes only (no runtime code)

Closes #87