### PR TITLE
feat(plugin-csv): add csv read/write plugin and hierarchy parity tests (#76)

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Sample.Csv/CsvCatalogPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Csv/CsvCatalogPlugin.cs
@@ -1,0 +1,208 @@
+using System.Text;
+using System.Text.Json;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Sample.Csv;
+
+public sealed class CsvCatalogPlugin : IPlugin, IFileFormatPluginCapability
+{
+    private static readonly string[] HeaderColumns = ["NodeId", "ParentId", "Kind", "Name", "SizeBytes"];
+
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.sample.csv",
+        "Sample CSV Format Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Example plugin that exposes CSV file format support.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor(
+            "skycd-csv",
+            "SkyCD CSV",
+            [".csv"],
+            CanRead: true,
+            CanWrite: true,
+            MimeType: "text/csv")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public async Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var reader = new StreamReader(request.Source, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
+            var headerLine = await reader.ReadLineAsync(cancellationToken);
+            if (string.IsNullOrWhiteSpace(headerLine))
+            {
+                return new FileFormatReadResult { Success = true, Payload = new List<Dictionary<string, object?>>() };
+            }
+
+            var actualHeader = ParseCsvLine(headerLine);
+            if (!HeaderColumns.SequenceEqual(actualHeader, StringComparer.OrdinalIgnoreCase))
+            {
+                return new FileFormatReadResult
+                {
+                    Success = false,
+                    Error = "CSV header must match: NodeId,ParentId,Kind,Name,SizeBytes."
+                };
+            }
+
+            var rows = new List<Dictionary<string, object?>>();
+            string? line;
+            while ((line = await reader.ReadLineAsync(cancellationToken)) is not null)
+            {
+                if (line.Length == 0)
+                {
+                    continue;
+                }
+
+                var fields = ParseCsvLine(line);
+                if (fields.Count != HeaderColumns.Length)
+                {
+                    return new FileFormatReadResult
+                    {
+                        Success = false,
+                        Error = $"CSV row has {fields.Count} fields, expected {HeaderColumns.Length}."
+                    };
+                }
+
+                rows.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["NodeId"] = fields[0],
+                    ["ParentId"] = fields[1],
+                    ["Kind"] = fields[2],
+                    ["Name"] = fields[3],
+                    ["SizeBytes"] = fields[4]
+                });
+            }
+
+            return new FileFormatReadResult
+            {
+                Success = true,
+                Payload = rows
+            };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatReadResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var rows = ResolveRows(request.Payload);
+            using var writer = new StreamWriter(request.Target, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), leaveOpen: true);
+            await writer.WriteLineAsync(string.Join(",", HeaderColumns));
+
+            foreach (var row in rows)
+            {
+                var values = HeaderColumns
+                    .Select(column => EscapeCsv(row.TryGetValue(column, out var value) ? value?.ToString() : null));
+                await writer.WriteLineAsync(string.Join(",", values));
+            }
+
+            await writer.FlushAsync(cancellationToken);
+            return new FileFormatWriteResult { Success = true };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatWriteResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    private static List<Dictionary<string, object?>> ResolveRows(object? payload)
+    {
+        if (payload is List<Dictionary<string, object?>> rows)
+        {
+            return rows;
+        }
+
+        if (payload is JsonElement { ValueKind: JsonValueKind.Array } arrayElement)
+        {
+            return arrayElement.EnumerateArray()
+                .Select(element => new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["NodeId"] = ReadJsonValue(element, "nodeId"),
+                    ["ParentId"] = ReadJsonValue(element, "parentId"),
+                    ["Kind"] = ReadJsonValue(element, "kind"),
+                    ["Name"] = ReadJsonValue(element, "name"),
+                    ["SizeBytes"] = ReadJsonValue(element, "sizeBytes")
+                })
+                .ToList();
+        }
+
+        throw new InvalidOperationException("CSV payload must be a row list or JSON array.");
+    }
+
+    private static string? ReadJsonValue(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var property)
+            ? property.ToString()
+            : null;
+    }
+
+    private static string EscapeCsv(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        var escaped = value.Replace("\"", "\"\"");
+        return escaped.Contains(',') || escaped.Contains('"') || escaped.Contains('\n') || escaped.Contains('\r')
+            ? $"\"{escaped}\""
+            : escaped;
+    }
+
+    private static List<string> ParseCsvLine(string line)
+    {
+        var result = new List<string>();
+        var buffer = new StringBuilder();
+        var inQuotes = false;
+
+        for (var index = 0; index < line.Length; index++)
+        {
+            var current = line[index];
+            if (current == '"')
+            {
+                if (inQuotes && index + 1 < line.Length && line[index + 1] == '"')
+                {
+                    buffer.Append('"');
+                    index++;
+                }
+                else
+                {
+                    inQuotes = !inQuotes;
+                }
+            }
+            else if (current == ',' && !inQuotes)
+            {
+                result.Add(buffer.ToString());
+                buffer.Clear();
+            }
+            else
+            {
+                buffer.Append(current);
+            }
+        }
+
+        result.Add(buffer.ToString());
+        return result;
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Sample.Csv/SkyCD.Plugin.Sample.Csv.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Csv/SkyCD.Plugin.Sample.Csv.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Sample.Csv/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Csv/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.sample.csv",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Sample.Csv.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -4,6 +4,7 @@
     <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Ascd/SkyCD.Plugin.Legacy.Ascd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Cscd/SkyCD.Plugin.Legacy.Cscd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Scd/SkyCD.Plugin.Legacy.Scd.csproj" />
+    <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Csv/SkyCD.Plugin.Sample.Csv.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Zip/SkyCD.Plugin.Sample.Zip.csproj" />

--- a/tests/SkyCD.Plugin.Host.Tests/CsvCatalogPluginTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/CsvCatalogPluginTests.cs
@@ -1,0 +1,112 @@
+using System.Text;
+using System.Text.Json;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Host;
+using SkyCD.Plugin.Host.FileFormats;
+using SkyCD.Plugin.Runtime.Discovery;
+using SkyCD.Plugin.Sample.Csv;
+
+namespace SkyCD.Plugin.Host.Tests;
+
+public class CsvCatalogPluginTests
+{
+    [Fact]
+    public void GetOpenAndSaveFormats_ExposesCsvPluginMetadata()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+
+        var openFormats = service.GetOpenFormats();
+        var saveFormats = service.GetSaveFormats();
+
+        Assert.Contains(openFormats, format => format.FormatId == "skycd-csv" && format.Extensions.Contains(".csv"));
+        Assert.Contains(saveFormats, format => format.FormatId == "skycd-csv" && format.Extensions.Contains(".csv"));
+    }
+
+    [Fact]
+    public async Task ReadAndWriteAsync_PreservesHierarchyAndSizeFields()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+        var fixturePath = Path.Combine(AppContext.BaseDirectory, "Fixtures", "Csv", "catalog-hierarchy.csv");
+
+        await using var source = File.OpenRead(fixturePath);
+        var readResult = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-csv",
+            Source = source
+        });
+
+        Assert.True(readResult.Success);
+
+        var rows = Assert.IsType<List<Dictionary<string, object?>>>(readResult.Payload);
+        Assert.Equal(3, rows.Count);
+        Assert.Equal("folder", rows[0]["Kind"]);
+        Assert.Equal("2", rows[2]["ParentId"]);
+        Assert.Equal("12345", rows[2]["SizeBytes"]);
+
+        await using var target = new MemoryStream();
+        var writeResult = await service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "skycd-csv",
+            Target = target,
+            Payload = rows
+        });
+
+        Assert.True(writeResult.Success);
+        var written = Encoding.UTF8.GetString(target.ToArray());
+        Assert.Contains("NodeId,ParentId,Kind,Name,SizeBytes", written);
+        Assert.Contains("\"Music, Archive\"", written);
+        Assert.Contains("\"Track \"\"A\"\".mp3\"", written);
+
+        target.Position = 0;
+        var roundTripRead = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-csv",
+            Source = target
+        });
+
+        Assert.True(roundTripRead.Success);
+        var roundTripRows = Assert.IsType<List<Dictionary<string, object?>>>(roundTripRead.Payload);
+        Assert.Equal("Track \"A\".mp3", roundTripRows[2]["Name"]);
+    }
+
+    [Fact]
+    public async Task WriteAsync_AcceptsJsonArrayPayload()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+        var payload = JsonSerializer.Deserialize<JsonElement>(
+            """
+            [
+              { "nodeId":"10", "parentId":"", "kind":"folder", "name":"Docs", "sizeBytes":"0" },
+              { "nodeId":"11", "parentId":"10", "kind":"file", "name":"readme.txt", "sizeBytes":"15" }
+            ]
+            """);
+
+        await using var target = new MemoryStream();
+        var result = await service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "skycd-csv",
+            Target = target,
+            Payload = payload
+        });
+
+        Assert.True(result.Success);
+        var text = Encoding.UTF8.GetString(target.ToArray());
+        Assert.Contains("10,,folder,Docs,0", text);
+        Assert.Contains("11,10,file,readme.txt,15", text);
+    }
+
+    private static PluginCatalog CreateCatalog()
+    {
+        var plugin = new CsvCatalogPlugin();
+        var catalog = new PluginCatalog();
+        catalog.SetPlugins(
+        [
+            new DiscoveredPlugin
+            {
+                Plugin = plugin,
+                Capabilities = [plugin]
+            }
+        ]);
+        return catalog;
+    }
+}

--- a/tests/SkyCD.Plugin.Host.Tests/Fixtures/Csv/catalog-hierarchy.csv
+++ b/tests/SkyCD.Plugin.Host.Tests/Fixtures/Csv/catalog-hierarchy.csv
@@ -1,0 +1,4 @@
+NodeId,ParentId,Kind,Name,SizeBytes
+1,,folder,Root,0
+2,1,folder,"Music, Archive",0
+3,2,file,"Track ""A"".mp3",12345

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -22,10 +22,14 @@
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Host\SkyCD.Plugin.Host.csproj" />
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Json\SkyCD.Plugin.Sample.Json.csproj" />
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Csv\SkyCD.Plugin.Sample.Csv.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Zip\SkyCD.Plugin.Sample.Zip.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Fixtures\Csv\catalog-hierarchy.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Fixtures\Json\catalog-v1.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Summary
- add new sample CSV file-format plugin (SkyCD.Plugin.Sample.Csv) with CanRead=true and CanWrite=true
- implement header-based column mapping with explicit hierarchy columns (NodeId, ParentId, Kind, Name, SizeBytes)
- implement deterministic CSV escaping/quoting for commas, quotes, and line breaks
- add host routing tests and fixture-based parity tests that verify hierarchy and size field round-trip

## Changed files
- Plugins/samples/SkyCD.Plugin.Sample.Csv/*
- 	ests/SkyCD.Plugin.Host.Tests/CsvCatalogPluginTests.cs
- 	ests/SkyCD.Plugin.Host.Tests/Fixtures/Csv/catalog-hierarchy.csv
- 	ests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
- SkyCD.V3.slnx

## Validation
- dotnet test tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj (Passed: 7)

## Known limitations
- CSV payload contract currently uses row dictionaries/JSON-array rows rather than full v3 domain entities.

Closes #76