### PR TITLE
docs(migration): legacy format parity tracker and matrix refresh (#74)

### DIFF
--- a/docs/migration/legacy-format-parity-tracker.md
+++ b/docs/migration/legacy-format-parity-tracker.md
@@ -1,0 +1,27 @@
+# Legacy File-Format Parity Tracker
+
+This tracker records migration parity status for legacy file formats and related dependencies.
+
+## Dependency Chain
+- [x] #65 Plugin SDK vNext contracts and lifecycle
+- [x] #66 File format plugin contracts
+- [x] #69 Plugin loading runtime
+- [x] #71 `*.scd` migration plugin
+- [x] #72 `*.cscd` migration plugin
+- [x] #73 `*.ascd` migration plugin
+- [ ] #70 Migration tooling/docs consume finalized plugins
+
+## Parity Matrix
+| Extension | Plugin Package | Read | Write | Fixture Coverage | Notes |
+|---|---|---|---|---|---|
+| `.scd` | `SkyCD.Plugin.Legacy.Scd` | Yes | Yes | `gamez.scd` parse + round-trip | Text comments/blank lines are ignored |
+| `.cscd` | `SkyCD.Plugin.Legacy.Cscd` | Yes | Yes | synthetic compressed round-trip | Shares `.scd` text model with deflate wrapper |
+| `.ascd` | `SkyCD.Plugin.Legacy.Ascd` | Yes | Yes | `My Documents.ascd`, `ftpz.ascd`, round-trip | Safe parser accepts only `skycd-nf` + `INSERT INTO list` shape |
+
+## Host Integration Status
+- Legacy file format handling is routed through `IFileFormatPluginCapability` in plugin host.
+- No host hardcoded extension-specific parser logic is required for `.scd`, `.cscd`, or `.ascd`.
+
+## Known Limitations
+- `.ascd` files containing SQL statements outside the supported insert shape are rejected.
+- `.scd/.cscd` output formatting may differ while preserving entry data semantics.

--- a/docs/migration/legacy-plugin-compatibility.md
+++ b/docs/migration/legacy-plugin-compatibility.md
@@ -2,10 +2,15 @@
 
 | Legacy Plugin | Legacy Extension(s) | v3 Status | Notes |
 |---|---|---|---|
-| TextFormat | `.scd` | Planned | Re-implemented as v3 file-format plugin (#71) |
-| CompressedTextFormat | `.cscd` | Planned | Re-implemented as v3 file-format plugin (#72) |
-| SkyCDNativeFormat | `.ascd` | Planned | Re-implemented as v3 file-format plugin (#73) |
+| TextFormat | `.scd` | Implemented | v3 plugin `SkyCD.Plugin.Legacy.Scd` with read/write + fixture round-trip tests (#71) |
+| CompressedTextFormat | `.cscd` | Implemented | v3 plugin `SkyCD.Plugin.Legacy.Cscd` with compressed round-trip tests (#72) |
+| SkyCDNativeFormat | `.ascd` | Implemented | v3 plugin `SkyCD.Plugin.Legacy.Ascd` with safe parser, header validation, and security tests (#73) |
 
 ## Binary Compatibility
 - v2 `.NET Framework` plugin binaries are **not** loaded in v3 runtime.
 - Migration path: port plugin to `SkyCD.Plugin.Abstractions` and provide `plugin.json` manifest.
+
+## Known Compatibility Limits
+- `.scd` output normalizes size formatting (`KB/MB/GB`) and skips comment/empty lines.
+- `.ascd` importer only accepts `# format: skycd-nf <version>` plus `INSERT INTO list ... VALUES (...)` statements.
+- `.ascd` payload is parsed as data only; no SQL execution, additional SQL statements, or script batches are supported.


### PR DESCRIPTION
## Summary
- adds legacy format parity/dependency tracker document
- updates compatibility matrix statuses and known limitations
- records host/plugin routing posture for legacy format handling

## Validation
- documentation changes only

Closes #74