### PR TITLE
Implement tree/list workspace parity with splitter sync and icons

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml
+++ b/src/SkyCD.App/Views/MainWindow.axaml
@@ -130,13 +130,17 @@
             </Grid>
         </Border>
 
-        <Grid ColumnDefinitions="220,3,*" RowDefinitions="*">
+        <Grid ColumnDefinitions="220,4,*" RowDefinitions="*">
             <TreeView Grid.Column="0"
+                      MinWidth="160"
                       ItemsSource="{Binding TreeNodes}"
                       SelectedItem="{Binding SelectedTreeNode}">
                 <TreeView.ItemTemplate>
                     <TreeDataTemplate x:DataType="vm:BrowserTreeNode" ItemsSource="{Binding Children}">
-                        <TextBlock Text="{Binding Title}"/>
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <TextBlock Text="{Binding IconGlyph}"/>
+                            <TextBlock Text="{Binding Title}"/>
+                        </StackPanel>
                     </TreeDataTemplate>
                 </TreeView.ItemTemplate>
                 <TreeView.ContextMenu>
@@ -181,19 +185,22 @@
             </TreeView>
 
             <GridSplitter Grid.Column="1"
-                          Width="3"
+                          Width="4"
                           ResizeDirection="Columns"
-                          Background="#CFCFCF"/>
+                          Background="#CFCFCF"
+                          ShowsPreview="True"/>
 
             <ListBox Grid.Column="2"
+                     MinWidth="240"
                      ItemsSource="{Binding BrowserItems}"
                      SelectedItem="{Binding SelectedBrowserItem}">
                 <ListBox.ItemTemplate>
                     <DataTemplate x:DataType="vm:BrowserItem">
-                        <Grid ColumnDefinitions="*,150,120" Margin="4,2">
-                            <TextBlock Text="{Binding Name}"/>
-                            <TextBlock Grid.Column="1" Text="{Binding Type}"/>
-                            <TextBlock Grid.Column="2" Text="{Binding Size}" HorizontalAlignment="Right"/>
+                        <Grid ColumnDefinitions="24,*,150,120" Margin="4,2">
+                            <TextBlock Text="{Binding IconGlyph}"/>
+                            <TextBlock Grid.Column="1" Text="{Binding Name}"/>
+                            <TextBlock Grid.Column="2" Text="{Binding Type}"/>
+                            <TextBlock Grid.Column="3" Text="{Binding Size}" HorizontalAlignment="Right"/>
                         </Grid>
                     </DataTemplate>
                 </ListBox.ItemTemplate>

--- a/src/SkyCD.Presentation/ViewModels/BrowserItem.cs
+++ b/src/SkyCD.Presentation/ViewModels/BrowserItem.cs
@@ -1,3 +1,3 @@
 namespace SkyCD.Presentation.ViewModels;
 
-public sealed record BrowserItem(string Name, string Type, string Size);
+public sealed record BrowserItem(string Name, string Type, string Size, string IconGlyph);

--- a/src/SkyCD.Presentation/ViewModels/BrowserTreeNode.cs
+++ b/src/SkyCD.Presentation/ViewModels/BrowserTreeNode.cs
@@ -1,9 +1,13 @@
 namespace SkyCD.Presentation.ViewModels;
 
-public sealed record BrowserTreeNode(string Key, string Title, IReadOnlyList<BrowserTreeNode> Children)
+public sealed record BrowserTreeNode(
+    string Key,
+    string Title,
+    string IconGlyph,
+    IReadOnlyList<BrowserTreeNode> Children)
 {
-    public BrowserTreeNode(string key, string title)
-        : this(key, title, [])
+    public BrowserTreeNode(string key, string title, string iconGlyph)
+        : this(key, title, iconGlyph, [])
     {
     }
 }

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -10,15 +10,16 @@ public partial class MainWindowViewModel : ObservableObject
 
     public MainWindowViewModel()
     {
-        var moviesNode = new BrowserTreeNode("movies", "Movies");
-        var musicNode = new BrowserTreeNode("music", "Music");
-        var projectsNode = new BrowserTreeNode("projects", "Projects");
+        var moviesNode = new BrowserTreeNode("movies", "Movies", "🎬");
+        var musicNode = new BrowserTreeNode("music", "Music", "🎵");
+        var projectsNode = new BrowserTreeNode("projects", "Projects", "🗂");
 
         TreeNodes =
         [
             new BrowserTreeNode(
                 "library",
                 "Library",
+                "📚",
                 [moviesNode, musicNode, projectsNode])
         ];
 
@@ -26,24 +27,24 @@ public partial class MainWindowViewModel : ObservableObject
         {
             ["library"] =
             [
-                new BrowserItem("Movies", "Folder", "128 items"),
-                new BrowserItem("Music", "Folder", "340 items"),
-                new BrowserItem("Projects", "Folder", "56 items")
+                new BrowserItem("Movies", "Folder", "128 items", "📁"),
+                new BrowserItem("Music", "Folder", "340 items", "📁"),
+                new BrowserItem("Projects", "Folder", "56 items", "📁")
             ],
             ["movies"] =
             [
-                new BrowserItem("Interstellar.mkv", "Video", "12.1 GB"),
-                new BrowserItem("Arrival.mkv", "Video", "9.4 GB")
+                new BrowserItem("Interstellar.mkv", "Video", "12.1 GB", "🎞"),
+                new BrowserItem("Arrival.mkv", "Video", "9.4 GB", "🎞")
             ],
             ["music"] =
             [
-                new BrowserItem("Classical Collection", "Folder", "42 items"),
-                new BrowserItem("Concert-2025.flac", "Audio", "414 MB")
+                new BrowserItem("Classical Collection", "Folder", "42 items", "📁"),
+                new BrowserItem("Concert-2025.flac", "Audio", "414 MB", "🎧")
             ],
             ["projects"] =
             [
-                new BrowserItem("SkyCD v3", "Folder", "11 items"),
-                new BrowserItem("Plugin Benchmarks", "Folder", "6 items")
+                new BrowserItem("SkyCD v3", "Folder", "11 items", "📁"),
+                new BrowserItem("Plugin Benchmarks", "Folder", "6 items", "📁")
             ]
         };
 
@@ -232,20 +233,27 @@ public partial class MainWindowViewModel : ObservableObject
 
     private void RefreshBrowserItemsForSelection()
     {
+        var previouslySelectedName = SelectedBrowserItem?.Name;
         var nodeKey = SelectedTreeNode?.Key ?? "library";
         if (!browserItemsByNodeKey.TryGetValue(nodeKey, out var items))
         {
             BrowserItems = [];
+            SelectedBrowserItem = null;
             return;
         }
 
-        BrowserItems = CurrentSortMode switch
+        var refreshedItems = CurrentSortMode switch
         {
             BrowserSortMode.Type => items.OrderBy(static item => item.Type)
                 .ThenBy(static item => item.Name, StringComparer.OrdinalIgnoreCase)
                 .ToArray(),
             _ => items.OrderBy(static item => item.Name, StringComparer.OrdinalIgnoreCase).ToArray()
         };
+
+        BrowserItems = refreshedItems;
+        SelectedBrowserItem = refreshedItems.FirstOrDefault(item =>
+                                 item.Name.Equals(previouslySelectedName, StringComparison.OrdinalIgnoreCase))
+                             ?? refreshedItems.FirstOrDefault();
     }
 
     partial void OnSelectedTreeNodeChanged(BrowserTreeNode? value)

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -12,11 +12,12 @@ public class MainWindowViewModelTests
         Assert.True(vm.IsStatusBarVisible);
         Assert.Equal("Done.", vm.StatusText);
         Assert.False(vm.IsSaveEnabled);
-        Assert.False(vm.IsDeleteEnabled);
+        Assert.True(vm.IsDeleteEnabled);
         Assert.Equal(BrowserViewMode.Details, vm.CurrentViewMode);
         Assert.Equal(BrowserSortMode.Name, vm.CurrentSortMode);
         Assert.Equal("library", vm.SelectedTreeNode?.Key);
         Assert.NotEmpty(vm.BrowserItems);
+        Assert.Equal(vm.BrowserItems[0], vm.SelectedBrowserItem);
     }
 
     [Fact]
@@ -76,6 +77,7 @@ public class MainWindowViewModelTests
     public void DeleteCommand_EnabledOnlyWhenItemIsSelected()
     {
         var vm = new MainWindowViewModel();
+        vm.SelectedBrowserItem = null;
 
         Assert.False(vm.DeleteItemCommand.CanExecute(null));
 
@@ -87,5 +89,28 @@ public class MainWindowViewModelTests
         vm.DeleteItemCommand.Execute(null);
 
         Assert.Equal($"Deleted {vm.BrowserItems[0].Name}.", vm.StatusText);
+    }
+
+    [Fact]
+    public void SelectingDifferentTreeNode_RefreshesListAndSelectsFirstItem()
+    {
+        var vm = new MainWindowViewModel();
+        var musicNode = vm.TreeNodes[0].Children.Single(node => node.Key == "music");
+
+        vm.SelectedTreeNode = musicNode;
+
+        Assert.NotEmpty(vm.BrowserItems);
+        Assert.Equal("music", vm.SelectedTreeNode?.Key);
+        Assert.Equal(vm.BrowserItems[0], vm.SelectedBrowserItem);
+    }
+
+    [Fact]
+    public void TreeAndListItems_ExposeIconGlyphs()
+    {
+        var vm = new MainWindowViewModel();
+
+        Assert.All(vm.TreeNodes, node => Assert.False(string.IsNullOrWhiteSpace(node.IconGlyph)));
+        Assert.All(vm.TreeNodes.SelectMany(node => node.Children), node => Assert.False(string.IsNullOrWhiteSpace(node.IconGlyph)));
+        Assert.All(vm.BrowserItems, item => Assert.False(string.IsNullOrWhiteSpace(item.IconGlyph)));
     }
 }


### PR DESCRIPTION
## Summary
Implements issue #133 by completing legacy-like tree/list workspace behavior in the main shell.

## What changed
- Kept split workspace and improved splitter usability:
  - widened splitter hit area (4px)
  - enabled splitter preview while resizing
  - set minimum widths for tree and list panes
- Added tree/list icon support:
  - BrowserTreeNode now carries IconGlyph
  - BrowserItem now carries IconGlyph
  - tree and list item templates now render icons next to labels
- Improved selection synchronization:
  - when tree selection or refresh changes list content, list selection now stays on matching item when possible
  - otherwise defaults to the first item
  - if list becomes empty, selected item is cleared
- Extended tests to cover:
  - first-item selection default behavior
  - selection sync on tree change
  - icon metadata presence for tree/list nodes

## Verification
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj
- dotnet build src/SkyCD.App/SkyCD.App.csproj

Closes #133
Part of #129