### PR TITLE
Implement main window shell layout parity foundation

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml
+++ b/src/SkyCD.App/Views/MainWindow.axaml
@@ -7,44 +7,221 @@
         x:Class="SkyCD.App.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Icon="/Assets/avalonia-logo.ico"
-        Title="SkyCD v3">
+        MinWidth="700"
+        MinHeight="450"
+        Title="SkyCD">
 
     <Design.DataContext>
         <vm:MainWindowViewModel/>
     </Design.DataContext>
 
-    <Grid ColumnDefinitions="220,*" RowDefinitions="Auto,*,Auto">
-        <Border Grid.ColumnSpan="2" Background="#1e293b" Padding="14,10">
-            <TextBlock Text="SkyCD v3 Shell" Foreground="White" FontSize="18" FontWeight="SemiBold"/>
-        </Border>
+    <DockPanel LastChildFill="True">
+        <Menu DockPanel.Dock="Top">
+            <MenuItem Header="_File">
+                <MenuItem Header="_New" HotKey="Ctrl+N"/>
+                <Separator/>
+                <MenuItem Header="_Open..." HotKey="Ctrl+O"/>
+                <MenuItem Header="_Save" HotKey="Ctrl+S" IsEnabled="{Binding IsSaveEnabled}"/>
+                <MenuItem Header="Save _As..." HotKey="F12"/>
+                <Separator/>
+                <MenuItem Header="_Properties..."/>
+                <Separator/>
+                <MenuItem Header="E_xit"/>
+            </MenuItem>
+            <MenuItem Header="_Edit">
+                <MenuItem Header="_Add..." HotKey="F2"/>
+                <MenuItem Header="_Delete" HotKey="Delete"/>
+            </MenuItem>
+            <MenuItem Header="_View">
+                <MenuItem Header="Status _Bar"
+                          ToggleType="CheckBox"
+                          IsChecked="{Binding IsStatusBarVisible}"/>
+                <Separator/>
+                <MenuItem Header="_Tiles"
+                          Command="{Binding SetViewModeCommand}"
+                          CommandParameter="Tiles"
+                          ToggleType="CheckBox"
+                          IsChecked="{Binding IsTilesViewChecked}"/>
+                <MenuItem Header="Small _Icons"
+                          Command="{Binding SetViewModeCommand}"
+                          CommandParameter="SmallIcons"
+                          ToggleType="CheckBox"
+                          IsChecked="{Binding IsSmallIconsViewChecked}"/>
+                <MenuItem Header="L_arge Icons"
+                          Command="{Binding SetViewModeCommand}"
+                          CommandParameter="LargeIcons"
+                          ToggleType="CheckBox"
+                          IsChecked="{Binding IsLargeIconsViewChecked}"/>
+                <MenuItem Header="_List"
+                          Command="{Binding SetViewModeCommand}"
+                          CommandParameter="List"
+                          ToggleType="CheckBox"
+                          IsChecked="{Binding IsListViewChecked}"/>
+                <MenuItem Header="_Details"
+                          Command="{Binding SetViewModeCommand}"
+                          CommandParameter="Details"
+                          ToggleType="CheckBox"
+                          IsChecked="{Binding IsDetailsViewChecked}"/>
+                <Separator/>
+                <MenuItem Header="Arrange Icons By">
+                    <MenuItem Header="_Name"
+                              Command="{Binding SetSortModeCommand}"
+                              CommandParameter="Name"
+                              ToggleType="CheckBox"
+                              IsChecked="{Binding IsSortByNameChecked}"/>
+                    <MenuItem Header="_Type"
+                              Command="{Binding SetSortModeCommand}"
+                              CommandParameter="Type"
+                              ToggleType="CheckBox"
+                              IsChecked="{Binding IsSortByTypeChecked}"/>
+                </MenuItem>
+                <MenuItem Header="_Refresh" HotKey="F5" Command="{Binding RefreshCommand}"/>
+            </MenuItem>
+            <MenuItem Header="_Tools">
+                <MenuItem Header="_Options..."/>
+            </MenuItem>
+            <MenuItem Header="_Help">
+                <MenuItem Header="Project website in _SourceForge.NET"/>
+                <MenuItem Header="Project area in _GitHub"/>
+                <Separator/>
+                <MenuItem Header="_About..."/>
+            </MenuItem>
+        </Menu>
 
-        <Border Grid.Row="1" Background="#f1f5f9" Padding="12" BorderBrush="#cbd5e1" BorderThickness="0,0,1,0">
-            <StackPanel Spacing="8">
-                <TextBlock Text="Navigation" FontWeight="SemiBold"/>
-                <ListBox ItemsSource="{Binding NavigationItems}" SelectedItem="{Binding SelectedItem}">
-                    <ListBox.ItemTemplate>
-                        <DataTemplate x:DataType="vm:ShellNavigationItem">
-                            <TextBlock Text="{Binding Title}"/>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
+        <Border DockPanel.Dock="Top" BorderBrush="#D4D4D4" BorderThickness="0,0,0,1" Padding="6,4">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <Button Content="_New" MinWidth="60"/>
+                <Button Content="_Open" MinWidth="60"/>
+                <Button Content="_Save" MinWidth="60" IsEnabled="{Binding IsSaveEnabled}"/>
             </StackPanel>
         </Border>
 
-        <StackPanel Grid.Column="1" Grid.Row="1" Margin="18" Spacing="12">
-            <TextBlock Text="{Binding CurrentPageTitle}" FontSize="22" FontWeight="Bold"/>
-            <TextBlock Text="{Binding CurrentPageDescription}" FontSize="14" TextWrapping="Wrap"/>
-
-            <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,10,0,0">
-                <Button Content="Catalog" Command="{Binding NavigateCommand}" CommandParameter="catalog"/>
-                <Button Content="Plugins" Command="{Binding NavigateCommand}" CommandParameter="plugins"/>
-                <Button Content="Settings" Command="{Binding NavigateCommand}" CommandParameter="settings"/>
-            </StackPanel>
-        </StackPanel>
-
-        <Border Grid.Row="2" Grid.ColumnSpan="2" Background="#e2e8f0" Padding="10,8">
-            <TextBlock Text="Bootstrap shell for Avalonia + .NET 10 migration (Issue #61)." FontSize="12"/>
+        <Border DockPanel.Dock="Bottom"
+                IsVisible="{Binding IsStatusBarVisible}"
+                BorderBrush="#D4D4D4"
+                BorderThickness="1,1,0,0"
+                Padding="8,4">
+            <Grid ColumnDefinitions="*,Auto,120" ColumnSpacing="10">
+                <TextBlock Text="{Binding StatusText}" VerticalAlignment="Center"/>
+                <TextBlock Grid.Column="1"
+                           Text="{Binding ProgressText}"
+                           VerticalAlignment="Center"
+                           IsVisible="{Binding IsProgressVisible}"/>
+                <ProgressBar Grid.Column="2"
+                             Minimum="0"
+                             Maximum="100"
+                             Value="{Binding ProgressValue}"
+                             IsVisible="{Binding IsProgressVisible}"/>
+            </Grid>
         </Border>
-    </Grid>
+
+        <Grid ColumnDefinitions="220,3,*" RowDefinitions="*">
+            <TreeView Grid.Column="0"
+                      ItemsSource="{Binding TreeNodes}"
+                      SelectedItem="{Binding SelectedTreeNode}">
+                <TreeView.ItemTemplate>
+                    <TreeDataTemplate x:DataType="vm:BrowserTreeNode" ItemsSource="{Binding Children}">
+                        <TextBlock Text="{Binding Title}"/>
+                    </TreeDataTemplate>
+                </TreeView.ItemTemplate>
+                <TreeView.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="_Expand"/>
+                        <MenuItem Header="C_ollapse"/>
+                        <Separator/>
+                        <MenuItem Header="_View">
+                            <MenuItem Header="Small _Icons"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="SmallIcons"/>
+                            <MenuItem Header="L_arge Icons"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="LargeIcons"/>
+                            <MenuItem Header="_List"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="List"/>
+                            <MenuItem Header="_Details"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="Details"/>
+                            <MenuItem Header="_Tiles"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="Tiles"/>
+                        </MenuItem>
+                        <Separator/>
+                        <MenuItem Header="Arrange Icons By">
+                            <MenuItem Header="_Name"
+                                      Command="{Binding SetSortModeCommand}"
+                                      CommandParameter="Name"/>
+                            <MenuItem Header="_Type"
+                                      Command="{Binding SetSortModeCommand}"
+                                      CommandParameter="Type"/>
+                        </MenuItem>
+                        <MenuItem Header="_Refresh" Command="{Binding RefreshCommand}"/>
+                        <Separator/>
+                        <MenuItem Header="_Add..."/>
+                        <MenuItem Header="_Delete"/>
+                        <Separator/>
+                        <MenuItem Header="_Properties..."/>
+                    </ContextMenu>
+                </TreeView.ContextMenu>
+            </TreeView>
+
+            <GridSplitter Grid.Column="1"
+                          Width="3"
+                          ResizeDirection="Columns"
+                          Background="#CFCFCF"/>
+
+            <ListBox Grid.Column="2"
+                     ItemsSource="{Binding BrowserItems}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate x:DataType="vm:BrowserItem">
+                        <Grid ColumnDefinitions="*,150,120" Margin="4,2">
+                            <TextBlock Text="{Binding Name}"/>
+                            <TextBlock Grid.Column="1" Text="{Binding Type}"/>
+                            <TextBlock Grid.Column="2" Text="{Binding Size}" HorizontalAlignment="Right"/>
+                        </Grid>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+                <ListBox.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="_Expand"/>
+                        <MenuItem Header="C_ollapse"/>
+                        <Separator/>
+                        <MenuItem Header="_View">
+                            <MenuItem Header="Small _Icons"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="SmallIcons"/>
+                            <MenuItem Header="L_arge Icons"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="LargeIcons"/>
+                            <MenuItem Header="_List"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="List"/>
+                            <MenuItem Header="_Details"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="Details"/>
+                            <MenuItem Header="_Tiles"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="Tiles"/>
+                        </MenuItem>
+                        <Separator/>
+                        <MenuItem Header="Arrange Icons By">
+                            <MenuItem Header="_Name"
+                                      Command="{Binding SetSortModeCommand}"
+                                      CommandParameter="Name"/>
+                            <MenuItem Header="_Type"
+                                      Command="{Binding SetSortModeCommand}"
+                                      CommandParameter="Type"/>
+                        </MenuItem>
+                        <MenuItem Header="_Refresh" Command="{Binding RefreshCommand}"/>
+                        <Separator/>
+                        <MenuItem Header="_Add..."/>
+                        <MenuItem Header="_Delete"/>
+                        <Separator/>
+                        <MenuItem Header="_Properties..."/>
+                    </ContextMenu>
+                </ListBox.ContextMenu>
+            </ListBox>
+        </Grid>
+    </DockPanel>
 
 </Window>

--- a/src/SkyCD.Presentation/ViewModels/BrowserItem.cs
+++ b/src/SkyCD.Presentation/ViewModels/BrowserItem.cs
@@ -1,0 +1,3 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public sealed record BrowserItem(string Name, string Type, string Size);

--- a/src/SkyCD.Presentation/ViewModels/BrowserSortMode.cs
+++ b/src/SkyCD.Presentation/ViewModels/BrowserSortMode.cs
@@ -1,0 +1,7 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public enum BrowserSortMode
+{
+    Name,
+    Type
+}

--- a/src/SkyCD.Presentation/ViewModels/BrowserTreeNode.cs
+++ b/src/SkyCD.Presentation/ViewModels/BrowserTreeNode.cs
@@ -1,0 +1,9 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public sealed record BrowserTreeNode(string Key, string Title, IReadOnlyList<BrowserTreeNode> Children)
+{
+    public BrowserTreeNode(string key, string title)
+        : this(key, title, [])
+    {
+    }
+}

--- a/src/SkyCD.Presentation/ViewModels/BrowserViewMode.cs
+++ b/src/SkyCD.Presentation/ViewModels/BrowserViewMode.cs
@@ -1,0 +1,10 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public enum BrowserViewMode
+{
+    Tiles,
+    SmallIcons,
+    LargeIcons,
+    List,
+    Details
+}

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -5,42 +5,187 @@ namespace SkyCD.Presentation.ViewModels;
 
 public partial class MainWindowViewModel : ObservableObject
 {
+    private readonly IReadOnlyDictionary<string, IReadOnlyList<BrowserItem>> browserItemsByNodeKey;
+
     public MainWindowViewModel()
     {
-        NavigationItems =
+        var moviesNode = new BrowserTreeNode("movies", "Movies");
+        var musicNode = new BrowserTreeNode("music", "Music");
+        var projectsNode = new BrowserTreeNode("projects", "Projects");
+
+        TreeNodes =
         [
-            new ShellNavigationItem("catalog", "Catalog", "Browse and manage indexed collections."),
-            new ShellNavigationItem("plugins", "Plugins", "Inspect loaded plugins and capabilities."),
-            new ShellNavigationItem("settings", "Settings", "Configure application behavior.")
+            new BrowserTreeNode(
+                "library",
+                "Library",
+                [moviesNode, musicNode, projectsNode])
         ];
 
-        SelectedItem = NavigationItems[0];
+        browserItemsByNodeKey = new Dictionary<string, IReadOnlyList<BrowserItem>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["library"] =
+            [
+                new BrowserItem("Movies", "Folder", "128 items"),
+                new BrowserItem("Music", "Folder", "340 items"),
+                new BrowserItem("Projects", "Folder", "56 items")
+            ],
+            ["movies"] =
+            [
+                new BrowserItem("Interstellar.mkv", "Video", "12.1 GB"),
+                new BrowserItem("Arrival.mkv", "Video", "9.4 GB")
+            ],
+            ["music"] =
+            [
+                new BrowserItem("Classical Collection", "Folder", "42 items"),
+                new BrowserItem("Concert-2025.flac", "Audio", "414 MB")
+            ],
+            ["projects"] =
+            [
+                new BrowserItem("SkyCD v3", "Folder", "11 items"),
+                new BrowserItem("Plugin Benchmarks", "Folder", "6 items")
+            ]
+        };
+
+        SelectedTreeNode = TreeNodes[0];
+        RefreshBrowserItemsForSelection();
     }
 
-    public IReadOnlyList<ShellNavigationItem> NavigationItems { get; }
+    public IReadOnlyList<BrowserTreeNode> TreeNodes { get; }
+
+    public bool IsSaveEnabled => IsDirtyDocument;
+
+    public string ProgressText => $"{ProgressValue}%";
+
+    public bool IsTilesViewChecked => CurrentViewMode == BrowserViewMode.Tiles;
+
+    public bool IsSmallIconsViewChecked => CurrentViewMode == BrowserViewMode.SmallIcons;
+
+    public bool IsLargeIconsViewChecked => CurrentViewMode == BrowserViewMode.LargeIcons;
+
+    public bool IsListViewChecked => CurrentViewMode == BrowserViewMode.List;
+
+    public bool IsDetailsViewChecked => CurrentViewMode == BrowserViewMode.Details;
+
+    public bool IsSortByNameChecked => CurrentSortMode == BrowserSortMode.Name;
+
+    public bool IsSortByTypeChecked => CurrentSortMode == BrowserSortMode.Type;
 
     [ObservableProperty]
-    private ShellNavigationItem selectedItem;
+    private IReadOnlyList<BrowserItem> browserItems = [];
 
-    public string CurrentPageTitle => SelectedItem.Title;
+    [ObservableProperty]
+    private BrowserTreeNode? selectedTreeNode;
 
-    public string CurrentPageDescription => SelectedItem.Description;
+    [ObservableProperty]
+    private BrowserViewMode currentViewMode = BrowserViewMode.Details;
+
+    [ObservableProperty]
+    private BrowserSortMode currentSortMode = BrowserSortMode.Name;
+
+    [ObservableProperty]
+    private bool isStatusBarVisible = true;
+
+    [ObservableProperty]
+    private bool isDirtyDocument;
+
+    [ObservableProperty]
+    private string statusText = "Done.";
+
+    [ObservableProperty]
+    private bool isProgressVisible;
+
+    [ObservableProperty]
+    private int progressValue;
 
     [RelayCommand]
-    private void Navigate(string key)
+    private void SetViewMode(string modeKey)
     {
-        var target = NavigationItems.FirstOrDefault(item =>
-            item.Key.Equals(key, StringComparison.OrdinalIgnoreCase));
-
-        if (target is not null)
+        if (Enum.TryParse<BrowserViewMode>(modeKey, true, out var mode))
         {
-            SelectedItem = target;
+            CurrentViewMode = mode;
+            StatusText = $"View mode: {GetViewModeDisplayName(mode)}.";
         }
     }
 
-    partial void OnSelectedItemChanged(ShellNavigationItem value)
+    [RelayCommand]
+    private void SetSortMode(string sortKey)
     {
-        OnPropertyChanged(nameof(CurrentPageTitle));
-        OnPropertyChanged(nameof(CurrentPageDescription));
+        if (Enum.TryParse<BrowserSortMode>(sortKey, true, out var sortMode))
+        {
+            CurrentSortMode = sortMode;
+            RefreshBrowserItemsForSelection();
+            StatusText = $"Arrange icons by: {sortMode}.";
+        }
+    }
+
+    [RelayCommand]
+    private void ToggleStatusBar()
+    {
+        IsStatusBarVisible = !IsStatusBarVisible;
+    }
+
+    [RelayCommand]
+    private void Refresh()
+    {
+        RefreshBrowserItemsForSelection();
+        StatusText = "Done.";
+    }
+
+    private static string GetViewModeDisplayName(BrowserViewMode viewMode)
+    {
+        return viewMode switch
+        {
+            BrowserViewMode.SmallIcons => "Small Icons",
+            BrowserViewMode.LargeIcons => "Large Icons",
+            _ => viewMode.ToString()
+        };
+    }
+
+    private void RefreshBrowserItemsForSelection()
+    {
+        var nodeKey = SelectedTreeNode?.Key ?? "library";
+        if (!browserItemsByNodeKey.TryGetValue(nodeKey, out var items))
+        {
+            BrowserItems = [];
+            return;
+        }
+
+        BrowserItems = CurrentSortMode switch
+        {
+            BrowserSortMode.Type => items.OrderBy(static item => item.Type)
+                .ThenBy(static item => item.Name, StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
+            _ => items.OrderBy(static item => item.Name, StringComparer.OrdinalIgnoreCase).ToArray()
+        };
+    }
+
+    partial void OnSelectedTreeNodeChanged(BrowserTreeNode? value)
+    {
+        RefreshBrowserItemsForSelection();
+    }
+
+    partial void OnCurrentViewModeChanged(BrowserViewMode value)
+    {
+        OnPropertyChanged(nameof(IsTilesViewChecked));
+        OnPropertyChanged(nameof(IsSmallIconsViewChecked));
+        OnPropertyChanged(nameof(IsLargeIconsViewChecked));
+        OnPropertyChanged(nameof(IsListViewChecked));
+        OnPropertyChanged(nameof(IsDetailsViewChecked));
+    }
+
+    partial void OnCurrentSortModeChanged(BrowserSortMode value)
+    {
+        OnPropertyChanged(nameof(IsSortByNameChecked));
+        OnPropertyChanged(nameof(IsSortByTypeChecked));
+    }
+
+    partial void OnIsDirtyDocumentChanged(bool value)
+    {
+        OnPropertyChanged(nameof(IsSaveEnabled));
+    }
+
+    partial void OnProgressValueChanged(int value)
+    {
+        OnPropertyChanged(nameof(ProgressText));
     }
 }

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -5,22 +5,49 @@ namespace SkyCD.App.Tests;
 public class MainWindowViewModelTests
 {
     [Fact]
-    public void Constructor_SelectsCatalogByDefault()
+    public void Constructor_InitializesLegacyShellDefaults()
     {
         var vm = new MainWindowViewModel();
 
-        Assert.Equal("Catalog", vm.CurrentPageTitle);
-        Assert.Equal("catalog", vm.SelectedItem.Key);
+        Assert.True(vm.IsStatusBarVisible);
+        Assert.Equal("Done.", vm.StatusText);
+        Assert.Equal(BrowserViewMode.Details, vm.CurrentViewMode);
+        Assert.Equal(BrowserSortMode.Name, vm.CurrentSortMode);
+        Assert.Equal("library", vm.SelectedTreeNode?.Key);
+        Assert.NotEmpty(vm.BrowserItems);
     }
 
     [Fact]
-    public void NavigateCommand_ChangesSelectedPage()
+    public void SetViewModeCommand_UpdatesModeAndCheckedState()
     {
         var vm = new MainWindowViewModel();
 
-        vm.NavigateCommand.Execute("plugins");
+        vm.SetViewModeCommand.Execute("Tiles");
 
-        Assert.Equal("Plugins", vm.CurrentPageTitle);
-        Assert.Equal("plugins", vm.SelectedItem.Key);
+        Assert.Equal(BrowserViewMode.Tiles, vm.CurrentViewMode);
+        Assert.True(vm.IsTilesViewChecked);
+        Assert.False(vm.IsDetailsViewChecked);
+    }
+
+    [Fact]
+    public void ToggleStatusBarCommand_ChangesVisibility()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.ToggleStatusBarCommand.Execute(null);
+
+        Assert.False(vm.IsStatusBarVisible);
+    }
+
+    [Fact]
+    public void SetSortModeCommand_AppliesRequestedSortMode()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.SetSortModeCommand.Execute("Type");
+
+        Assert.Equal(BrowserSortMode.Type, vm.CurrentSortMode);
+        Assert.True(vm.IsSortByTypeChecked);
+        Assert.False(vm.IsSortByNameChecked);
     }
 }


### PR DESCRIPTION
## Summary
Replaces the placeholder Avalonia bootstrap shell with a legacy-structured main window foundation.

## What changed
- Rebuilt MainWindow.axaml with:
  - top menu region (File/Edit/View/Tools/Help)
  - file toolbar region
  - split workspace (tree left, list right) with resizable splitter
  - bottom status bar region with progress indicators
  - context menu scaffolding for tree/list interactions
- Reworked MainWindowViewModel to expose shell state and commands for:
  - view mode toggles
  - sort mode toggles
  - status bar visibility
  - refresh behavior
  - workspace sample node/item data and synchronization
- Added supporting presentation models/enums for tree/list/view/sort state.
- Updated MainWindowViewModel tests for the new shell defaults and command behaviors.

## Verification
- dotnet build src/SkyCD.App/SkyCD.App.csproj
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj

Closes #130
Part of #129