### PR TITLE
feat(plugin-html): add write-only html export plugin with escaping tests (#80)

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Sample.Html/HtmlCatalogExportPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Html/HtmlCatalogExportPlugin.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Sample.Html;
+
+public sealed class HtmlCatalogExportPlugin : IPlugin, IFileFormatPluginCapability
+{
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.sample.html",
+        "Sample HTML Export Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Example plugin that exports catalog payloads to HTML.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor(
+            "skycd-html",
+            "SkyCD HTML Export",
+            [".html"],
+            CanRead: false,
+            CanWrite: true,
+            MimeType: "text/html")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(new FileFormatReadResult
+        {
+            Success = false,
+            Error = "HTML export plugin is write-only."
+        });
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var rows = request.Payload as List<Dictionary<string, object?>>
+                ?? throw new InvalidOperationException("HTML export payload must be a list of row dictionaries.");
+
+            var orderedRows = rows
+                .OrderBy(row => row.TryGetValue("nodeId", out var nodeId) ? nodeId?.ToString() : null, StringComparer.Ordinal)
+                .ToList();
+
+            var builder = new StringBuilder();
+            builder.AppendLine("<!doctype html>");
+            builder.AppendLine("<html lang=\"en\">");
+            builder.AppendLine("<head><meta charset=\"utf-8\"><title>SkyCD Catalog Export</title></head>");
+            builder.AppendLine("<body>");
+            builder.AppendLine("<h1>SkyCD Catalog Export</h1>");
+            builder.AppendLine("<nav><ul>");
+
+            foreach (var row in orderedRows)
+            {
+                var nodeId = WebUtility.HtmlEncode(GetValue(row, "nodeId"));
+                var name = WebUtility.HtmlEncode(GetValue(row, "name"));
+                builder.AppendLine($"<li><a href=\"#node-{nodeId}\">{name}</a></li>");
+            }
+
+            builder.AppendLine("</ul></nav>");
+            builder.AppendLine("<main>");
+
+            foreach (var row in orderedRows)
+            {
+                var nodeId = WebUtility.HtmlEncode(GetValue(row, "nodeId"));
+                var parentId = WebUtility.HtmlEncode(GetValue(row, "parentId"));
+                var kind = WebUtility.HtmlEncode(GetValue(row, "kind"));
+                var name = WebUtility.HtmlEncode(GetValue(row, "name"));
+                var sizeBytes = WebUtility.HtmlEncode(GetValue(row, "sizeBytes"));
+
+                builder.AppendLine($"<section id=\"node-{nodeId}\">");
+                builder.AppendLine($"<h2>{name}</h2>");
+                builder.AppendLine("<ul>");
+                builder.AppendLine($"<li>Kind: {kind}</li>");
+                builder.AppendLine($"<li>ParentId: {parentId}</li>");
+                builder.AppendLine($"<li>SizeBytes: {sizeBytes}</li>");
+                builder.AppendLine("</ul>");
+                builder.AppendLine("</section>");
+            }
+
+            builder.AppendLine("</main>");
+            builder.AppendLine("</body>");
+            builder.AppendLine("</html>");
+
+            await using var writer = new StreamWriter(request.Target, new UTF8Encoding(false), leaveOpen: true);
+            await writer.WriteAsync(builder.ToString().AsMemory(), cancellationToken);
+            await writer.FlushAsync(cancellationToken);
+
+            return new FileFormatWriteResult { Success = true };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatWriteResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    private static string GetValue(IReadOnlyDictionary<string, object?> row, string key)
+    {
+        return row.TryGetValue(key, out var value) ? value?.ToString() ?? string.Empty : string.Empty;
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Sample.Html/SkyCD.Plugin.Sample.Html.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Html/SkyCD.Plugin.Sample.Html.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Sample.Html/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Html/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.sample.html",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Sample.Html.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -5,6 +5,7 @@
     <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Cscd/SkyCD.Plugin.Legacy.Cscd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Scd/SkyCD.Plugin.Legacy.Scd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Csv/SkyCD.Plugin.Sample.Csv.csproj" />
+    <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Html/SkyCD.Plugin.Sample.Html.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Zip/SkyCD.Plugin.Sample.Zip.csproj" />

--- a/tests/SkyCD.Plugin.Host.Tests/HtmlCatalogExportPluginTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/HtmlCatalogExportPluginTests.cs
@@ -1,0 +1,93 @@
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Host;
+using SkyCD.Plugin.Host.FileFormats;
+using SkyCD.Plugin.Runtime.Discovery;
+using SkyCD.Plugin.Sample.Html;
+
+namespace SkyCD.Plugin.Host.Tests;
+
+public class HtmlCatalogExportPluginTests
+{
+    [Fact]
+    public void SaveFormats_IncludeHtml_ButOpenFormatsDoNot()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+
+        var openFormats = service.GetOpenFormats();
+        var saveFormats = service.GetSaveFormats();
+
+        Assert.DoesNotContain(openFormats, format => format.FormatId == "skycd-html");
+        Assert.Contains(saveFormats, format => format.FormatId == "skycd-html" && format.Extensions.Contains(".html"));
+    }
+
+    [Fact]
+    public async Task ReadAsync_IsBlocked_ForWriteOnlyHtmlFormat()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+        await using var source = new MemoryStream(Encoding.UTF8.GetBytes("<html></html>"));
+
+        var exception = await Assert.ThrowsAsync<FileFormatRoutingException>(() => service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-html",
+            Source = source
+        }));
+
+        Assert.Contains("not readable", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task WriteAsync_ExportsNavigationStructure_WithEscapedNames()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+        var payload = new List<Dictionary<string, object?>>
+        {
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["nodeId"] = "1",
+                ["parentId"] = "",
+                ["kind"] = "folder",
+                ["name"] = "Root <Catalog>",
+                ["sizeBytes"] = "0"
+            },
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["nodeId"] = "2",
+                ["parentId"] = "1",
+                ["kind"] = "file",
+                ["name"] = "track & one.mp3",
+                ["sizeBytes"] = "42"
+            }
+        };
+
+        await using var target = new MemoryStream();
+        var result = await service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "skycd-html",
+            Target = target,
+            Payload = payload
+        });
+
+        Assert.True(result.Success);
+        var html = Encoding.UTF8.GetString(target.ToArray());
+        Assert.Contains("<nav", html);
+        Assert.Contains("href=\"#node-1\"", html);
+        Assert.Contains("Root &lt;Catalog&gt;", html);
+        Assert.Contains("track &amp; one.mp3", html);
+    }
+
+    private static PluginCatalog CreateCatalog()
+    {
+        var plugin = new HtmlCatalogExportPlugin();
+        var catalog = new PluginCatalog();
+        catalog.SetPlugins(
+        [
+            new DiscoveredPlugin
+            {
+                Plugin = plugin,
+                Capabilities = [plugin]
+            }
+        ]);
+        return catalog;
+    }
+}

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Host\SkyCD.Plugin.Host.csproj" />
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Html\SkyCD.Plugin.Sample.Html.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Json\SkyCD.Plugin.Sample.Json.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Csv\SkyCD.Plugin.Sample.Csv.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Zip\SkyCD.Plugin.Sample.Zip.csproj" />
@@ -34,5 +35,4 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Adds SkyCD.Plugin.Sample.Html as a write-only file format plugin (.html), with safe HTML encoding, basic navigation structure for large catalogs, save-only capability exposure, and tests validating write-only behavior + escaping. Closes #80