### PR TITLE
feat(plugin-tar): add read-only tar/targz index plugin with tests (#84)

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Sample.Tar/SkyCD.Plugin.Sample.Tar.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Tar/SkyCD.Plugin.Sample.Tar.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Sample.Tar/TarArchiveIndexPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Tar/TarArchiveIndexPlugin.cs
@@ -1,0 +1,148 @@
+using System.Formats.Tar;
+using System.IO.Compression;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Sample.Tar;
+
+public sealed class TarArchiveIndexPlugin : IPlugin, IFileFormatPluginCapability
+{
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.sample.tar",
+        "Sample TAR Index Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Example plugin that indexes TAR archive entries.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor(
+            "skycd-tar",
+            "TAR Archive Index",
+            [".tar", ".tar.gz", ".tgz"],
+            CanRead: true,
+            CanWrite: false,
+            MimeType: "application/x-tar")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(new FileFormatWriteResult
+        {
+            Success = false,
+            Error = "TAR archive index plugin is read-only."
+        });
+    }
+
+    public Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var tarStream = EnsureTarStream(request.Source);
+            var reader = new TarReader(tarStream, leaveOpen: true);
+            var rows = new List<Dictionary<string, object?>>();
+            var seenDirectories = new HashSet<string>(StringComparer.Ordinal);
+
+            while (reader.GetNextEntry(copyData: false) is { } entry)
+            {
+                var normalizedPath = (entry.Name ?? string.Empty).Replace('\\', '/').TrimEnd('/');
+                if (string.IsNullOrWhiteSpace(normalizedPath))
+                {
+                    continue;
+                }
+
+                var parts = normalizedPath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                for (var index = 0; index < parts.Length - 1; index++)
+                {
+                    var directoryPath = string.Join("/", parts.Take(index + 1));
+                    if (!seenDirectories.Add(directoryPath))
+                    {
+                        continue;
+                    }
+
+                    rows.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["kind"] = "folder",
+                        ["fullPath"] = directoryPath,
+                        ["name"] = parts[index],
+                        ["sizeBytes"] = "0",
+                        ["modifiedUtc"] = entry.ModificationTime.UtcDateTime.ToString("O")
+                    });
+                }
+
+                var isDirectory = entry.EntryType is TarEntryType.Directory;
+                var leafName = parts[^1];
+                if (isDirectory)
+                {
+                    if (seenDirectories.Add(normalizedPath))
+                    {
+                        rows.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            ["kind"] = "folder",
+                            ["fullPath"] = normalizedPath,
+                            ["name"] = leafName,
+                            ["sizeBytes"] = "0",
+                            ["modifiedUtc"] = entry.ModificationTime.UtcDateTime.ToString("O")
+                        });
+                    }
+                }
+                else
+                {
+                    rows.Add(new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["kind"] = "file",
+                        ["fullPath"] = normalizedPath,
+                        ["name"] = leafName,
+                        ["sizeBytes"] = entry.Length.ToString(),
+                        ["modifiedUtc"] = entry.ModificationTime.UtcDateTime.ToString("O")
+                    });
+                }
+            }
+
+            var ordered = rows
+                .OrderBy(row => row["fullPath"]?.ToString(), StringComparer.Ordinal)
+                .ThenBy(row => row["kind"]?.ToString(), StringComparer.Ordinal)
+                .ToList();
+
+            return Task.FromResult(new FileFormatReadResult
+            {
+                Success = true,
+                Payload = ordered
+            });
+        }
+        catch (Exception exception)
+        {
+            return Task.FromResult(new FileFormatReadResult
+            {
+                Success = false,
+                Error = exception.Message
+            });
+        }
+    }
+
+    private static Stream EnsureTarStream(Stream source)
+    {
+        if (!source.CanSeek)
+        {
+            var buffered = new MemoryStream();
+            source.CopyTo(buffered);
+            buffered.Position = 0;
+            return EnsureTarStream(buffered);
+        }
+
+        var originalPosition = source.Position;
+        var header = new byte[2];
+        var read = source.Read(header, 0, 2);
+        source.Position = originalPosition;
+
+        var isGzip = read == 2 && header[0] == 0x1F && header[1] == 0x8B;
+        return isGzip
+            ? new GZipStream(source, CompressionMode.Decompress, leaveOpen: true)
+            : source;
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Sample.Tar/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Tar/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.sample.tar",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Sample.Tar.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -8,6 +8,7 @@
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Zip/SkyCD.Plugin.Sample.Zip.csproj" />
+    <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Tar/SkyCD.Plugin.Sample.Tar.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/SkyCD.App/SkyCD.App.csproj" />

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Json\SkyCD.Plugin.Sample.Json.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Csv\SkyCD.Plugin.Sample.Csv.csproj" />
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Tar\SkyCD.Plugin.Sample.Tar.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Zip\SkyCD.Plugin.Sample.Zip.csproj" />
   </ItemGroup>
 

--- a/tests/SkyCD.Plugin.Host.Tests/TarArchiveIndexPluginTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/TarArchiveIndexPluginTests.cs
@@ -1,0 +1,122 @@
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Text;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Host;
+using SkyCD.Plugin.Host.FileFormats;
+using SkyCD.Plugin.Runtime.Discovery;
+using SkyCD.Plugin.Sample.Tar;
+
+namespace SkyCD.Plugin.Host.Tests;
+
+public class TarArchiveIndexPluginTests
+{
+    [Fact]
+    public void OpenFormats_IncludeTarVariants_ButSaveFormatsDoNot()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+
+        var openFormats = service.GetOpenFormats();
+        var saveFormats = service.GetSaveFormats();
+
+        Assert.Contains(openFormats, format =>
+            format.FormatId == "skycd-tar" &&
+            format.Extensions.Contains(".tar") &&
+            format.Extensions.Contains(".tar.gz") &&
+            format.Extensions.Contains(".tgz"));
+        Assert.DoesNotContain(saveFormats, format => format.FormatId == "skycd-tar");
+    }
+
+    [Fact]
+    public async Task WriteAsync_IsBlocked_ForReadOnlyTarFormat()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+        await using var stream = new MemoryStream();
+
+        var exception = await Assert.ThrowsAsync<FileFormatRoutingException>(() => service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "skycd-tar",
+            Target = stream,
+            Payload = new { }
+        }));
+
+        Assert.Contains("read-only", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReadAsync_IndexesTarAndGzipTar_WithPathNormalizationAndMetadata()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog());
+
+        await using var tarStream = CreateTarFixture(gzip: false);
+        var tarResult = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-tar",
+            Source = tarStream
+        });
+        Assert.True(tarResult.Success);
+        var tarRows = Assert.IsType<List<Dictionary<string, object?>>>(tarResult.Payload);
+        Assert.Contains(tarRows, row => Equals(row["fullPath"], "root/deep/įrašas.txt"));
+
+        await using var tarGzStream = CreateTarFixture(gzip: true);
+        var tarGzResult = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-tar",
+            Source = tarGzStream
+        });
+        Assert.True(tarGzResult.Success);
+        var tarGzRows = Assert.IsType<List<Dictionary<string, object?>>>(tarGzResult.Payload);
+        Assert.Contains(tarGzRows, row => Equals(row["kind"], "file") && Equals(row["sizeBytes"], "5"));
+    }
+
+    private static MemoryStream CreateTarFixture(bool gzip)
+    {
+        var output = new MemoryStream();
+        Stream target;
+        IDisposable? compression = null;
+        if (gzip)
+        {
+            compression = new GZipStream(output, CompressionLevel.SmallestSize, leaveOpen: true);
+            target = (Stream)compression;
+        }
+        else
+        {
+            target = output;
+        }
+
+        using (compression)
+        using (var writer = new TarWriter(target, TarEntryFormat.Pax, leaveOpen: true))
+        {
+            var directory = new PaxTarEntry(TarEntryType.Directory, "root/deep/");
+            writer.WriteEntry(directory);
+
+            var fileBytes = Encoding.UTF8.GetBytes("hello");
+            var fileStream = new MemoryStream(fileBytes);
+            var file = new PaxTarEntry(TarEntryType.RegularFile, "root\\deep\\įrašas.txt")
+            {
+                DataStream = fileStream,
+                ModificationTime = new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc))
+            };
+
+            writer.WriteEntry(file);
+        }
+
+        output.Position = 0;
+        return output;
+    }
+
+    private static PluginCatalog CreateCatalog()
+    {
+        var plugin = new TarArchiveIndexPlugin();
+        var catalog = new PluginCatalog();
+        catalog.SetPlugins(
+        [
+            new DiscoveredPlugin
+            {
+                Plugin = plugin,
+                Capabilities = [plugin]
+            }
+        ]);
+        return catalog;
+    }
+}


### PR DESCRIPTION
Adds SkyCD.Plugin.Sample.Tar as a read-only archive index plugin for .tar/.tar.gz/.tgz. It reconstructs directory hierarchy, supports gzip-compressed tar streams, normalizes paths, maps metadata, enforces read-only contract, and includes host routing tests covering capability gating and fixture mapping for tar and tar.gz streams. Closes #84