### PR TITLE
docs(ci): enforce v3-only default build path and contributor guidance (#91)

### DIFF
--- a/.github/workflows/v3-ci.yml
+++ b/.github/workflows/v3-ci.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   style:
-    name: Style (.NET format)
+    name: v3 Style (.NET format)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,7 +38,7 @@ jobs:
         run: dotnet format SkyCD.V3.slnx --verify-no-changes --verbosity minimal
 
   build-test:
-    name: Build & Test (${{ matrix.os }})
+    name: v3 Build & Test (${{ matrix.os }})
     needs: style
     strategy:
       fail-fast: false
@@ -76,7 +76,7 @@ jobs:
           path: artifacts/test-results/${{ matrix.os }}/
 
   license-compliance:
-    name: License Compliance
+    name: v3 License Compliance
     needs: style
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,18 @@
+# Contributing to SkyCD
+
+## Default Development Path
+Use the v3 stack for all new work.
+
+- Build/test entrypoint: `SkyCD.V3.slnx`
+- CI quality gates: `.github/workflows/v3-ci.yml`
+- Architecture and migration docs: `docs/architecture/`, `docs/migration/`
+
+## Do
+- Implement features and fixes in `src/`, `tests/`, `tools/`, and `Plugins/samples/` for v3.
+- Keep pull requests green against v3 CI checks.
+- Use `dotnet format SkyCD.V3.slnx --verify-no-changes` before opening PRs.
+
+## Do Not
+- Add new feature work to legacy VB.NET/WinForms code paths.
+- Add or depend on legacy solution builds in default CI workflows.
+- Use legacy build artifacts as acceptance evidence for v3 changes.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ SkyCD is a program for indexing your files in CDs and CDs also. All indexing inf
 
 License: BSD-2-Clause.
 
+## Development (v3 Default)
+New development is done in the v3 stack only.
+
+Primary entrypoints:
+- solution: `SkyCD.V3.slnx`
+- CI workflow: `.github/workflows/v3-ci.yml`
+- architecture docs: `docs/architecture/`
+
+Useful local commands:
+```powershell
+dotnet restore SkyCD.V3.slnx
+dotnet build SkyCD.V3.slnx --configuration Release
+dotnet test SkyCD.V3.slnx --configuration Release
+dotnet format SkyCD.V3.slnx --verify-no-changes
+```
+
+Legacy VB.NET/WinForms code is archived for reference/migration and is non-default for new feature work.
+
 ![](https://a.fsdn.com/con/app/proj/skycd/screenshots/94408.jpg)
 
 [![Download SkyCD](https://a.fsdn.com/con/app/sf-download-button)](https://sourceforge.net/projects/skycd/files/latest/download)

--- a/docs/ci/github-actions-quality-gates.md
+++ b/docs/ci/github-actions-quality-gates.md
@@ -1,33 +1,32 @@
 # GitHub Actions Quality Gates (v3)
 
-This document describes the CI checks required for v3 pull requests and pushes.
+This document describes the default CI checks for pull requests and pushes.
+Default CI validates only the v3 solution path (`SkyCD.V3.slnx`) and does not build legacy solutions.
 
 ## Workflows
 - `v3-ci`:
-- `style` job: `dotnet format --verify-no-changes`
-- `build-test` job: restore/build/test on `ubuntu-latest`, `windows-latest`, and `macos-latest`
-- `license-compliance` job: CycloneDX SBOM generation and policy verification
+- `style` job runs `dotnet format --verify-no-changes`.
+- `build-test` job restores/builds/tests `SkyCD.V3.slnx` on `ubuntu-latest`, `windows-latest`, and `macos-latest`.
+- `license-compliance` job generates CycloneDX SBOM and validates dependency policy.
 - `dependabot-automerge`:
-- dependabot-only metadata + approval + auto-merge workflow
+- Dependabot-only metadata, approval, and auto-merge workflow.
 
 ## Required Branch Protection Checks
-For `main`, configure branch protection to require these status checks:
-- `Style (.NET format)`
-- `Build & Test (ubuntu-latest)`
-- `Build & Test (windows-latest)`
-- `Build & Test (macos-latest)`
-- `License Compliance`
+For `main`, configure branch protection to require:
+- `v3 Style (.NET format)`
+- `v3 Build & Test (ubuntu-latest)`
+- `v3 Build & Test (windows-latest)`
+- `v3 Build & Test (macos-latest)`
+- `v3 License Compliance`
 
 ## Test Results and Artifacts
-- CI publishes per-OS test result artifacts from:
-- `artifacts/test-results/<os>/`
-- License compliance reports are published as:
-- `license-artifacts`
+- CI publishes per-OS test artifacts under `artifacts/test-results/<os>/`.
+- License compliance reports are published as `license-artifacts`.
 
 ## Runtime and Flaky-Risk Notes
-- Matrix execution increases runtime; expect slower queues during dependency or SDK updates.
+- Matrix execution increases runtime during SDK/dependency update waves.
 - Cross-platform differences (path handling, file locking, line endings) can cause intermittent failures.
-- If flaky tests are observed:
-- capture TRX artifacts from failed jobs
-- quarantine/annotate test with linked issue
-- require two consecutive green reruns before merge for suspected flakes
+- If a flaky test is suspected:
+- inspect TRX artifacts from failed jobs.
+- quarantine/annotate the test and link a tracking issue.
+- require two consecutive green reruns before merge.


### PR DESCRIPTION
## Summary
- clarifies v3-only default development path in `README.md` with concrete entrypoints/commands
- adds `CONTRIBUTING.md` guidance that new features target v3 stack only
- updates CI check naming to explicitly reference v3 in required status checks
- refreshes CI quality-gate docs to state legacy solutions are not default CI targets

## Validation
- `dotnet test SkyCD.V3.slnx --configuration Release`

Closes #91