### PR TITLE
feat(plugin-toml): add toml format plugin with schema/hierarchy support (#79)

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Sample.Toml/SkyCD.Plugin.Sample.Toml.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Toml/SkyCD.Plugin.Sample.Toml.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Tomlyn" Version="0.20.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Sample.Toml/TomlCatalogPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Toml/TomlCatalogPlugin.cs
@@ -1,0 +1,139 @@
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+using Tomlyn;
+using Tomlyn.Model;
+
+namespace SkyCD.Plugin.Sample.Toml;
+
+public sealed class TomlCatalogPlugin : IPlugin, IFileFormatPluginCapability
+{
+    private const string SchemaVersion = "skycd.catalog.v1";
+    private const string HierarchyStrategy = "adjacency-list";
+
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.sample.toml",
+        "Sample TOML Format Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Example plugin that exposes TOML file format support.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor(
+            "skycd-toml",
+            "SkyCD TOML",
+            [".toml"],
+            CanRead: true,
+            CanWrite: true,
+            MimeType: "application/toml")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public async Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var reader = new StreamReader(request.Source, Encoding.UTF8, detectEncodingFromByteOrderMarks: true, leaveOpen: true);
+            var text = await reader.ReadToEndAsync(cancellationToken);
+            var model = Tomlyn.Toml.ToModel(text) as TomlTable;
+            if (model is null)
+            {
+                return new FileFormatReadResult { Success = false, Error = "Invalid TOML document." };
+            }
+
+            if (model["schema"] is not TomlTable schema ||
+                schema["version"]?.ToString() is not { } version ||
+                !SchemaVersion.Equals(version, StringComparison.Ordinal))
+            {
+                return new FileFormatReadResult
+                {
+                    Success = false,
+                    Error = "TOML_SCHEMA_ERROR: missing or unsupported schema.version."
+                };
+            }
+
+            if (model["nodes"] is not TomlTableArray nodes)
+            {
+                return new FileFormatReadResult { Success = true, Payload = new List<Dictionary<string, object?>>() };
+            }
+
+            var rows = nodes
+                .Select(node => new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["nodeId"] = node["nodeId"]?.ToString(),
+                    ["parentId"] = node["parentId"]?.ToString(),
+                    ["kind"] = node["kind"]?.ToString(),
+                    ["name"] = node["name"]?.ToString(),
+                    ["sizeBytes"] = node["sizeBytes"]?.ToString()
+                })
+                .ToList();
+
+            return new FileFormatReadResult
+            {
+                Success = true,
+                Payload = rows
+            };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatReadResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var rows = request.Payload as List<Dictionary<string, object?>>
+                ?? throw new InvalidOperationException("TOML payload must be a list of row dictionaries.");
+
+            var table = new TomlTable
+            {
+                ["schema"] = new TomlTable
+                {
+                    ["version"] = SchemaVersion,
+                    ["hierarchy"] = HierarchyStrategy
+                }
+            };
+
+            var array = new TomlTableArray();
+            foreach (var row in rows.OrderBy(row => row.TryGetValue("nodeId", out var id) ? id?.ToString() : null, StringComparer.Ordinal))
+            {
+                array.Add(new TomlTable
+                {
+                    ["nodeId"] = row.TryGetValue("nodeId", out var nodeId) ? nodeId?.ToString() ?? string.Empty : string.Empty,
+                    ["parentId"] = row.TryGetValue("parentId", out var parentId) ? parentId?.ToString() ?? string.Empty : string.Empty,
+                    ["kind"] = row.TryGetValue("kind", out var kind) ? kind?.ToString() ?? string.Empty : string.Empty,
+                    ["name"] = row.TryGetValue("name", out var name) ? name?.ToString() ?? string.Empty : string.Empty,
+                    ["sizeBytes"] = row.TryGetValue("sizeBytes", out var sizeBytes) ? sizeBytes?.ToString() ?? string.Empty : string.Empty
+                });
+            }
+
+            table["nodes"] = array;
+
+            var text = Tomlyn.Toml.FromModel(table);
+            await using var writer = new StreamWriter(request.Target, new UTF8Encoding(false), leaveOpen: true);
+            await writer.WriteAsync(text.AsMemory(), cancellationToken);
+            await writer.FlushAsync(cancellationToken);
+
+            return new FileFormatWriteResult { Success = true };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatWriteResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Sample.Toml/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Toml/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.sample.toml",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Sample.Toml.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -8,6 +8,7 @@
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Zip/SkyCD.Plugin.Sample.Zip.csproj" />
+    <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Toml/SkyCD.Plugin.Sample.Toml.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/SkyCD.App/SkyCD.App.csproj" />

--- a/docs/plugins/toml-hierarchy-mapping.md
+++ b/docs/plugins/toml-hierarchy-mapping.md
@@ -1,0 +1,14 @@
+# TOML Hierarchy Mapping (v1)
+
+The TOML plugin (`skycd.plugin.sample.toml`) uses an adjacency-list model:
+
+- `schema.version` must be `skycd.catalog.v1`
+- `schema.hierarchy` is fixed to `adjacency-list`
+- each `[[nodes]]` entry maps one catalog node with:
+  - `nodeId`
+  - `parentId` (empty string for root)
+  - `kind` (`folder` or `file`)
+  - `name`
+  - `sizeBytes`
+
+Writer output is deterministic by sorting rows on `nodeId` using ordinal string order before serialization.

--- a/tests/SkyCD.Plugin.Host.Tests/Fixtures/Toml/catalog-v1.toml
+++ b/tests/SkyCD.Plugin.Host.Tests/Fixtures/Toml/catalog-v1.toml
@@ -1,0 +1,17 @@
+[schema]
+version = "skycd.catalog.v1"
+hierarchy = "adjacency-list"
+
+[[nodes]]
+nodeId = "1"
+parentId = ""
+kind = "folder"
+name = "Root"
+sizeBytes = "0"
+
+[[nodes]]
+nodeId = "2"
+parentId = "1"
+kind = "file"
+name = "notes.txt"
+sizeBytes = "16"

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -23,11 +23,13 @@
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Json\SkyCD.Plugin.Sample.Json.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Csv\SkyCD.Plugin.Sample.Csv.csproj" />
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Toml\SkyCD.Plugin.Sample.Toml.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Zip\SkyCD.Plugin.Sample.Zip.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <None Update="Fixtures\Csv\catalog-hierarchy.csv">
+    <None Update="Fixtures\Toml\catalog-v1.toml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Fixtures\Json\catalog-v1.json">

--- a/tests/SkyCD.Plugin.Host.Tests/TomlCatalogPluginTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/TomlCatalogPluginTests.cs
@@ -1,0 +1,73 @@
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Host;
+using SkyCD.Plugin.Host.FileFormats;
+using SkyCD.Plugin.Runtime.Discovery;
+using SkyCD.Plugin.Sample.Toml;
+
+namespace SkyCD.Plugin.Host.Tests;
+
+public class TomlCatalogPluginTests
+{
+    [Fact]
+    public void GetOpenAndSaveFormats_ExposesTomlMetadata()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+
+        var openFormats = service.GetOpenFormats();
+        var saveFormats = service.GetSaveFormats();
+
+        Assert.Contains(openFormats, format => format.FormatId == "skycd-toml" && format.Extensions.Contains(".toml"));
+        Assert.Contains(saveFormats, format => format.FormatId == "skycd-toml" && format.Extensions.Contains(".toml"));
+    }
+
+    [Fact]
+    public async Task ReadAndWriteAsync_RoundTripsFixtureHierarchyAndMetadata()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+        var fixturePath = Path.Combine(AppContext.BaseDirectory, "Fixtures", "Toml", "catalog-v1.toml");
+
+        await using var source = File.OpenRead(fixturePath);
+        var readResult = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-toml",
+            Source = source
+        });
+
+        Assert.True(readResult.Success);
+        var rows = Assert.IsType<List<Dictionary<string, object?>>>(readResult.Payload);
+        Assert.Equal(2, rows.Count);
+        Assert.Equal("1", rows[1]["parentId"]);
+        Assert.Equal("16", rows[1]["sizeBytes"]);
+
+        await using var target = new MemoryStream();
+        var writeResult = await service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "skycd-toml",
+            Target = target,
+            Payload = rows
+        });
+
+        Assert.True(writeResult.Success);
+        var text = Encoding.UTF8.GetString(target.ToArray());
+        Assert.Contains("[schema]", text);
+        Assert.Contains("version = \"skycd.catalog.v1\"", text);
+        Assert.Contains("hierarchy = \"adjacency-list\"", text);
+        Assert.Contains("[[nodes]]", text);
+    }
+
+    private static PluginCatalog CreateCatalog()
+    {
+        var plugin = new TomlCatalogPlugin();
+        var catalog = new PluginCatalog();
+        catalog.SetPlugins(
+        [
+            new DiscoveredPlugin
+            {
+                Plugin = plugin,
+                Capabilities = [plugin]
+            }
+        ]);
+        return catalog;
+    }
+}


### PR DESCRIPTION
Adds SkyCD.Plugin.Sample.Toml with read/write support for .toml, a versioned schema section, deterministic writer ordering, fixture round-trip coverage for hierarchy + metadata, and explicit hierarchy strategy documentation. Closes #79