### PR TITLE
feat(plugin-json): add schema-versioned read/write and fixture tests (#75)

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Sample.Json/JsonCatalogPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Json/JsonCatalogPlugin.cs
@@ -7,6 +7,8 @@ namespace SkyCD.Plugin.Sample.Json;
 
 public sealed class JsonCatalogPlugin : IPlugin, IFileFormatPluginCapability
 {
+    private const string SchemaVersion = "skycd.catalog.v1";
+
     public PluginDescriptor Descriptor => new(
         "skycd.plugin.sample.json",
         "Sample JSON Format Plugin",
@@ -46,12 +48,42 @@ public sealed class JsonCatalogPlugin : IPlugin, IFileFormatPluginCapability
         {
             using var reader = new StreamReader(request.Source, Encoding.UTF8, leaveOpen: true);
             var json = await reader.ReadToEndAsync(cancellationToken);
+            using var document = JsonDocument.Parse(json);
+            var root = document.RootElement;
 
-            var payload = JsonSerializer.Deserialize<Dictionary<string, object?>>(json);
+            if (!root.TryGetProperty("schemaVersion", out var schemaElement) ||
+                !schemaElement.ValueKind.Equals(JsonValueKind.String))
+            {
+                return new FileFormatReadResult
+                {
+                    Success = false,
+                    Error = "JSON catalog payload is missing required 'schemaVersion'."
+                };
+            }
+
+            var actualSchemaVersion = schemaElement.GetString();
+            if (!SchemaVersion.Equals(actualSchemaVersion, StringComparison.Ordinal))
+            {
+                return new FileFormatReadResult
+                {
+                    Success = false,
+                    Error = $"Unsupported schemaVersion '{actualSchemaVersion}'."
+                };
+            }
+
+            if (!root.TryGetProperty("payload", out var payloadElement))
+            {
+                return new FileFormatReadResult
+                {
+                    Success = false,
+                    Error = "JSON catalog payload is missing required 'payload'."
+                };
+            }
+
             return new FileFormatReadResult
             {
                 Success = true,
-                Payload = payload ?? new Dictionary<string, object?>()
+                Payload = payloadElement.Clone()
             };
         }
         catch (Exception exception)
@@ -68,7 +100,20 @@ public sealed class JsonCatalogPlugin : IPlugin, IFileFormatPluginCapability
     {
         try
         {
-            await JsonSerializer.SerializeAsync(request.Target, request.Payload, cancellationToken: cancellationToken);
+            var envelope = new Dictionary<string, object?>
+            {
+                ["schemaVersion"] = SchemaVersion,
+                ["payload"] = request.Payload
+            };
+
+            await JsonSerializer.SerializeAsync(
+                request.Target,
+                envelope,
+                new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                },
+                cancellationToken: cancellationToken);
             await request.Target.FlushAsync(cancellationToken);
 
             return new FileFormatWriteResult

--- a/tests/SkyCD.Plugin.Host.Tests/Fixtures/Json/catalog-v1.json
+++ b/tests/SkyCD.Plugin.Host.Tests/Fixtures/Json/catalog-v1.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": "skycd.catalog.v1",
+  "payload": {
+    "title": "Žalias katalogas",
+    "items": [
+      {
+        "name": "Muzika",
+        "count": 42
+      }
+    ]
+  }
+}

--- a/tests/SkyCD.Plugin.Host.Tests/JsonCatalogPluginTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/JsonCatalogPluginTests.cs
@@ -1,0 +1,99 @@
+using System.Text;
+using System.Text.Json;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+using SkyCD.Plugin.Host;
+using SkyCD.Plugin.Host.FileFormats;
+using SkyCD.Plugin.Runtime.Discovery;
+using SkyCD.Plugin.Sample.Json;
+
+namespace SkyCD.Plugin.Host.Tests;
+
+public class JsonCatalogPluginTests
+{
+    [Fact]
+    public void GetOpenAndSaveFormats_ExposesJsonPluginMetadata()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+
+        var openFormats = service.GetOpenFormats();
+        var saveFormats = service.GetSaveFormats();
+
+        Assert.Contains(openFormats, format => format.FormatId == "skycd-json" && format.Extensions.Contains(".json"));
+        Assert.Contains(saveFormats, format => format.FormatId == "skycd-json" && format.Extensions.Contains(".json"));
+    }
+
+    [Fact]
+    public async Task WriteAndReadAsync_RoundTripsFixturePayload_WithSchemaEnvelope()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+        var fixturePath = Path.Combine(AppContext.BaseDirectory, "Fixtures", "Json", "catalog-v1.json");
+
+        await using var fixtureStream = File.OpenRead(fixturePath);
+        var fixtureRead = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-json",
+            Source = fixtureStream
+        });
+
+        Assert.True(fixtureRead.Success);
+
+        await using var writeStream = new MemoryStream();
+        var readPayload = Assert.IsType<JsonElement>(fixtureRead.Payload);
+        var writeResult = await service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "skycd-json",
+            Target = writeStream,
+            Payload = readPayload
+        });
+
+        Assert.True(writeResult.Success);
+
+        var writtenText = Encoding.UTF8.GetString(writeStream.ToArray());
+        Assert.Contains("\"schemaVersion\":\"skycd.catalog.v1\"", writtenText);
+        using var writtenDocument = JsonDocument.Parse(writtenText);
+        var writtenPayload = writtenDocument.RootElement.GetProperty("payload");
+        Assert.Equal("Žalias katalogas", writtenPayload.GetProperty("title").GetString());
+
+        writeStream.Position = 0;
+        var roundTrip = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-json",
+            Source = writeStream
+        });
+
+        Assert.True(roundTrip.Success);
+        var payload = Assert.IsType<JsonElement>(roundTrip.Payload);
+        Assert.Equal("Žalias katalogas", payload.GetProperty("title").GetString());
+    }
+
+    [Fact]
+    public async Task ReadAsync_ReturnsFailure_WhenSchemaVersionMissingOrUnknown()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+        await using var stream = new MemoryStream(Encoding.UTF8.GetBytes("{\"payload\":{\"title\":\"x\"}}"));
+
+        var exception = await Assert.ThrowsAsync<FileFormatRoutingException>(() => service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-json",
+            Source = stream
+        }));
+
+        Assert.Contains("schemaVersion", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static PluginCatalog CreateCatalog()
+    {
+        var capability = new JsonCatalogPlugin();
+        var catalog = new PluginCatalog();
+        catalog.SetPlugins(
+        [
+            new DiscoveredPlugin
+            {
+                Plugin = capability,
+                Capabilities = [capability]
+            }
+        ]);
+        return catalog;
+    }
+}

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -21,6 +21,13 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Host\SkyCD.Plugin.Host.csproj" />
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Json\SkyCD.Plugin.Sample.Json.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Fixtures\Json\catalog-v1.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- update SkyCD.Plugin.Sample.Json to use a plugin-owned JSON envelope with stable schemaVersion marker (skycd.catalog.v1)
- enforce schema validation on read and return plugin errors for unsupported/missing schema
- keep UTF-8 serialization/deserialization and include non-ASCII fixture data coverage
- add host-level routing tests proving .json format is exposed for open/save and round-trip works through plugin routing

## Changed files
- Plugins/samples/SkyCD.Plugin.Sample.Json/JsonCatalogPlugin.cs
- 	ests/SkyCD.Plugin.Host.Tests/JsonCatalogPluginTests.cs
- 	ests/SkyCD.Plugin.Host.Tests/Fixtures/Json/catalog-v1.json
- 	ests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj

## Validation
- dotnet test tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj (Passed: 7)

## Known limitations
- schema compatibility currently supports one schema version (skycd.catalog.v1) without migration adapters.

Closes #75