### PR TITLE
feat(plugin-iso): add read-only iso image index plugin with tests (#85)

### DIFF
--- a/Plugins/samples/SkyCD.Plugin.Sample.Iso/IsoImageIndexPlugin.cs
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Iso/IsoImageIndexPlugin.cs
@@ -1,0 +1,127 @@
+using DiscUtils.Iso9660;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+
+namespace SkyCD.Plugin.Sample.Iso;
+
+public sealed class IsoImageIndexPlugin : IPlugin, IFileFormatPluginCapability
+{
+    private readonly IIsoEntryReader _entryReader;
+
+    public IsoImageIndexPlugin() : this(new DiscUtilsIsoEntryReader())
+    {
+    }
+
+    public IsoImageIndexPlugin(IIsoEntryReader entryReader)
+    {
+        _entryReader = entryReader;
+    }
+
+    public PluginDescriptor Descriptor => new(
+        "skycd.plugin.sample.iso",
+        "Sample ISO Index Plugin",
+        new Version(1, 0, 0),
+        new Version(3, 0, 0),
+        "Example plugin that indexes ISO image entries.");
+
+    public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+    [
+        new FileFormatDescriptor(
+            "skycd-iso",
+            "ISO Image Index",
+            [".iso"],
+            CanRead: true,
+            CanWrite: false,
+            MimeType: "application/x-iso9660-image")
+    ];
+
+    public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    public Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(new FileFormatWriteResult
+        {
+            Success = false,
+            Error = "ISO image index plugin is read-only."
+        });
+    }
+
+    public Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var entries = _entryReader.ReadEntries(request.Source);
+            var rows = entries
+                .Select(entry => new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
+                {
+                    ["kind"] = entry.IsDirectory ? "folder" : "file",
+                    ["fullPath"] = entry.Path.Replace('\\', '/'),
+                    ["name"] = entry.Path.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? string.Empty,
+                    ["sizeBytes"] = entry.SizeBytes.ToString(),
+                    ["modifiedUtc"] = entry.ModifiedUtc?.ToString("O")
+                })
+                .OrderBy(row => row["fullPath"]?.ToString(), StringComparer.Ordinal)
+                .ThenBy(row => row["kind"]?.ToString(), StringComparer.Ordinal)
+                .ToList();
+
+            return Task.FromResult(new FileFormatReadResult
+            {
+                Success = true,
+                Payload = rows
+            });
+        }
+        catch (Exception exception)
+        {
+            return Task.FromResult(new FileFormatReadResult
+            {
+                Success = false,
+                Error = exception.Message
+            });
+        }
+    }
+}
+
+public interface IIsoEntryReader
+{
+    IReadOnlyCollection<IsoEntryInfo> ReadEntries(Stream source);
+}
+
+public sealed record IsoEntryInfo(
+    string Path,
+    bool IsDirectory,
+    long SizeBytes,
+    DateTime? ModifiedUtc);
+
+public sealed class DiscUtilsIsoEntryReader : IIsoEntryReader
+{
+    public IReadOnlyCollection<IsoEntryInfo> ReadEntries(Stream source)
+    {
+        using var reader = new CDReader(source, joliet: true);
+        var entries = new List<IsoEntryInfo>();
+        TraverseDirectory(reader, path: string.Empty, entries);
+        return entries;
+    }
+
+    private static void TraverseDirectory(CDReader reader, string path, List<IsoEntryInfo> entries)
+    {
+        foreach (var directory in reader.GetDirectories(path))
+        {
+            var normalized = directory.Replace('\\', '/');
+            entries.Add(new IsoEntryInfo(normalized, IsDirectory: true, SizeBytes: 0, ModifiedUtc: null));
+            TraverseDirectory(reader, normalized, entries);
+        }
+
+        foreach (var file in reader.GetFiles(path))
+        {
+            var normalized = file.Replace('\\', '/');
+            entries.Add(new IsoEntryInfo(
+                normalized,
+                IsDirectory: false,
+                SizeBytes: reader.GetFileLength(normalized),
+                ModifiedUtc: reader.GetLastWriteTimeUtc(normalized)));
+        }
+    }
+}

--- a/Plugins/samples/SkyCD.Plugin.Sample.Iso/SkyCD.Plugin.Sample.Iso.csproj
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Iso/SkyCD.Plugin.Sample.Iso.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DiscUtils.Iso9660" Version="0.16.13" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Plugins/samples/SkyCD.Plugin.Sample.Iso/plugin.json
+++ b/Plugins/samples/SkyCD.Plugin.Sample.Iso/plugin.json
@@ -1,0 +1,9 @@
+{
+  "id": "skycd.plugin.sample.iso",
+  "version": "1.0.0",
+  "minHostVersion": "3.0.0",
+  "assembly": "SkyCD.Plugin.Sample.Iso.dll",
+  "capabilities": [
+    "file-format"
+  ]
+}

--- a/SkyCD.V3.slnx
+++ b/SkyCD.V3.slnx
@@ -5,6 +5,7 @@
     <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Cscd/SkyCD.Plugin.Legacy.Cscd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Legacy.Scd/SkyCD.Plugin.Legacy.Scd.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Csv/SkyCD.Plugin.Sample.Csv.csproj" />
+    <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Iso/SkyCD.Plugin.Sample.Iso.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Json/SkyCD.Plugin.Sample.Json.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj" />
     <Project Path="Plugins/samples/SkyCD.Plugin.Sample.Zip/SkyCD.Plugin.Sample.Zip.csproj" />

--- a/tests/SkyCD.Plugin.Host.Tests/IsoImageIndexPluginTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/IsoImageIndexPluginTests.cs
@@ -1,0 +1,83 @@
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Host;
+using SkyCD.Plugin.Host.FileFormats;
+using SkyCD.Plugin.Runtime.Discovery;
+using SkyCD.Plugin.Sample.Iso;
+
+namespace SkyCD.Plugin.Host.Tests;
+
+public class IsoImageIndexPluginTests
+{
+    [Fact]
+    public void OpenFormats_IncludeIso_ButSaveFormatsDoNot()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog(new FakeReader([])));
+
+        var openFormats = service.GetOpenFormats();
+        var saveFormats = service.GetSaveFormats();
+
+        Assert.Contains(openFormats, format => format.FormatId == "skycd-iso" && format.Extensions.Contains(".iso"));
+        Assert.DoesNotContain(saveFormats, format => format.FormatId == "skycd-iso");
+    }
+
+    [Fact]
+    public async Task WriteAsync_IsBlocked_ForReadOnlyIsoFormat()
+    {
+        var service = new FileFormatRoutingService(CreateCatalog(new FakeReader([])));
+        await using var target = new MemoryStream();
+
+        var exception = await Assert.ThrowsAsync<FileFormatRoutingException>(() => service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "skycd-iso",
+            Target = target,
+            Payload = new { }
+        }));
+
+        Assert.Contains("read-only", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReadAsync_ProjectsDirectoryTree_AndLargeFileMetadata()
+    {
+        var reader = new FakeReader(
+        [
+            new IsoEntryInfo("ROOT", IsDirectory: true, SizeBytes: 0, ModifiedUtc: null),
+            new IsoEntryInfo("ROOT/DEEP", IsDirectory: true, SizeBytes: 0, ModifiedUtc: null),
+            new IsoEntryInfo("ROOT/DEEP/MOVIE.MKV", IsDirectory: false, SizeBytes: 8589934592L, ModifiedUtc: new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc))
+        ]);
+        var service = new FileFormatRoutingService(CreateCatalog(reader));
+        await using var source = new MemoryStream([0x43, 0x44]); // fake stream for fixture reader
+
+        var result = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-iso",
+            Source = source
+        });
+
+        Assert.True(result.Success);
+        var rows = Assert.IsType<List<Dictionary<string, object?>>>(result.Payload);
+        Assert.Contains(rows, row => Equals(row["fullPath"], "ROOT/DEEP"));
+        Assert.Contains(rows, row => Equals(row["fullPath"], "ROOT/DEEP/MOVIE.MKV"));
+        Assert.Contains(rows, row => Equals(row["sizeBytes"], "8589934592"));
+    }
+
+    private static PluginCatalog CreateCatalog(IIsoEntryReader reader)
+    {
+        var plugin = new IsoImageIndexPlugin(reader);
+        var catalog = new PluginCatalog();
+        catalog.SetPlugins(
+        [
+            new DiscoveredPlugin
+            {
+                Plugin = plugin,
+                Capabilities = [plugin]
+            }
+        ]);
+        return catalog;
+    }
+
+    private sealed class FakeReader(IReadOnlyCollection<IsoEntryInfo> entries) : IIsoEntryReader
+    {
+        public IReadOnlyCollection<IsoEntryInfo> ReadEntries(Stream source) => entries;
+    }
+}

--- a/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
+++ b/tests/SkyCD.Plugin.Host.Tests/SkyCD.Plugin.Host.Tests.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Json\SkyCD.Plugin.Sample.Json.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Csv\SkyCD.Plugin.Sample.Csv.csproj" />
+    <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Iso\SkyCD.Plugin.Sample.Iso.csproj" />
     <ProjectReference Include="..\..\Plugins\samples\SkyCD.Plugin.Sample.Zip\SkyCD.Plugin.Sample.Zip.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds SkyCD.Plugin.Sample.Iso as a read-only .iso image indexing plugin. It enumerates ISO filesystem entries into hierarchy rows, maps available metadata (size + modified time), enforces read-only capability, and includes host routing tests for open/save filtering, write blocking, directory tree mapping, and large-image metadata behavior. Closes #85