### PR TITLE
feat(plugin-7z): add read-only 7z archive index plugin with typed errors (#83)

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Sample.SevenZip/SevenZipArchiveIndexPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Sample.SevenZip/SevenZipArchiveIndexPlugin.cs
@@ -1,0 +1,177 @@
+using SharpCompress.Archives.SevenZip;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Sample.SevenZip;
+
+public sealed class SevenZipArchiveIndexPlugin : IPlugin, IFileFormatPluginCapability
+{
+    private readonly ISevenZipEntryReader _entryReader;
+
+    public SevenZipArchiveIndexPlugin() : this(new SharpCompressSevenZipEntryReader())
+    {
+    }
+
+    public SevenZipArchiveIndexPlugin(ISevenZipEntryReader entryReader)
+    {
+        _entryReader = entryReader;
+    }
+
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.sample.7z",
+        "Sample 7z Index Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Example plugin that indexes 7z archive entries.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor(
+            "skycd-7z",
+            "7z Archive Index",
+            [".7z"],
+            CanRead: true,
+            CanWrite: false,
+            MimeType: "application/x-7z-compressed")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(new FileFormatWriteResult
+        {
+            Success = false,
+            Error = "7z archive index plugin is read-only."
+        });
+    }
+
+    public Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var entries = _entryReader.ReadEntries(request.Source);
+            var rows = ProjectHierarchy(entries);
+
+            return Task.FromResult(new FileFormatReadResult
+            {
+                Success = true,
+                Payload = rows
+            });
+        }
+        catch (NotSupportedException exception)
+        {
+            return Task.FromResult(new FileFormatReadResult
+            {
+                Success = false,
+                Error = $"SEVENZIP_UNSUPPORTED_METHOD: {exception.Message}"
+            });
+        }
+        catch (Exception exception)
+        {
+            return Task.FromResult(new FileFormatReadResult
+            {
+                Success = false,
+                Error = exception.Message
+            });
+        }
+    }
+
+    private static List<Dictionary<string, object?>> ProjectHierarchy(IReadOnlyCollection<SevenZipEntryInfo> entries)
+    {
+        var rows = new List<Dictionary<string, object?>>();
+        var seenDirectories = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var entry in entries)
+        {
+            var normalized = entry.Path.Replace('\\', '/').TrimEnd('/');
+            if (string.IsNullOrWhiteSpace(normalized))
+            {
+                continue;
+            }
+
+            var parts = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            for (var index = 0; index < parts.Length - 1; index++)
+            {
+                var directoryPath = string.Join("/", parts.Take(index + 1));
+                if (!seenDirectories.Add(directoryPath))
+                {
+                    continue;
+                }
+
+                rows.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["kind"] = "folder",
+                    ["fullPath"] = directoryPath,
+                    ["name"] = parts[index],
+                    ["sizeBytes"] = "0",
+                    ["modifiedUtc"] = entry.ModifiedUtc?.ToString("O")
+                });
+            }
+
+            var leafName = parts[^1];
+            if (entry.IsDirectory)
+            {
+                if (seenDirectories.Add(normalized))
+                {
+                    rows.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["kind"] = "folder",
+                        ["fullPath"] = normalized,
+                        ["name"] = leafName,
+                        ["sizeBytes"] = "0",
+                        ["modifiedUtc"] = entry.ModifiedUtc?.ToString("O")
+                    });
+                }
+            }
+            else
+            {
+                rows.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["kind"] = "file",
+                    ["fullPath"] = normalized,
+                    ["name"] = leafName,
+                    ["sizeBytes"] = entry.SizeBytes.ToString(),
+                    ["modifiedUtc"] = entry.ModifiedUtc?.ToString("O")
+                });
+            }
+        }
+
+        return rows
+            .OrderBy(row => row["fullPath"]?.ToString(), StringComparer.Ordinal)
+            .ThenBy(row => row["kind"]?.ToString(), StringComparer.Ordinal)
+            .ToList();
+    }
+}
+
+public interface ISevenZipEntryReader
+{
+    IReadOnlyCollection<SevenZipEntryInfo> ReadEntries(Stream source);
+}
+
+public sealed record SevenZipEntryInfo(
+    string Path,
+    bool IsDirectory,
+    long SizeBytes,
+    DateTime? ModifiedUtc);
+
+public sealed class SharpCompressSevenZipEntryReader : ISevenZipEntryReader
+{
+    public IReadOnlyCollection<SevenZipEntryInfo> ReadEntries(Stream source)
+    {
+        using var archive = SevenZipArchive.Open(source);
+        return archive.Entries
+            .Where(entry => !entry.IsEncrypted)
+            .Select(entry => new SevenZipEntryInfo(
+                entry.Key ?? string.Empty,
+                entry.IsDirectory,
+                entry.Size,
+                entry.LastModifiedTime is DateTime value
+                    ? DateTime.SpecifyKind(value, DateTimeKind.Utc)
+                    : null))
+            .ToList();
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Sample.SevenZip/SkyCD.Plugin.Sample.SevenZip.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Sample.SevenZip/SkyCD.Plugin.Sample.SevenZip.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SharpCompress" Version="0.41.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Sample.SevenZip/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Sample.SevenZip/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.sample.7z",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Sample.SevenZip.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -8,6 +8,7 @@
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Zip/SkyCD.Plugin.Sample.Zip.csproj" />
+    <Project Path="Plugins/samples/SkyCD.Plugin.Sample.SevenZip/SkyCD.Plugin.Sample.SevenZip.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/SkyCD.App/SkyCD.App.csproj" />

--- a/tests/SkyCD.Plugin.Host.Tests/SevenZipArchiveIndexPluginTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/SevenZipArchiveIndexPluginTests.cs
@@ -1,0 +1,104 @@
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Host;
+using SkyCD.Plugin.Host.FileFormats;
+using SkyCD.Plugin.Runtime.Discovery;
+using SkyCD.Plugin.Sample.SevenZip;
+
+namespace SkyCD.Plugin.Host.Tests;
+
+public class SevenZipArchiveIndexPluginTests
+{
+    [Fact]
+    public void OpenFormats_Include7z_ButSaveFormatsDoNot()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog(new FakeReader([])));
+
+        var openFormats = service.GetOpenFormats();
+        var saveFormats = service.GetSaveFormats();
+
+        Assert.Contains(openFormats, format => format.FormatId == "skycd-7z" && format.Extensions.Contains(".7z"));
+        Assert.DoesNotContain(saveFormats, format => format.FormatId == "skycd-7z");
+    }
+
+    [Fact]
+    public async Task WriteAsync_IsBlocked_ForReadOnly7zFormat()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog(new FakeReader([])));
+        await using var target = new MemoryStream();
+
+        var exception = await Assert.ThrowsAsync<FileFormatRoutingException>(() => service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "skycd-7z",
+            Target = target,
+            Payload = new { }
+        }));
+
+        Assert.Contains("read-only", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ProjectsNestedPathsAndMetadata()
+    {
+        var reader = new FakeReader(
+        [
+            new SevenZipEntryInfo("root/deep/įrašas.txt", IsDirectory: false, SizeBytes: 123, ModifiedUtc: new DateTime(2026, 01, 01, 0, 0, 0, DateTimeKind.Utc)),
+            new SevenZipEntryInfo("root/docs/", IsDirectory: true, SizeBytes: 0, ModifiedUtc: null)
+        ]);
+        var service = new FileFormatRoutingService(CreateCatalog(reader));
+        await using var source = new MemoryStream([0x37, 0x7A]); // test stream ignored by fake reader
+
+        var result = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-7z",
+            Source = source
+        });
+
+        Assert.True(result.Success);
+        var rows = Assert.IsType<List<Dictionary<string, object?>>>(result.Payload);
+        Assert.Contains(rows, row => Equals(row["fullPath"], "root/deep/įrašas.txt"));
+        Assert.Contains(rows, row => Equals(row["kind"], "file") && Equals(row["sizeBytes"], "123"));
+    }
+
+    [Fact]
+    public async Task ReadAsync_ReturnsTypedError_WhenCompressionMethodUnsupported()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog(new ThrowingReader()));
+        await using var source = new MemoryStream([0x37, 0x7A]);
+
+        var exception = await Assert.ThrowsAsync<FileFormatRoutingException>(() => service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-7z",
+            Source = source
+        }));
+
+        Assert.Contains("SEVENZIP_UNSUPPORTED_METHOD", exception.Message);
+    }
+
+    private static PluginCatalog CreateCatalog(ISevenZipEntryReader reader)
+    {
+        var plugin = new SevenZipArchiveIndexPlugin(reader);
+        var catalog = new PluginCatalog();
+        catalog.SetPlugins(
+        [
+            new DiscoveredPlugin
+            {
+                Plugin = plugin,
+                Capabilities = [plugin]
+            }
+        ]);
+        return catalog;
+    }
+
+    private sealed class FakeReader(IReadOnlyCollection<SevenZipEntryInfo> entries) : ISevenZipEntryReader
+    {
+        public IReadOnlyCollection<SevenZipEntryInfo> ReadEntries(Stream source) => entries;
+    }
+
+    private sealed class ThrowingReader : ISevenZipEntryReader
+    {
+        public IReadOnlyCollection<SevenZipEntryInfo> ReadEntries(Stream source)
+        {
+            throw new NotSupportedException("LZMA2 variant is not supported.");
+        }
+    }
+}

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Json\SkyCD.Plugin.Sample.Json.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Csv\SkyCD.Plugin.Sample.Csv.csproj" />
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.SevenZip\SkyCD.Plugin.Sample.SevenZip.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Zip\SkyCD.Plugin.Sample.Zip.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds SkyCD.Plugin.Sample.SevenZip as a read-only .7z archive indexing plugin. It projects nested paths into hierarchy rows, maps metadata fields, enforces read-only capability, and returns typed unsupported compression method errors (SEVENZIP_UNSUPPORTED_METHOD). Includes host routing tests for open/save filtering, write blocking, metadata mapping, and typed error behavior. Closes #83