### PR TITLE
Implement list view mode and sort parity with synced check states

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml
+++ b/src/SkyCD.App/Views/MainWindow.axaml
@@ -151,28 +151,42 @@
                         <MenuItem Header="_View">
                             <MenuItem Header="Small _Icons"
                                       Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="SmallIcons"/>
+                                      CommandParameter="SmallIcons"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsSmallIconsViewChecked}"/>
                             <MenuItem Header="L_arge Icons"
                                       Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="LargeIcons"/>
+                                      CommandParameter="LargeIcons"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsLargeIconsViewChecked}"/>
                             <MenuItem Header="_List"
                                       Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="List"/>
+                                      CommandParameter="List"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsListViewChecked}"/>
                             <MenuItem Header="_Details"
                                       Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="Details"/>
+                                      CommandParameter="Details"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsDetailsViewChecked}"/>
                             <MenuItem Header="_Tiles"
                                       Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="Tiles"/>
+                                      CommandParameter="Tiles"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsTilesViewChecked}"/>
                         </MenuItem>
                         <Separator/>
                         <MenuItem Header="Arrange Icons By">
                             <MenuItem Header="_Name"
                                       Command="{Binding SetSortModeCommand}"
-                                      CommandParameter="Name"/>
+                                      CommandParameter="Name"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsSortByNameChecked}"/>
                             <MenuItem Header="_Type"
                                       Command="{Binding SetSortModeCommand}"
-                                      CommandParameter="Type"/>
+                                      CommandParameter="Type"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsSortByTypeChecked}"/>
                         </MenuItem>
                         <MenuItem Header="_Refresh" Command="{Binding RefreshCommand}"/>
                         <Separator/>
@@ -192,15 +206,21 @@
 
             <ListBox Grid.Column="2"
                      MinWidth="240"
+                     IsVisible="{Binding IsListLikeMode}"
                      ItemsSource="{Binding BrowserItems}"
                      SelectedItem="{Binding SelectedBrowserItem}">
                 <ListBox.ItemTemplate>
-                    <DataTemplate x:DataType="vm:BrowserItem">
+                    <DataTemplate>
                         <Grid ColumnDefinitions="24,*,150,120" Margin="4,2">
-                            <TextBlock Text="{Binding IconGlyph}"/>
+                            <TextBlock Text="{Binding IconGlyph}" FontSize="{Binding $parent[Window].DataContext.BrowserIconFontSize}"/>
                             <TextBlock Grid.Column="1" Text="{Binding Name}"/>
-                            <TextBlock Grid.Column="2" Text="{Binding Type}"/>
-                            <TextBlock Grid.Column="3" Text="{Binding Size}" HorizontalAlignment="Right"/>
+                            <TextBlock Grid.Column="2"
+                                       IsVisible="{Binding $parent[Window].DataContext.ShowDetailsColumns}"
+                                       Text="{Binding Type}"/>
+                            <TextBlock Grid.Column="3"
+                                       IsVisible="{Binding $parent[Window].DataContext.ShowDetailsColumns}"
+                                       Text="{Binding Size}"
+                                       HorizontalAlignment="Right"/>
                         </Grid>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
@@ -212,28 +232,129 @@
                         <MenuItem Header="_View">
                             <MenuItem Header="Small _Icons"
                                       Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="SmallIcons"/>
+                                      CommandParameter="SmallIcons"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsSmallIconsViewChecked}"/>
                             <MenuItem Header="L_arge Icons"
                                       Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="LargeIcons"/>
+                                      CommandParameter="LargeIcons"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsLargeIconsViewChecked}"/>
                             <MenuItem Header="_List"
                                       Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="List"/>
+                                      CommandParameter="List"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsListViewChecked}"/>
                             <MenuItem Header="_Details"
                                       Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="Details"/>
+                                      CommandParameter="Details"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsDetailsViewChecked}"/>
                             <MenuItem Header="_Tiles"
                                       Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="Tiles"/>
+                                      CommandParameter="Tiles"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsTilesViewChecked}"/>
                         </MenuItem>
                         <Separator/>
                         <MenuItem Header="Arrange Icons By">
                             <MenuItem Header="_Name"
                                       Command="{Binding SetSortModeCommand}"
-                                      CommandParameter="Name"/>
+                                      CommandParameter="Name"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsSortByNameChecked}"/>
                             <MenuItem Header="_Type"
                                       Command="{Binding SetSortModeCommand}"
-                                      CommandParameter="Type"/>
+                                      CommandParameter="Type"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsSortByTypeChecked}"/>
+                        </MenuItem>
+                        <MenuItem Header="_Refresh" Command="{Binding RefreshCommand}"/>
+                        <Separator/>
+                        <MenuItem Header="_Add..." Command="{Binding AddItemCommand}"/>
+                        <MenuItem Header="_Delete" Command="{Binding DeleteItemCommand}"/>
+                        <Separator/>
+                        <MenuItem Header="_Properties..." Command="{Binding OpenPropertiesCommand}"/>
+                    </ContextMenu>
+                </ListBox.ContextMenu>
+            </ListBox>
+
+            <ListBox Grid.Column="2"
+                     MinWidth="240"
+                     IsVisible="{Binding IsIconGridMode}"
+                     ItemsSource="{Binding BrowserItems}"
+                     SelectedItem="{Binding SelectedBrowserItem}">
+                <ListBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel Orientation="Horizontal"/>
+                    </ItemsPanelTemplate>
+                </ListBox.ItemsPanel>
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <Border Width="{Binding $parent[Window].DataContext.BrowserGridItemWidth}"
+                                Margin="6"
+                                Padding="8"
+                                BorderBrush="#D0D0D0"
+                                BorderThickness="1"
+                                CornerRadius="4">
+                            <StackPanel>
+                                <TextBlock Text="{Binding IconGlyph}"
+                                           FontSize="{Binding $parent[Window].DataContext.BrowserIconFontSize}"
+                                           HorizontalAlignment="Center"/>
+                                <TextBlock Text="{Binding Name}" TextAlignment="Center" TextWrapping="Wrap"/>
+                                <StackPanel Margin="0,4,0,0"
+                                            IsVisible="{Binding $parent[Window].DataContext.IsTilesMode}">
+                                    <TextBlock Text="{Binding Type}" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Size}" HorizontalAlignment="Center"/>
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+                <ListBox.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="_Expand"/>
+                        <MenuItem Header="C_ollapse"/>
+                        <Separator/>
+                        <MenuItem Header="_View">
+                            <MenuItem Header="Small _Icons"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="SmallIcons"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsSmallIconsViewChecked}"/>
+                            <MenuItem Header="L_arge Icons"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="LargeIcons"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsLargeIconsViewChecked}"/>
+                            <MenuItem Header="_List"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="List"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsListViewChecked}"/>
+                            <MenuItem Header="_Details"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="Details"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsDetailsViewChecked}"/>
+                            <MenuItem Header="_Tiles"
+                                      Command="{Binding SetViewModeCommand}"
+                                      CommandParameter="Tiles"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsTilesViewChecked}"/>
+                        </MenuItem>
+                        <Separator/>
+                        <MenuItem Header="Arrange Icons By">
+                            <MenuItem Header="_Name"
+                                      Command="{Binding SetSortModeCommand}"
+                                      CommandParameter="Name"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsSortByNameChecked}"/>
+                            <MenuItem Header="_Type"
+                                      Command="{Binding SetSortModeCommand}"
+                                      CommandParameter="Type"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsSortByTypeChecked}"/>
                         </MenuItem>
                         <MenuItem Header="_Refresh" Command="{Binding RefreshCommand}"/>
                         <Separator/>

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -74,6 +74,31 @@ public partial class MainWindowViewModel : ObservableObject
 
     public bool IsSortByTypeChecked => CurrentSortMode == BrowserSortMode.Type;
 
+    public bool IsIconGridMode =>
+        CurrentViewMode is BrowserViewMode.Tiles or BrowserViewMode.SmallIcons or BrowserViewMode.LargeIcons;
+
+    public bool IsListLikeMode => !IsIconGridMode;
+
+    public bool IsTilesMode => CurrentViewMode == BrowserViewMode.Tiles;
+
+    public double BrowserIconFontSize => CurrentViewMode switch
+    {
+        BrowserViewMode.SmallIcons => 14,
+        BrowserViewMode.LargeIcons => 24,
+        BrowserViewMode.Tiles => 20,
+        _ => 16
+    };
+
+    public double BrowserGridItemWidth => CurrentViewMode switch
+    {
+        BrowserViewMode.SmallIcons => 120,
+        BrowserViewMode.LargeIcons => 170,
+        BrowserViewMode.Tiles => 300,
+        _ => 220
+    };
+
+    public bool ShowDetailsColumns => CurrentViewMode == BrowserViewMode.Details;
+
     [ObservableProperty]
     private IReadOnlyList<BrowserItem> browserItems = [];
 
@@ -274,6 +299,12 @@ public partial class MainWindowViewModel : ObservableObject
         OnPropertyChanged(nameof(IsLargeIconsViewChecked));
         OnPropertyChanged(nameof(IsListViewChecked));
         OnPropertyChanged(nameof(IsDetailsViewChecked));
+        OnPropertyChanged(nameof(IsIconGridMode));
+        OnPropertyChanged(nameof(IsListLikeMode));
+        OnPropertyChanged(nameof(IsTilesMode));
+        OnPropertyChanged(nameof(BrowserIconFontSize));
+        OnPropertyChanged(nameof(BrowserGridItemWidth));
+        OnPropertyChanged(nameof(ShowDetailsColumns));
     }
 
     partial void OnCurrentSortModeChanged(BrowserSortMode value)

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -55,6 +55,48 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void SetSortModeCommand_ChangesCurrentListOrdering()
+    {
+        var vm = new MainWindowViewModel();
+        var musicNode = vm.TreeNodes[0].Children.Single(node => node.Key == "music");
+        vm.SelectedTreeNode = musicNode;
+
+        vm.SetSortModeCommand.Execute("Name");
+        var firstByName = vm.BrowserItems[0].Name;
+
+        vm.SetSortModeCommand.Execute("Type");
+        var firstByType = vm.BrowserItems[0].Name;
+
+        Assert.NotEqual(firstByName, firstByType);
+        Assert.Equal("Classical Collection", firstByName);
+        Assert.Equal("Concert-2025.flac", firstByType);
+    }
+
+    [Fact]
+    public void SetViewModeCommand_UpdatesDerivedLayoutFlags()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.SetViewModeCommand.Execute("LargeIcons");
+        Assert.True(vm.IsIconGridMode);
+        Assert.False(vm.IsListLikeMode);
+        Assert.False(vm.IsTilesMode);
+        Assert.Equal(24, vm.BrowserIconFontSize);
+
+        vm.SetViewModeCommand.Execute("Tiles");
+        Assert.True(vm.IsTilesMode);
+        Assert.True(vm.IsIconGridMode);
+        Assert.False(vm.IsListLikeMode);
+        Assert.Equal(300, vm.BrowserGridItemWidth);
+
+        vm.SetViewModeCommand.Execute("Details");
+        Assert.True(vm.IsDetailsViewChecked);
+        Assert.True(vm.IsListLikeMode);
+        Assert.False(vm.IsIconGridMode);
+        Assert.True(vm.ShowDetailsColumns);
+    }
+
+    [Fact]
     public void OpenThenSave_UpdatesSaveCommandState()
     {
         var vm = new MainWindowViewModel();


### PR DESCRIPTION
## Summary
Implements issue #134 on top of the #133 workspace branch by completing list view-mode/sort parity behavior and check-state synchronization.

## What changed
- Added stronger view-mode rendering behavior:
  - List/Details mode uses a row-style list view
  - Small/Large Icons/Tiles mode uses a grid/wrap layout
  - mode switch updates icon sizing and tile sizing immediately
  - Details mode shows type/size columns; List mode hides them
- Added checked-state synchronization across main menu and context menus:
  - view mode toggles now bind IsChecked in tree/list context menus
  - sort toggles now bind IsChecked in tree/list context menus
- Added derived ViewModel flags/properties used by rendering:
  - IsIconGridMode, IsListLikeMode, IsTilesMode
  - BrowserIconFontSize, BrowserGridItemWidth, ShowDetailsColumns
- Expanded tests for:
  - sort changing actual list ordering
  - derived layout flags updating with mode changes

## Acceptance criteria mapping
- Switching modes updates rendering immediately: implemented with list-vs-grid rendering and mode-driven sizing/visibility.
- Checked states remain mutually consistent: all menu/context toggles bind to same state properties.
- Sort option changes reflected in current ordering: verified by test using mixed-type list content.

## Verification
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj
- dotnet build src/SkyCD.App/SkyCD.App.csproj

Closes #134
Part of #129