### PR TITLE
feat(plugin-md): add write-only markdown export plugin with hierarchy tests (#81)

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Sample.Markdown/MarkdownCatalogExportPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Markdown/MarkdownCatalogExportPlugin.cs
@@ -1,0 +1,119 @@
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Sample.Markdown;
+
+public sealed class MarkdownCatalogExportPlugin : IPlugin, IFileFormatPluginCapability
+{
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.sample.markdown",
+        "Sample Markdown Export Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Example plugin that exports catalog payloads to Markdown.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor(
+            "skycd-md",
+            "SkyCD Markdown Export",
+            [".md"],
+            CanRead: false,
+            CanWrite: true,
+            MimeType: "text/markdown")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(new FileFormatReadResult
+        {
+            Success = false,
+            Error = "Markdown export plugin is write-only."
+        });
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var rows = request.Payload as List<Dictionary<string, object?>>
+                ?? throw new InvalidOperationException("Markdown export payload must be a list of row dictionaries.");
+
+            var orderedRows = rows
+                .OrderBy(row => row.TryGetValue("nodeId", out var nodeId) ? nodeId?.ToString() : null, StringComparer.Ordinal)
+                .ToList();
+
+            var byParent = orderedRows
+                .GroupBy(row => GetValue(row, "parentId"))
+                .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.Ordinal);
+
+            var builder = new StringBuilder();
+            builder.AppendLine("# SkyCD Catalog Export");
+            builder.AppendLine();
+            builder.AppendLine("## Nodes");
+
+            WriteChildren(builder, byParent, parentId: string.Empty, depth: 0);
+
+            await using var writer = new StreamWriter(request.Target, new UTF8Encoding(false), leaveOpen: true);
+            await writer.WriteAsync(builder.ToString().AsMemory(), cancellationToken);
+            await writer.FlushAsync(cancellationToken);
+            return new FileFormatWriteResult { Success = true };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatWriteResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    private static void WriteChildren(
+        StringBuilder builder,
+        IReadOnlyDictionary<string, List<Dictionary<string, object?>>> byParent,
+        string parentId,
+        int depth)
+    {
+        if (!byParent.TryGetValue(parentId, out var children))
+        {
+            return;
+        }
+
+        foreach (var row in children)
+        {
+            var indent = new string(' ', depth * 2);
+            var kind = EscapeMarkdown(GetValue(row, "kind"));
+            var name = EscapeMarkdown(GetValue(row, "name"));
+            var nodeId = EscapeMarkdown(GetValue(row, "nodeId"));
+            var sizeBytes = EscapeMarkdown(GetValue(row, "sizeBytes"));
+
+            builder.AppendLine($"{indent}- `{kind}` {name} (`nodeId={nodeId}`) (`sizeBytes={sizeBytes}`)");
+            WriteChildren(builder, byParent, GetValue(row, "nodeId"), depth + 1);
+        }
+    }
+
+    private static string GetValue(IReadOnlyDictionary<string, object?> row, string key)
+    {
+        return row.TryGetValue(key, out var value) ? value?.ToString() ?? string.Empty : string.Empty;
+    }
+
+    private static string EscapeMarkdown(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("_", "\\_", StringComparison.Ordinal)
+            .Replace("*", "\\*", StringComparison.Ordinal)
+            .Replace("[", "\\[", StringComparison.Ordinal)
+            .Replace("]", "\\]", StringComparison.Ordinal)
+            .Replace("(", "\\(", StringComparison.Ordinal)
+            .Replace(")", "\\)", StringComparison.Ordinal)
+            .Replace("`", "\\`", StringComparison.Ordinal);
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Sample.Markdown/SkyCD.Plugin.Sample.Markdown.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Markdown/SkyCD.Plugin.Sample.Markdown.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Sample.Markdown/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Markdown/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.sample.markdown",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Sample.Markdown.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -6,6 +6,7 @@
     <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Scd/SkyCD.Plugin.Legacy.Scd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Csv/SkyCD.Plugin.Sample.Csv.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
+    <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Markdown/SkyCD.Plugin.Sample.Markdown.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Zip/SkyCD.Plugin.Sample.Zip.csproj" />
   </Folder>

--- a/tests/SkyCD.Plugin.Host.Tests/MarkdownCatalogExportPluginTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/MarkdownCatalogExportPluginTests.cs
@@ -1,0 +1,92 @@
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Host;
+using SkyCD.Plugin.Host.FileFormats;
+using SkyCD.Plugin.Runtime.Discovery;
+using SkyCD.Plugin.Sample.Markdown;
+
+namespace SkyCD.Plugin.Host.Tests;
+
+public class MarkdownCatalogExportPluginTests
+{
+    [Fact]
+    public void SaveFormats_IncludeMarkdown_ButOpenFormatsDoNot()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+
+        var openFormats = service.GetOpenFormats();
+        var saveFormats = service.GetSaveFormats();
+
+        Assert.DoesNotContain(openFormats, format => format.FormatId == "skycd-md");
+        Assert.Contains(saveFormats, format => format.FormatId == "skycd-md" && format.Extensions.Contains(".md"));
+    }
+
+    [Fact]
+    public async Task ReadAsync_IsBlocked_ForWriteOnlyMarkdownFormat()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+        await using var source = new MemoryStream(Encoding.UTF8.GetBytes("# export"));
+
+        var exception = await Assert.ThrowsAsync<FileFormatRoutingException>(() => service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-md",
+            Source = source
+        }));
+
+        Assert.Contains("not readable", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task WriteAsync_ExportsDeterministicHierarchy_WithEscaping()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+        var payload = new List<Dictionary<string, object?>>
+        {
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["nodeId"] = "1",
+                ["parentId"] = "",
+                ["kind"] = "folder",
+                ["name"] = "Root_[Catalog]",
+                ["sizeBytes"] = "0"
+            },
+            new(StringComparer.OrdinalIgnoreCase)
+            {
+                ["nodeId"] = "2",
+                ["parentId"] = "1",
+                ["kind"] = "file",
+                ["name"] = "track*(demo).mp3",
+                ["sizeBytes"] = "42"
+            }
+        };
+
+        await using var target = new MemoryStream();
+        var result = await service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "skycd-md",
+            Target = target,
+            Payload = payload
+        });
+
+        Assert.True(result.Success);
+        var markdown = Encoding.UTF8.GetString(target.ToArray());
+        Assert.Contains("# SkyCD Catalog Export", markdown);
+        Assert.Contains("- `folder` Root\\_\\[Catalog\\] (`nodeId=1`)", markdown);
+        Assert.Contains("- `file` track\\*\\(demo\\).mp3 (`nodeId=2`)", markdown);
+    }
+
+    private static PluginCatalog CreateCatalog()
+    {
+        var plugin = new MarkdownCatalogExportPlugin();
+        var catalog = new PluginCatalog();
+        catalog.SetPlugins(
+        [
+            new DiscoveredPlugin
+            {
+                Plugin = plugin,
+                Capabilities = [plugin]
+            }
+        ]);
+        return catalog;
+    }
+}

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Json\SkyCD.Plugin.Sample.Json.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Csv\SkyCD.Plugin.Sample.Csv.csproj" />
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Markdown\SkyCD.Plugin.Sample.Markdown.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Zip\SkyCD.Plugin.Sample.Zip.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds SkyCD.Plugin.Sample.Markdown as a write-only .md export plugin with deterministic hierarchy output, markdown escaping for special characters in names/paths, save-only capability exposure, and host routing tests validating read blocking + export structure. Closes #81