### PR TITLE
docs(migration): track related format support tickets (#118)

### DIFF
--- a/docs/migration/related-format-support-tracker.md
+++ b/docs/migration/related-format-support-tracker.md
@@ -1,0 +1,28 @@
+# Related Format Support Tracker
+
+This file tracks v3 format-support tickets created from issue `#118` ("Add related file formats support").
+
+## Catalog formats
+
+- `#75` JSON (`*.json`) read/write
+- `#76` CSV (`*.csv`) read/write
+- `#77` XML (`*.xml`) read/write
+- `#78` YAML (`*.yaml`, `*.yml`) read/write
+- `#79` TOML (`*.toml`) read/write
+
+## Export formats
+
+- `#80` HTML export (`*.html`) write-only
+- `#81` Markdown export (`*.md`) write-only
+
+## Archive index import formats
+
+- `#82` ZIP (`*.zip`) read-only
+- `#83` 7z (`*.7z`) read-only
+- `#84` TAR/TAR.GZ (`*.tar`, `*.tar.gz`, `*.tgz`) read-only
+- `#85` ISO (`*.iso`) read-only
+
+## Notes
+
+- Tickets are grouped by behavior (read/write, write-only, read-only).
+- Detailed acceptance criteria and implementation status are managed per-ticket.


### PR DESCRIPTION
Adds a migration tracker document listing all per-format v3 issues created from #118 (catalog, export, and archive-index formats), so the meta ticket has an explicit artifact and references to concrete implementation tickets. Closes #118