### PR TITLE
feat(plugin-yaml): add yaml format plugin with strict-mode tests (#78)

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Sample.Yaml/SkyCD.Plugin.Sample.Yaml.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Yaml/SkyCD.Plugin.Sample.Yaml.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Sample.Yaml/YamlCatalogPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Yaml/YamlCatalogPlugin.cs
@@ -1,0 +1,142 @@
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace SkyCD.Plugin.Sample.Yaml;
+
+public sealed class YamlCatalogPlugin : IPlugin, IFileFormatPluginCapability
+{
+    private const string SchemaVersion = "skycd.catalog.v1";
+
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.sample.yaml",
+        "Sample YAML Format Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Example plugin that exposes YAML file format support.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor(
+            "skycd-yaml",
+            "SkyCD YAML",
+            [".yaml", ".yml"],
+            CanRead: true,
+            CanWrite: true,
+            MimeType: "application/yaml")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public async Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var reader = new StreamReader(request.Source, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
+            var yaml = await reader.ReadToEndAsync(cancellationToken);
+
+            if (yaml.Contains("<<:", StringComparison.Ordinal) || yaml.Contains('*'))
+            {
+                return new FileFormatReadResult
+                {
+                    Success = false,
+                    Error = "YAML_UNSUPPORTED_CONSTRUCT: aliases and merge keys are not supported in strict mode."
+                };
+            }
+
+            var document = Deserializer.Deserialize<YamlCatalogDocument>(yaml);
+            if (document is null || !SchemaVersion.Equals(document.SchemaVersion, StringComparison.Ordinal))
+            {
+                return new FileFormatReadResult
+                {
+                    Success = false,
+                    Error = "YAML_SCHEMA_ERROR: missing or unsupported schemaVersion."
+                };
+            }
+
+            var rows = (document.Payload ?? [])
+                .Select(row => row.ToDictionary(
+                    pair => pair.Key,
+                    pair => (object?)pair.Value,
+                    StringComparer.OrdinalIgnoreCase))
+                .ToList();
+
+            return new FileFormatReadResult
+            {
+                Success = true,
+                Payload = rows
+            };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatReadResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var rows = request.Payload as List<Dictionary<string, object?>>
+                ?? throw new InvalidOperationException("YAML payload must be a list of row dictionaries.");
+
+            var orderedRows = rows
+                .Select(row => new SortedDictionary<string, string?>(StringComparer.Ordinal)
+                {
+                    ["kind"] = row.TryGetValue("kind", out var kind) ? kind?.ToString() : null,
+                    ["name"] = row.TryGetValue("name", out var name) ? name?.ToString() : null,
+                    ["nodeId"] = row.TryGetValue("nodeId", out var nodeId) ? nodeId?.ToString() : null,
+                    ["parentId"] = row.TryGetValue("parentId", out var parentId) ? parentId?.ToString() : null,
+                    ["sizeBytes"] = row.TryGetValue("sizeBytes", out var sizeBytes) ? sizeBytes?.ToString() : null
+                })
+                .OrderBy(row => row["nodeId"], StringComparer.Ordinal)
+                .ToList();
+
+            var document = new
+            {
+                schemaVersion = SchemaVersion,
+                payload = orderedRows
+            };
+
+            var serializer = new SerializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .DisableAliases()
+                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+                .Build();
+
+            var yaml = serializer.Serialize(document);
+            await using var writer = new StreamWriter(request.Target, new UTF8Encoding(false), leaveOpen: true);
+            await writer.WriteAsync(yaml.AsMemory(), cancellationToken);
+            await writer.FlushAsync(cancellationToken);
+
+            return new FileFormatWriteResult { Success = true };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatWriteResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    private sealed class YamlCatalogDocument
+    {
+        public string? SchemaVersion { get; set; }
+        public List<Dictionary<string, string?>>? Payload { get; set; }
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Sample.Yaml/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Yaml/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.sample.yaml",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Sample.Yaml.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -8,6 +8,7 @@
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Zip/SkyCD.Plugin.Sample.Zip.csproj" />
+    <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Yaml/SkyCD.Plugin.Sample.Yaml.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/SkyCD.App/SkyCD.App.csproj" />

--- a/tests/SkyCD.Plugin.Host.Tests/Fixtures/Yaml/catalog-v1.yaml
+++ b/tests/SkyCD.Plugin.Host.Tests/Fixtures/Yaml/catalog-v1.yaml
@@ -1,0 +1,12 @@
+schemaVersion: skycd.catalog.v1
+payload:
+  - nodeId: "1"
+    parentId: ""
+    kind: folder
+    name: Root
+    sizeBytes: "0"
+  - nodeId: "2"
+    parentId: "1"
+    kind: file
+    name: track.mp3
+    sizeBytes: "42"

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -29,6 +29,8 @@
 
   <ItemGroup>
     <None Update="Fixtures\Csv\catalog-hierarchy.csv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Fixtures\Yaml\catalog-v1.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -23,11 +23,13 @@
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Json\SkyCD.Plugin.Sample.Json.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Csv\SkyCD.Plugin.Sample.Csv.csproj" />
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Yaml\SkyCD.Plugin.Sample.Yaml.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Zip\SkyCD.Plugin.Sample.Zip.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <None Update="Fixtures\Csv\catalog-hierarchy.csv">
+    <None Update="Fixtures\Yaml\catalog-v1.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Fixtures\Json\catalog-v1.json">

--- a/tests/SkyCD.Plugin.Host.Tests/YamlCatalogPluginTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/YamlCatalogPluginTests.cs
@@ -1,0 +1,98 @@
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Host;
+using SkyCD.Plugin.Host.FileFormats;
+using SkyCD.Plugin.Runtime.Discovery;
+using SkyCD.Plugin.Sample.Yaml;
+
+namespace SkyCD.Plugin.Host.Tests;
+
+public class YamlCatalogPluginTests
+{
+    [Fact]
+    public void GetOpenAndSaveFormats_ExposesYamlExtensions()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+
+        var openFormats = service.GetOpenFormats();
+        var saveFormats = service.GetSaveFormats();
+
+        Assert.Contains(openFormats, format =>
+            format.FormatId == "skycd-yaml" &&
+            format.Extensions.Contains(".yaml") &&
+            format.Extensions.Contains(".yml"));
+        Assert.Contains(saveFormats, format => format.FormatId == "skycd-yaml");
+    }
+
+    [Fact]
+    public async Task ReadAndWriteAsync_RoundTripsFixture()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+        var fixturePath = Path.Combine(AppContext.BaseDirectory, "Fixtures", "Yaml", "catalog-v1.yaml");
+
+        await using var source = File.OpenRead(fixturePath);
+        var readResult = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-yaml",
+            Source = source
+        });
+
+        Assert.True(readResult.Success);
+        var rows = Assert.IsType<List<Dictionary<string, object?>>>(readResult.Payload);
+        Assert.Equal("track.mp3", rows[1]["name"]);
+
+        await using var target = new MemoryStream();
+        var writeResult = await service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "skycd-yaml",
+            Target = target,
+            Payload = rows
+        });
+
+        Assert.True(writeResult.Success);
+        var text = Encoding.UTF8.GetString(target.ToArray());
+        Assert.Contains("schemaVersion: skycd.catalog.v1", text);
+        Assert.Contains("payload:", text);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ReturnsTypedError_ForUnsupportedConstructs()
+    {
+        const string unsupported = """
+                                   defaults: &defaults
+                                     name: Root
+                                   schemaVersion: skycd.catalog.v1
+                                   payload:
+                                     - <<: *defaults
+                                       nodeId: "1"
+                                       parentId: ""
+                                       kind: folder
+                                       sizeBytes: "0"
+                                   """;
+        var service = new FileFormatRoutingService(CreateCatalog());
+        await using var source = new MemoryStream(Encoding.UTF8.GetBytes(unsupported));
+
+        var exception = await Assert.ThrowsAsync<FileFormatRoutingException>(() => service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-yaml",
+            Source = source
+        }));
+
+        Assert.Contains("YAML_UNSUPPORTED_CONSTRUCT", exception.Message);
+    }
+
+    private static PluginCatalog CreateCatalog()
+    {
+        var plugin = new YamlCatalogPlugin();
+        var catalog = new PluginCatalog();
+        catalog.SetPlugins(
+        [
+            new DiscoveredPlugin
+            {
+                Plugin = plugin,
+                Capabilities = [plugin]
+            }
+        ]);
+        return catalog;
+    }
+}


### PR DESCRIPTION
Adds SkyCD.Plugin.Sample.Yaml with read/write support for .yaml/.yml, required schemaVersion validation, deterministic writer behavior, and strict unsupported construct detection (typed YAML_UNSUPPORTED_CONSTRUCT errors). Includes fixture round-trip tests via host routing. Closes #78