### PR TITLE
feat(plugin-xml): add xml read/write plugin with xxe-hardening tests (#77)

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Sample.Xml/SkyCD.Plugin.Sample.Xml.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Xml/SkyCD.Plugin.Sample.Xml.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Sample.Xml/XmlCatalogPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Xml/XmlCatalogPlugin.cs
@@ -1,0 +1,170 @@
+using System.Globalization;
+using System.Text;
+using System.Xml;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Sample.Xml;
+
+public sealed class XmlCatalogPlugin : IPlugin, IFileFormatPluginCapability
+{
+    private const string NamespaceUri = "urn:skycd:catalog";
+    private const string SchemaVersion = "1.0";
+
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.sample.xml",
+        "Sample XML Format Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Example plugin that exposes XML file format support.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor(
+            "skycd-xml",
+            "SkyCD XML",
+            [".xml"],
+            CanRead: true,
+            CanWrite: true,
+            MimeType: "application/xml")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var settings = new XmlReaderSettings
+            {
+                DtdProcessing = DtdProcessing.Prohibit,
+                XmlResolver = null
+            };
+
+            using var reader = XmlReader.Create(request.Source, settings);
+            var document = new XmlDocument
+            {
+                XmlResolver = null
+            };
+            document.Load(reader);
+
+            var root = document.DocumentElement;
+            if (root is null || root.LocalName != "catalog" || root.NamespaceURI != NamespaceUri)
+            {
+                return Task.FromResult(new FileFormatReadResult
+                {
+                    Success = false,
+                    Error = "Invalid XML root element. Expected skycd:catalog."
+                });
+            }
+
+            var version = root.GetAttribute("schemaVersion");
+            if (!version.Equals(SchemaVersion, StringComparison.Ordinal))
+            {
+                return Task.FromResult(new FileFormatReadResult
+                {
+                    Success = false,
+                    Error = $"Unsupported schema version '{version}'."
+                });
+            }
+
+            var rows = new List<Dictionary<string, object?>>();
+            foreach (XmlElement nodeElement in root.GetElementsByTagName("node", NamespaceUri))
+            {
+                rows.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["NodeId"] = nodeElement.GetAttribute("nodeId"),
+                    ["ParentId"] = nodeElement.GetAttribute("parentId"),
+                    ["Kind"] = nodeElement.GetAttribute("kind"),
+                    ["Name"] = nodeElement.GetAttribute("name"),
+                    ["SizeBytes"] = nodeElement.GetAttribute("sizeBytes")
+                });
+            }
+
+            return Task.FromResult(new FileFormatReadResult
+            {
+                Success = true,
+                Payload = rows
+            });
+        }
+        catch (Exception exception)
+        {
+            return Task.FromResult(new FileFormatReadResult
+            {
+                Success = false,
+                Error = exception.Message
+            });
+        }
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var rows = ResolveRows(request.Payload)
+                .OrderBy(row => ParseSortKey(row, "NodeId"))
+                .ThenBy(row => GetValue(row, "Name"), StringComparer.Ordinal)
+                .ToList();
+
+            var settings = new XmlWriterSettings
+            {
+                Encoding = new UTF8Encoding(false),
+                Indent = true,
+                Async = true
+            };
+
+            await using var writer = XmlWriter.Create(request.Target, settings);
+            await writer.WriteStartDocumentAsync();
+            await writer.WriteStartElementAsync("skycd", "catalog", NamespaceUri);
+            await writer.WriteAttributeStringAsync(null, "schemaVersion", null, SchemaVersion);
+
+            foreach (var row in rows)
+            {
+                await writer.WriteStartElementAsync("skycd", "node", NamespaceUri);
+                await writer.WriteAttributeStringAsync(null, "nodeId", null, GetValue(row, "NodeId"));
+                await writer.WriteAttributeStringAsync(null, "parentId", null, GetValue(row, "ParentId"));
+                await writer.WriteAttributeStringAsync(null, "kind", null, GetValue(row, "Kind"));
+                await writer.WriteAttributeStringAsync(null, "name", null, GetValue(row, "Name"));
+                await writer.WriteAttributeStringAsync(null, "sizeBytes", null, GetValue(row, "SizeBytes"));
+                await writer.WriteEndElementAsync();
+            }
+
+            await writer.WriteEndElementAsync();
+            await writer.WriteEndDocumentAsync();
+            await writer.FlushAsync();
+            return new FileFormatWriteResult { Success = true };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatWriteResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    private static List<Dictionary<string, object?>> ResolveRows(object? payload)
+    {
+        return payload as List<Dictionary<string, object?>>
+               ?? throw new InvalidOperationException("XML payload must be a list of row dictionaries.");
+    }
+
+    private static string GetValue(IReadOnlyDictionary<string, object?> row, string key)
+    {
+        return row.TryGetValue(key, out var value)
+            ? Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty
+            : string.Empty;
+    }
+
+    private static long ParseSortKey(IReadOnlyDictionary<string, object?> row, string key)
+    {
+        var value = GetValue(row, key);
+        return long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : long.MaxValue;
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Sample.Xml/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Xml/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.sample.xml",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Sample.Xml.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -8,6 +8,7 @@
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Zip/SkyCD.Plugin.Sample.Zip.csproj" />
+    <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Xml/SkyCD.Plugin.Sample.Xml.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/SkyCD.App/SkyCD.App.csproj" />

--- a/tests/SkyCD.Plugin.Host.Tests/Fixtures/Xml/catalog-v1.xml
+++ b/tests/SkyCD.Plugin.Host.Tests/Fixtures/Xml/catalog-v1.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<skycd:catalog xmlns:skycd="urn:skycd:catalog" schemaVersion="1.0">
+  <skycd:node nodeId="1" parentId="" kind="folder" name="Root" sizeBytes="0" />
+  <skycd:node nodeId="2" parentId="1" kind="folder" name="Music" sizeBytes="0" />
+  <skycd:node nodeId="3" parentId="2" kind="file" name="Track A.mp3" sizeBytes="12345" />
+</skycd:catalog>

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -25,8 +25,6 @@
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Csv\SkyCD.Plugin.Sample.Csv.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Xml\SkyCD.Plugin.Sample.Xml.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Iso\SkyCD.Plugin.Sample.Iso.csproj" />
-    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Modal\SkyCD.Plugin.Sample.Modal.csproj" />
-    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Yaml\SkyCD.Plugin.Sample.Yaml.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Zip\SkyCD.Plugin.Sample.Zip.csproj" />
   </ItemGroup>
 

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -23,11 +23,13 @@
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Json\SkyCD.Plugin.Sample.Json.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Csv\SkyCD.Plugin.Sample.Csv.csproj" />
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Xml\SkyCD.Plugin.Sample.Xml.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Zip\SkyCD.Plugin.Sample.Zip.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <None Update="Fixtures\Csv\catalog-hierarchy.csv">
+    <None Update="Fixtures\Xml\catalog-v1.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Fixtures\Json\catalog-v1.json">

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -29,6 +29,8 @@
 
   <ItemGroup>
     <None Update="Fixtures\Csv\catalog-hierarchy.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Fixtures\Xml\catalog-v1.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/SkyCD.Plugin.Host.Tests/XmlCatalogPluginTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/XmlCatalogPluginTests.cs
@@ -1,0 +1,97 @@
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Host;
+using SkyCD.Plugin.Host.FileFormats;
+using SkyCD.Plugin.Runtime.Discovery;
+using SkyCD.Plugin.Sample.Xml;
+
+namespace SkyCD.Plugin.Host.Tests;
+
+public class XmlCatalogPluginTests
+{
+    [Fact]
+    public void GetOpenAndSaveFormats_ExposesXmlPluginMetadata()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+
+        var openFormats = service.GetOpenFormats();
+        var saveFormats = service.GetSaveFormats();
+
+        Assert.Contains(openFormats, format => format.FormatId == "skycd-xml" && format.Extensions.Contains(".xml"));
+        Assert.Contains(saveFormats, format => format.FormatId == "skycd-xml" && format.Extensions.Contains(".xml"));
+    }
+
+    [Fact]
+    public async Task ReadAndWriteAsync_RoundTripsFixturePayload_WithStableOrdering()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+        var fixturePath = Path.Combine(AppContext.BaseDirectory, "Fixtures", "Xml", "catalog-v1.xml");
+
+        await using var source = File.OpenRead(fixturePath);
+        var readResult = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-xml",
+            Source = source
+        });
+
+        Assert.True(readResult.Success);
+        var rows = Assert.IsType<List<Dictionary<string, object?>>>(readResult.Payload);
+        Assert.Equal(3, rows.Count);
+
+        await using var target = new MemoryStream();
+        var writeResult = await service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "skycd-xml",
+            Target = target,
+            Payload = rows
+        });
+
+        Assert.True(writeResult.Success);
+        var xmlText = Encoding.UTF8.GetString(target.ToArray());
+        Assert.Contains("xmlns:skycd=\"urn:skycd:catalog\"", xmlText);
+        Assert.Contains("schemaVersion=\"1.0\"", xmlText);
+
+        var rootIndex = xmlText.IndexOf("nodeId=\"1\"", StringComparison.Ordinal);
+        var childIndex = xmlText.IndexOf("nodeId=\"2\"", StringComparison.Ordinal);
+        var fileIndex = xmlText.IndexOf("nodeId=\"3\"", StringComparison.Ordinal);
+
+        Assert.True(rootIndex < childIndex && childIndex < fileIndex);
+    }
+
+    [Fact]
+    public async Task ReadAsync_RejectsXxePayloads()
+    {
+        const string xxePayload = """
+                                  <?xml version="1.0"?>
+                                  <!DOCTYPE foo [ <!ENTITY xxe SYSTEM "file:///etc/passwd"> ]>
+                                  <skycd:catalog xmlns:skycd="urn:skycd:catalog" schemaVersion="1.0">
+                                    <skycd:node nodeId="1" parentId="" kind="file" name="&xxe;" sizeBytes="1" />
+                                  </skycd:catalog>
+                                  """;
+        var service = new FileFormatRoutingService(CreateCatalog());
+        await using var source = new MemoryStream(Encoding.UTF8.GetBytes(xxePayload));
+
+        var exception = await Assert.ThrowsAsync<FileFormatRoutingException>(() => service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-xml",
+            Source = source
+        }));
+
+        Assert.Contains("DTD", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static PluginCatalog CreateCatalog()
+    {
+        var plugin = new XmlCatalogPlugin();
+        var catalog = new PluginCatalog();
+        catalog.SetPlugins(
+        [
+            new DiscoveredPlugin
+            {
+                Plugin = plugin,
+                Capabilities = [plugin]
+            }
+        ]);
+        return catalog;
+    }
+}


### PR DESCRIPTION
Adds SkyCD.Plugin.Sample.Xml with namespaced schema-versioned XML read/write support, secure parser settings (DTD prohibited), deterministic node ordering, and host routing tests including fixture round-trip and XXE hardening checks. Closes #77