### PR TITLE
Implement context menu parity for tree/list interactions

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml
+++ b/src/SkyCD.App/Views/MainWindow.axaml
@@ -135,6 +135,11 @@
                       MinWidth="160"
                       ItemsSource="{Binding TreeNodes}"
                       SelectedItem="{Binding SelectedTreeNode}">
+                <TreeView.Styles>
+                    <Style Selector="TreeViewItem" x:DataType="vm:BrowserTreeNode">
+                        <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
+                    </Style>
+                </TreeView.Styles>
                 <TreeView.ItemTemplate>
                     <TreeDataTemplate x:DataType="vm:BrowserTreeNode" ItemsSource="{Binding Children}">
                         <StackPanel Orientation="Horizontal" Spacing="6">
@@ -145,8 +150,8 @@
                 </TreeView.ItemTemplate>
                 <TreeView.ContextMenu>
                     <ContextMenu>
-                        <MenuItem Header="_Expand"/>
-                        <MenuItem Header="C_ollapse"/>
+                        <MenuItem Header="_Expand" Command="{Binding ExpandSelectionCommand}" CommandParameter="tree"/>
+                        <MenuItem Header="C_ollapse" Command="{Binding CollapseSelectionCommand}" CommandParameter="tree"/>
                         <Separator/>
                         <MenuItem Header="_View">
                             <MenuItem Header="Small _Icons"
@@ -313,8 +318,8 @@
                 </ListBox.ItemTemplate>
                 <ListBox.ContextMenu>
                     <ContextMenu>
-                        <MenuItem Header="_Expand"/>
-                        <MenuItem Header="C_ollapse"/>
+                        <MenuItem Header="_Expand" Command="{Binding ExpandSelectionCommand}" CommandParameter="list"/>
+                        <MenuItem Header="C_ollapse" Command="{Binding CollapseSelectionCommand}" CommandParameter="list"/>
                         <Separator/>
                         <MenuItem Header="_View">
                             <MenuItem Header="Small _Icons"

--- a/src/SkyCD.Presentation/ViewModels/BrowserTreeNode.cs
+++ b/src/SkyCD.Presentation/ViewModels/BrowserTreeNode.cs
@@ -1,13 +1,31 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace SkyCD.Presentation.ViewModels;
 
-public sealed record BrowserTreeNode(
-    string Key,
-    string Title,
-    string IconGlyph,
-    IReadOnlyList<BrowserTreeNode> Children)
+public partial class BrowserTreeNode : ObservableObject
 {
+    public BrowserTreeNode(string key, string title, string iconGlyph, IReadOnlyList<BrowserTreeNode> children, bool isExpanded = false)
+    {
+        Key = key;
+        Title = title;
+        IconGlyph = iconGlyph;
+        Children = children;
+        this.isExpanded = isExpanded;
+    }
+
     public BrowserTreeNode(string key, string title, string iconGlyph)
-        : this(key, title, iconGlyph, [])
+        : this(key, title, iconGlyph, [], false)
     {
     }
+
+    public string Key { get; }
+
+    public string Title { get; }
+
+    public string IconGlyph { get; }
+
+    public IReadOnlyList<BrowserTreeNode> Children { get; }
+
+    [ObservableProperty]
+    private bool isExpanded;
 }

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -6,6 +6,8 @@ namespace SkyCD.Presentation.ViewModels;
 public partial class MainWindowViewModel : ObservableObject
 {
     private readonly IReadOnlyDictionary<string, IReadOnlyList<BrowserItem>> browserItemsByNodeKey;
+    private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByKey;
+    private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByTitle;
     private const string DefaultStatusText = "Done.";
 
     public MainWindowViewModel()
@@ -14,14 +16,21 @@ public partial class MainWindowViewModel : ObservableObject
         var musicNode = new BrowserTreeNode("music", "Music", "🎵");
         var projectsNode = new BrowserTreeNode("projects", "Projects", "🗂");
 
+        var libraryNode = new BrowserTreeNode(
+            "library",
+            "Library",
+            "📚",
+            [moviesNode, musicNode, projectsNode],
+            true);
+
         TreeNodes =
         [
-            new BrowserTreeNode(
-                "library",
-                "Library",
-                "📚",
-                [moviesNode, musicNode, projectsNode])
+            libraryNode
         ];
+
+        var allTreeNodes = FlattenNodes(TreeNodes).ToArray();
+        treeNodesByKey = allTreeNodes.ToDictionary(static node => node.Key, StringComparer.OrdinalIgnoreCase);
+        treeNodesByTitle = allTreeNodes.ToDictionary(static node => node.Title, StringComparer.OrdinalIgnoreCase);
 
         browserItemsByNodeKey = new Dictionary<string, IReadOnlyList<BrowserItem>>(StringComparer.OrdinalIgnoreCase)
         {
@@ -212,6 +221,32 @@ public partial class MainWindowViewModel : ObservableObject
         StatusText = "About dialog is not implemented yet.";
     }
 
+    [RelayCommand(CanExecute = nameof(CanExpandSelection))]
+    private void ExpandSelection(string? context)
+    {
+        if (!TryResolveContextNode(context, out var targetNode))
+        {
+            return;
+        }
+
+        targetNode.IsExpanded = true;
+        SelectedTreeNode = targetNode;
+        StatusText = $"Expanded {targetNode.Title}.";
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCollapseSelection))]
+    private void CollapseSelection(string? context)
+    {
+        if (!TryResolveContextNode(context, out var targetNode))
+        {
+            return;
+        }
+
+        targetNode.IsExpanded = false;
+        SelectedTreeNode = targetNode;
+        StatusText = $"Collapsed {targetNode.Title}.";
+    }
+
     [RelayCommand]
     private void SetViewMode(string modeKey)
     {
@@ -256,6 +291,67 @@ public partial class MainWindowViewModel : ObservableObject
         };
     }
 
+    private static IEnumerable<BrowserTreeNode> FlattenNodes(IEnumerable<BrowserTreeNode> roots)
+    {
+        foreach (var root in roots)
+        {
+            yield return root;
+            foreach (var child in FlattenNodes(root.Children))
+            {
+                yield return child;
+            }
+        }
+    }
+
+    private bool CanExpandSelection(string? context)
+    {
+        return TryResolveContextNode(context, out _);
+    }
+
+    private bool CanCollapseSelection(string? context)
+    {
+        return TryResolveContextNode(context, out _);
+    }
+
+    private bool TryResolveContextNode(string? context, out BrowserTreeNode targetNode)
+    {
+        if (string.Equals(context, "list", StringComparison.OrdinalIgnoreCase) &&
+            TryResolveNodeFromBrowserSelection(out targetNode))
+        {
+            return true;
+        }
+
+        if (SelectedTreeNode is not null)
+        {
+            targetNode = SelectedTreeNode;
+            return true;
+        }
+
+        return TryResolveNodeFromBrowserSelection(out targetNode);
+    }
+
+    private bool TryResolveNodeFromBrowserSelection(out BrowserTreeNode targetNode)
+    {
+        if (SelectedBrowserItem is not null &&
+            SelectedBrowserItem.Type.Equals("Folder", StringComparison.OrdinalIgnoreCase))
+        {
+            if (treeNodesByTitle.TryGetValue(SelectedBrowserItem.Name, out targetNode))
+            {
+                return true;
+            }
+
+            var normalizedKey = SelectedBrowserItem.Name.Replace(" ", string.Empty, StringComparison.Ordinal)
+                .ToLowerInvariant();
+            if (treeNodesByKey.TryGetValue(normalizedKey, out targetNode))
+            {
+                return true;
+            }
+        }
+
+        targetNode = null!;
+        return false;
+    }
+
     private void RefreshBrowserItemsForSelection()
     {
         var previouslySelectedName = SelectedBrowserItem?.Name;
@@ -284,12 +380,16 @@ public partial class MainWindowViewModel : ObservableObject
     partial void OnSelectedTreeNodeChanged(BrowserTreeNode? value)
     {
         RefreshBrowserItemsForSelection();
+        ExpandSelectionCommand.NotifyCanExecuteChanged();
+        CollapseSelectionCommand.NotifyCanExecuteChanged();
     }
 
     partial void OnSelectedBrowserItemChanged(BrowserItem? value)
     {
         OnPropertyChanged(nameof(IsDeleteEnabled));
         DeleteItemCommand.NotifyCanExecuteChanged();
+        ExpandSelectionCommand.NotifyCanExecuteChanged();
+        CollapseSelectionCommand.NotifyCanExecuteChanged();
     }
 
     partial void OnCurrentViewModeChanged(BrowserViewMode value)

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -97,6 +97,35 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void ExpandAndCollapseSelectionCommand_UpdatesSelectedTreeNodeExpansion()
+    {
+        var vm = new MainWindowViewModel();
+        var moviesNode = vm.TreeNodes[0].Children.Single(node => node.Key == "movies");
+        vm.SelectedTreeNode = moviesNode;
+
+        vm.ExpandSelectionCommand.Execute("tree");
+        Assert.True(moviesNode.IsExpanded);
+        Assert.Equal("movies", vm.SelectedTreeNode?.Key);
+
+        vm.CollapseSelectionCommand.Execute("tree");
+        Assert.False(moviesNode.IsExpanded);
+        Assert.Equal("movies", vm.SelectedTreeNode?.Key);
+    }
+
+    [Fact]
+    public void ExpandSelectionCommand_FromListContext_TargetsMatchingFolderNode()
+    {
+        var vm = new MainWindowViewModel();
+        var moviesFolder = vm.BrowserItems.Single(item => item.Name == "Movies");
+
+        vm.SelectedBrowserItem = moviesFolder;
+        vm.ExpandSelectionCommand.Execute("list");
+
+        Assert.Equal("movies", vm.SelectedTreeNode?.Key);
+        Assert.True(vm.SelectedTreeNode?.IsExpanded);
+    }
+
+    [Fact]
     public void OpenThenSave_UpdatesSaveCommandState()
     {
         var vm = new MainWindowViewModel();


### PR DESCRIPTION
## Summary
Implements issue #135 by wiring context menu behavior to match legacy tree/list interactions, including functional expand/collapse behavior.

## What changed
- Added context-specific expand/collapse commands:
  - ExpandSelectionCommand
  - CollapseSelectionCommand
- Wired tree/list context menu Expand/Collapse items to those commands with target parameters (	ree / list).
- Added node-level expansion state support:
  - converted BrowserTreeNode into an observable class
  - added IsExpanded property
  - bound TreeViewItem.IsExpanded to node expansion state
- Implemented target semantics:
  - tree context expands/collapses currently selected tree node
  - list context resolves selected folder item to matching tree node, selects it, and applies expand/collapse
- Kept View/Arrange/Refresh/Add/Delete/Properties context actions bound to the same handlers used elsewhere.
- Added tests for:
  - expanding/collapsing selected tree node
  - list-context expansion targeting matching folder node

## Verification
- dotnet build src/SkyCD.App/SkyCD.App.csproj
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj

Closes #135
Part of #129