### PR TITLE
ci: configure v3 GitHub Actions quality gates (#86)

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -1,68 +1,29 @@
-name: build and test
+name: dependabot-automerge
 
 on:
   pull_request:
     branches: [ main ]
 
 jobs:
-  build-and-test:
-
-    name: Build & Test on ${{matrix.os}} & .NET ${{ matrix.dotnet }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: 
-#          - ubuntu-latest
-          - windows-latest
-#          - macOS-latest
-        dotnet: 
-          - '5.0.x'
-          - '6.0.x'
-    steps:
-    - uses: actions/checkout@v6
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v5
-      with:
-        dotnet-version: ${{ matrix.dotnet }}
-        
-    - name: Preparing nuget source
-      run: dotnet nuget add source --username SkyCD --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/SkyCD/index.json"        
-
-    - name: Install dependencies
-      run: dotnet restore
-      
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-    
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
-
   automerge:
     if: ${{ github.actor == 'dependabot[bot]' }}
-    needs: build-and-test
     permissions:
       pull-requests: write
-      contents: write    
+      contents: write
     runs-on: ubuntu-latest
     steps:
-      # This first step will fail if there's no metadata and so the approval
-      # will not occur.
       - name: Dependabot metadata
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v3.0.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      # Here the PR gets approved.
       - name: Approve a PR
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Finally, this sets the PR to allow auto-merging for patch and minor
-      # updates if all checks pass
       - name: Enable auto-merge for Dependabot PRs
-        # if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}                
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/v3-ci.yml
+++ b/.github/workflows/v3-ci.yml
@@ -7,8 +7,39 @@ on:
       - feat/**
   pull_request:
 
+concurrency:
+  group: v3-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
+  style:
+    name: Style (.NET format)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            **/packages.lock.json
+
+      - name: Restore v3 solution
+        run: dotnet restore SkyCD.V3.slnx
+
+      - name: Verify formatting
+        run: dotnet format SkyCD.V3.slnx --verify-no-changes --verbosity minimal
+
   build-test:
+    name: Build & Test (${{ matrix.os }})
+    needs: style
     strategy:
       fail-fast: false
       matrix:
@@ -23,17 +54,30 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
+          cache: true
+          cache-dependency-path: |
+            **/*.csproj
+            **/packages.lock.json
 
       - name: Restore v3 solution
         run: dotnet restore SkyCD.V3.slnx
 
       - name: Build v3 solution
-        run: dotnet build SkyCD.V3.slnx --configuration Release --no-restore
+        run: dotnet build SkyCD.V3.slnx --configuration Release --no-restore -warnaserror
 
       - name: Test v3 solution
-        run: dotnet test SkyCD.V3.slnx --configuration Release --no-build --verbosity normal
+        run: dotnet test SkyCD.V3.slnx --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=test-results-${{ matrix.os }}.trx" --results-directory artifacts/test-results/${{ matrix.os }}
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ matrix.os }}
+          path: artifacts/test-results/${{ matrix.os }}/
 
   license-compliance:
+    name: License Compliance
+    needs: style
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/docs/ci/github-actions-quality-gates.md
+++ b/docs/ci/github-actions-quality-gates.md
@@ -1,0 +1,33 @@
+# GitHub Actions Quality Gates (v3)
+
+This document describes the CI checks required for v3 pull requests and pushes.
+
+## Workflows
+- `v3-ci`:
+- `style` job: `dotnet format --verify-no-changes`
+- `build-test` job: restore/build/test on `ubuntu-latest`, `windows-latest`, and `macos-latest`
+- `license-compliance` job: CycloneDX SBOM generation and policy verification
+- `dependabot-automerge`:
+- dependabot-only metadata + approval + auto-merge workflow
+
+## Required Branch Protection Checks
+For `main`, configure branch protection to require these status checks:
+- `Style (.NET format)`
+- `Build & Test (ubuntu-latest)`
+- `Build & Test (windows-latest)`
+- `Build & Test (macos-latest)`
+- `License Compliance`
+
+## Test Results and Artifacts
+- CI publishes per-OS test result artifacts from:
+- `artifacts/test-results/<os>/`
+- License compliance reports are published as:
+- `license-artifacts`
+
+## Runtime and Flaky-Risk Notes
+- Matrix execution increases runtime; expect slower queues during dependency or SDK updates.
+- Cross-platform differences (path handling, file locking, line endings) can cause intermittent failures.
+- If flaky tests are observed:
+- capture TRX artifacts from failed jobs
+- quarantine/annotate test with linked issue
+- require two consecutive green reruns before merge for suspected flakes


### PR DESCRIPTION
## Summary
- updates `v3-ci` to enforce style (`dotnet format --verify-no-changes`), build, and test checks
- runs build/test matrix across Linux, Windows, and macOS with warnings treated as errors
- publishes per-OS test result artifacts (TRX) and keeps license compliance artifacts
- narrows `on_pull_request.yml` to Dependabot auto-merge responsibilities only
- adds CI quality gate documentation and required branch protection checks

## Validation
- `dotnet format SkyCD.V3.slnx --verify-no-changes --verbosity minimal`
- `dotnet test SkyCD.V3.slnx --configuration Release`

Closes #86