### PR TITLE
Implement file toolbar parity with icon+text actions

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml
+++ b/src/SkyCD.App/Views/MainWindow.axaml
@@ -88,11 +88,26 @@
             </MenuItem>
         </Menu>
 
-        <Border DockPanel.Dock="Top" BorderBrush="#D4D4D4" BorderThickness="0,0,0,1" Padding="6,4">
+        <Border DockPanel.Dock="Top" BorderBrush="#D4D4D4" BorderThickness="0,0,0,1" Padding="4,3">
             <StackPanel Orientation="Horizontal" Spacing="8">
-                <Button Content="_New" MinWidth="60" Command="{Binding NewCatalogCommand}"/>
-                <Button Content="_Open" MinWidth="60" Command="{Binding OpenCatalogCommand}"/>
-                <Button Content="_Save" MinWidth="60" Command="{Binding SaveCatalogCommand}"/>
+                <Button MinWidth="68" Padding="8,3" Command="{Binding NewCatalogCommand}">
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                        <PathIcon Width="14" Height="14" Data="M2,1 H8 L12,5 V15 H2 Z M8,1 V5 H12 M4,9 H10 M4,12 H10"/>
+                        <TextBlock Text="_New"/>
+                    </StackPanel>
+                </Button>
+                <Button MinWidth="68" Padding="8,3" Command="{Binding OpenCatalogCommand}">
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                        <PathIcon Width="14" Height="14" Data="M1,5 H6 L7.5,3 H15 V13 H1 Z M1,7 H15"/>
+                        <TextBlock Text="_Open"/>
+                    </StackPanel>
+                </Button>
+                <Button MinWidth="68" Padding="8,3" Command="{Binding SaveCatalogCommand}">
+                    <StackPanel Orientation="Horizontal" Spacing="5">
+                        <PathIcon Width="14" Height="14" Data="M2,1 H12 L15,4 V15 H2 Z M4,1 V6 H10 V1 M5,11 H12"/>
+                        <TextBlock Text="_Save"/>
+                    </StackPanel>
+                </Button>
             </StackPanel>
         </Border>
 


### PR DESCRIPTION
## Summary
Implements legacy-style file toolbar parity under the main menu with icon+text New/Open/Save actions and command-state wiring.

## What changed
- Wired File menu New/Open/Save items to shared ViewModel commands.
- Added shared file commands in MainWindowViewModel:
  - NewFileCommand
  - OpenFileCommand
  - SaveFileCommand (enabled only when dirty)
- Hooked command state updates so Save availability tracks dirty/clean transitions.
- Replaced plain text toolbar buttons with icon+text buttons for New/Open/Save.
- Bound toolbar buttons to the same commands as menu items, so behavior stays consistent.
- Added tests covering dirty-state and Save enable/disable transitions.

## Verification
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj
- dotnet build src/SkyCD.App/SkyCD.App.csproj

Closes #132
Part of #129