### PR TITLE
feat(plugin-zip): add read-only zip archive index plugin with tests (#82)

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Sample.Zip/SkyCD.Plugin.Sample.Zip.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Zip/SkyCD.Plugin.Sample.Zip.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Sample.Zip/ZipArchiveIndexPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Zip/ZipArchiveIndexPlugin.cs
@@ -1,0 +1,126 @@
+using System.IO.Compression;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Sample.Zip;
+
+public sealed class ZipArchiveIndexPlugin : IPlugin, IFileFormatPluginCapability
+{
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.sample.zip",
+        "Sample ZIP Index Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Example plugin that indexes ZIP archive entries.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor(
+            "skycd-zip",
+            "ZIP Archive Index",
+            [".zip"],
+            CanRead: true,
+            CanWrite: false,
+            MimeType: "application/zip")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(new FileFormatWriteResult
+        {
+            Success = false,
+            Error = "ZIP archive index plugin is read-only."
+        });
+    }
+
+    public Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var archive = new ZipArchive(request.Source, ZipArchiveMode.Read, leaveOpen: true);
+            var rows = new List<Dictionary<string, object?>>();
+            var seenDirectories = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var entry in archive.Entries)
+            {
+                var normalizedPath = entry.FullName.Replace('\\', '/').TrimEnd('/');
+                if (string.IsNullOrWhiteSpace(normalizedPath))
+                {
+                    continue;
+                }
+
+                var parts = normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                var isDirectoryEntry = entry.FullName.EndsWith("/", StringComparison.Ordinal);
+
+                for (var index = 0; index < parts.Length - 1; index++)
+                {
+                    var directoryPath = string.Join("/", parts.Take(index + 1));
+                    if (!seenDirectories.Add(directoryPath))
+                    {
+                        continue;
+                    }
+
+                    rows.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["kind"] = "folder",
+                        ["fullPath"] = directoryPath,
+                        ["name"] = parts[index],
+                        ["sizeBytes"] = "0",
+                        ["modifiedUtc"] = entry.LastWriteTime.UtcDateTime.ToString("O")
+                    });
+                }
+
+                var leafName = parts[^1];
+                if (isDirectoryEntry)
+                {
+                    if (seenDirectories.Add(normalizedPath))
+                    {
+                        rows.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["kind"] = "folder",
+                            ["fullPath"] = normalizedPath,
+                            ["name"] = leafName,
+                            ["sizeBytes"] = "0",
+                            ["modifiedUtc"] = entry.LastWriteTime.UtcDateTime.ToString("O")
+                        });
+                    }
+                }
+                else
+                {
+                    rows.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["kind"] = "file",
+                        ["fullPath"] = normalizedPath,
+                        ["name"] = leafName,
+                        ["sizeBytes"] = entry.Length.ToString(),
+                        ["modifiedUtc"] = entry.LastWriteTime.UtcDateTime.ToString("O")
+                    });
+                }
+            }
+
+            var ordered = rows
+                .OrderBy(row => row["fullPath"]?.ToString(), StringComparer.Ordinal)
+                .ThenBy(row => row["kind"]?.ToString(), StringComparer.Ordinal)
+                .ToList();
+
+            return Task.FromResult(new FileFormatReadResult
+            {
+                Success = true,
+                Payload = ordered
+            });
+        }
+        catch (Exception exception)
+        {
+            return Task.FromResult(new FileFormatReadResult
+            {
+                Success = false,
+                Error = exception.Message
+            });
+        }
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Sample.Zip/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Zip/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.sample.zip",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Sample.Zip.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -6,6 +6,7 @@
     <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Scd/SkyCD.Plugin.Legacy.Scd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj" />
+    <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Zip/SkyCD.Plugin.Sample.Zip.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/SkyCD.App/SkyCD.App.csproj" />

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Host\SkyCD.Plugin.Host.csproj" />
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Json\SkyCD.Plugin.Sample.Json.csproj" />
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Zip\SkyCD.Plugin.Sample.Zip.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/SkyCD.Plugin.Host.Tests/ZipArchiveIndexPluginTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/ZipArchiveIndexPluginTests.cs
@@ -1,0 +1,96 @@
+using System.IO.Compression;
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Host;
+using SkyCD.Plugin.Host.FileFormats;
+using SkyCD.Plugin.Runtime.Discovery;
+using SkyCD.Plugin.Sample.Zip;
+
+namespace SkyCD.Plugin.Host.Tests;
+
+public class ZipArchiveIndexPluginTests
+{
+    [Fact]
+    public void OpenFormats_IncludeZip_ButSaveFormatsDoNot()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+
+        var openFormats = service.GetOpenFormats();
+        var saveFormats = service.GetSaveFormats();
+
+        Assert.Contains(openFormats, format => format.FormatId == "skycd-zip" && format.Extensions.Contains(".zip"));
+        Assert.DoesNotContain(saveFormats, format => format.FormatId == "skycd-zip");
+    }
+
+    [Fact]
+    public async Task WriteAsync_IsBlocked_ForReadOnlyZipFormat()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+        await using var stream = new MemoryStream();
+
+        var exception = await Assert.ThrowsAsync<FileFormatRoutingException>(() => service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "skycd-zip",
+            Target = stream,
+            Payload = new { }
+        }));
+
+        Assert.Contains("read-only", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReadAsync_IndexesDeepAndUnicodeEntries_WithMetadata()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+        await using var zipStream = CreateFixtureZip();
+
+        var result = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-zip",
+            Source = zipStream
+        });
+
+        Assert.True(result.Success);
+        var rows = Assert.IsType<List<Dictionary<string, object?>>>(result.Payload);
+
+        Assert.Contains(rows, row => Equals(row["fullPath"], "root/deep"));
+        Assert.Contains(rows, row => Equals(row["fullPath"], "root/deep/įrašas.txt"));
+        Assert.Contains(rows, row => Equals(row["kind"], "file") && Equals(row["sizeBytes"], "5"));
+        Assert.Contains(rows, row => row.ContainsKey("modifiedUtc"));
+    }
+
+    private static MemoryStream CreateFixtureZip()
+    {
+        var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var first = archive.CreateEntry("root/deep/įrašas.txt");
+            using (var writer = new StreamWriter(first.Open(), new UTF8Encoding(false), leaveOpen: false))
+            {
+                writer.Write("hello");
+            }
+
+            var second = archive.CreateEntry("root/notes.txt");
+            using var secondWriter = new StreamWriter(second.Open(), new UTF8Encoding(false), leaveOpen: false);
+            secondWriter.Write("abc");
+        }
+
+        stream.Position = 0;
+        return stream;
+    }
+
+    private static PluginCatalog CreateCatalog()
+    {
+        var plugin = new ZipArchiveIndexPlugin();
+        var catalog = new PluginCatalog();
+        catalog.SetPlugins(
+        [
+            new DiscoveredPlugin
+            {
+                Plugin = plugin,
+                Capabilities = [plugin]
+            }
+        ]);
+        return catalog;
+    }
+}


### PR DESCRIPTION
Adds SkyCD.Plugin.Sample.Zip as a read-only .zip archive indexing plugin. It enumerates archive entries into hierarchy rows, preserves size/modified metadata, enforces read-only contract, and includes host routing tests for open/save filtering, write blocking, and deep unicode entry fixtures. Closes #82