### PR TITLE
Implement Add To List dialog parity with source workflows

### DIFF
--- a/src/SkyCD.App/Views/AddToListWindow.axaml
+++ b/src/SkyCD.App/Views/AddToListWindow.axaml
@@ -1,0 +1,85 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:SkyCD.Presentation.ViewModels;assembly=SkyCD.Presentation"
+        x:Class="SkyCD.App.Views.AddToListWindow"
+        x:DataType="vm:AddToListDialogViewModel"
+        Width="560"
+        Height="460"
+        MinWidth="520"
+        MinHeight="420"
+        WindowStartupLocation="CenterOwner"
+        Title="Add To List">
+
+    <Design.DataContext>
+        <vm:AddToListDialogViewModel/>
+    </Design.DataContext>
+
+    <Grid RowDefinitions="*,Auto" Margin="12">
+        <StackPanel Spacing="10">
+            <GroupBox Header="Source">
+                <StackPanel Margin="10" Spacing="8">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Button Content="From Media"
+                                Command="{Binding SelectSourceCommand}"
+                                CommandParameter="Media"/>
+                        <Button Content="From Folder"
+                                Command="{Binding SelectSourceCommand}"
+                                CommandParameter="Folder"/>
+                        <Button Content="From Internet"
+                                Command="{Binding SelectSourceCommand}"
+                                CommandParameter="Internet"/>
+                    </StackPanel>
+                    <TextBlock Text="Mode: Media" IsVisible="{Binding IsSourceMedia}"/>
+                    <TextBlock Text="Mode: Folder" IsVisible="{Binding IsSourceFolder}"/>
+                    <TextBlock Text="Mode: Internet" IsVisible="{Binding IsSourceInternet}"/>
+                </StackPanel>
+            </GroupBox>
+
+            <GroupBox Header="Options">
+                <StackPanel Margin="10" Spacing="8">
+                    <CheckBox Content="Include media info" IsChecked="{Binding IncludeMediaInfo}"/>
+                    <CheckBox Content="Include subfolders" IsChecked="{Binding IncludeSubfolders}"/>
+                    <CheckBox Content="Extended info" IsChecked="{Binding IncludeExtendedInfo}"/>
+                </StackPanel>
+            </GroupBox>
+
+            <GroupBox Header="Target Placement">
+                <StackPanel Margin="10" Spacing="8">
+                    <Button Content="Add to selected folder"
+                            HorizontalAlignment="Left"
+                            Command="{Binding SelectTargetCommand}"
+                            CommandParameter="SelectedFolder"/>
+                    <Button Content="Add as new media"
+                            HorizontalAlignment="Left"
+                            Command="{Binding SelectTargetCommand}"
+                            CommandParameter="NewMedia"/>
+                    <TextBlock Text="Target: Selected folder" IsVisible="{Binding IsTargetSelectedFolder}"/>
+                    <TextBlock Text="Target: New media" IsVisible="{Binding IsTargetNewMedia}"/>
+                </StackPanel>
+            </GroupBox>
+
+            <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="8">
+                <TextBlock Text="Media Name:" VerticalAlignment="Center"/>
+                <TextBox Grid.Column="1" Text="{Binding MediaName}"/>
+
+                <TextBlock Grid.Row="1" Text="{Binding SourceValueLabel}" VerticalAlignment="Center"/>
+                <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding SourceValue}"/>
+            </Grid>
+
+            <TextBlock Foreground="#B00020" Text="{Binding ValidationMessage}" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="1"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8"
+                    Margin="0,14,0,0">
+            <Button Content="OK"
+                    MinWidth="80"
+                    Command="{Binding ConfirmCommand}"/>
+            <Button Content="Cancel"
+                    MinWidth="80"
+                    Click="OnCancelClicked"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/SkyCD.App/Views/AddToListWindow.axaml.cs
+++ b/src/SkyCD.App/Views/AddToListWindow.axaml.cs
@@ -1,0 +1,44 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using SkyCD.Presentation.ViewModels;
+using System;
+
+namespace SkyCD.App.Views;
+
+public partial class AddToListWindow : Window
+{
+    public AddToListWindow()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (sender is not AddToListWindow window)
+        {
+            return;
+        }
+
+        if (window.DataContext is AddToListDialogViewModel vm)
+        {
+            vm.PropertyChanged -= OnViewModelPropertyChanged;
+            vm.PropertyChanged += OnViewModelPropertyChanged;
+        }
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (sender is AddToListDialogViewModel vm &&
+            e.PropertyName == nameof(AddToListDialogViewModel.DialogAccepted) &&
+            vm.DialogAccepted)
+        {
+            Close(true);
+        }
+    }
+
+    private void OnCancelClicked(object? sender, RoutedEventArgs e)
+    {
+        Close(false);
+    }
+}

--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -1,11 +1,51 @@
 using Avalonia.Controls;
+using SkyCD.Presentation.ViewModels;
+using System;
 
 namespace SkyCD.App.Views;
 
 public partial class MainWindow : Window
 {
+    private MainWindowViewModel? subscribedViewModel;
+
     public MainWindow()
     {
         InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (subscribedViewModel is not null)
+        {
+            subscribedViewModel.AddToListRequested -= OnAddToListRequested;
+        }
+
+        subscribedViewModel = DataContext as MainWindowViewModel;
+        if (subscribedViewModel is not null)
+        {
+            subscribedViewModel.AddToListRequested += OnAddToListRequested;
+        }
+    }
+
+    private async void OnAddToListRequested(object? sender, EventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel vm)
+        {
+            return;
+        }
+
+        var dialogVm = new AddToListDialogViewModel();
+        var dialog = new AddToListWindow
+        {
+            DataContext = dialogVm
+        };
+
+        var accepted = await dialog.ShowDialog<bool?>(this);
+        if (accepted == true)
+        {
+            vm.StatusText = "Done.";
+            vm.IsDirtyDocument = true;
+        }
     }
 }

--- a/src/SkyCD.Presentation/ViewModels/AddToListDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/AddToListDialogViewModel.cs
@@ -1,0 +1,132 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace SkyCD.Presentation.ViewModels;
+
+public partial class AddToListDialogViewModel : ObservableObject
+{
+    public AddToListDialogViewModel()
+    {
+        RecomputeValidation();
+    }
+
+    public bool CanConfirm => string.IsNullOrWhiteSpace(ValidationMessage);
+
+    public bool IsSourceMedia => SourceMode == AddToListSourceMode.Media;
+
+    public bool IsSourceFolder => SourceMode == AddToListSourceMode.Folder;
+
+    public bool IsSourceInternet => SourceMode == AddToListSourceMode.Internet;
+
+    public bool IsTargetSelectedFolder => TargetPlacement == AddToListTargetPlacement.SelectedFolder;
+
+    public bool IsTargetNewMedia => TargetPlacement == AddToListTargetPlacement.NewMedia;
+
+    [ObservableProperty]
+    private AddToListSourceMode sourceMode = AddToListSourceMode.Media;
+
+    [ObservableProperty]
+    private AddToListTargetPlacement targetPlacement = AddToListTargetPlacement.SelectedFolder;
+
+    [ObservableProperty]
+    private bool includeMediaInfo = true;
+
+    [ObservableProperty]
+    private bool includeSubfolders;
+
+    [ObservableProperty]
+    private bool includeExtendedInfo;
+
+    [ObservableProperty]
+    private string mediaName = string.Empty;
+
+    [ObservableProperty]
+    private string sourceValue = string.Empty;
+
+    [ObservableProperty]
+    private bool dialogAccepted;
+
+    [ObservableProperty]
+    private string? validationMessage;
+
+    public string SourceValueLabel => SourceMode == AddToListSourceMode.Internet ? "Address" : "Folder";
+
+    [RelayCommand(CanExecute = nameof(CanConfirm))]
+    private void Confirm()
+    {
+        DialogAccepted = true;
+    }
+
+    [RelayCommand]
+    private void SelectSource(string modeKey)
+    {
+        if (Enum.TryParse<AddToListSourceMode>(modeKey, true, out var mode))
+        {
+            SourceMode = mode;
+        }
+    }
+
+    [RelayCommand]
+    private void SelectTarget(string targetKey)
+    {
+        if (Enum.TryParse<AddToListTargetPlacement>(targetKey, true, out var target))
+        {
+            TargetPlacement = target;
+        }
+    }
+
+    partial void OnSourceModeChanged(AddToListSourceMode value)
+    {
+        RecomputeValidation();
+        OnPropertyChanged(nameof(SourceValueLabel));
+        OnPropertyChanged(nameof(IsSourceMedia));
+        OnPropertyChanged(nameof(IsSourceFolder));
+        OnPropertyChanged(nameof(IsSourceInternet));
+    }
+
+    partial void OnTargetPlacementChanged(AddToListTargetPlacement value)
+    {
+        RecomputeValidation();
+        OnPropertyChanged(nameof(IsTargetSelectedFolder));
+        OnPropertyChanged(nameof(IsTargetNewMedia));
+    }
+
+    partial void OnMediaNameChanged(string value)
+    {
+        RecomputeValidation();
+    }
+
+    partial void OnSourceValueChanged(string value)
+    {
+        RecomputeValidation();
+    }
+
+    private void RecomputeValidation()
+    {
+        ValidationMessage = GetValidationMessage();
+        ConfirmCommand.NotifyCanExecuteChanged();
+    }
+
+    private string? GetValidationMessage()
+    {
+        if (TargetPlacement == AddToListTargetPlacement.NewMedia &&
+            string.IsNullOrWhiteSpace(MediaName))
+        {
+            return "Media name is required when adding as new media.";
+        }
+
+        return SourceMode switch
+        {
+            AddToListSourceMode.Media => string.IsNullOrWhiteSpace(MediaName)
+                ? "Media name is required for media source."
+                : null,
+            AddToListSourceMode.Folder => string.IsNullOrWhiteSpace(SourceValue)
+                ? "Folder path is required for folder source."
+                : null,
+            AddToListSourceMode.Internet => string.IsNullOrWhiteSpace(SourceValue)
+                ? "Address is required for internet source."
+                : null,
+            _ => null
+        };
+    }
+}

--- a/src/SkyCD.Presentation/ViewModels/AddToListSourceMode.cs
+++ b/src/SkyCD.Presentation/ViewModels/AddToListSourceMode.cs
@@ -1,0 +1,8 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public enum AddToListSourceMode
+{
+    Media,
+    Folder,
+    Internet
+}

--- a/src/SkyCD.Presentation/ViewModels/AddToListTargetPlacement.cs
+++ b/src/SkyCD.Presentation/ViewModels/AddToListTargetPlacement.cs
@@ -1,0 +1,7 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public enum AddToListTargetPlacement
+{
+    SelectedFolder,
+    NewMedia
+}

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -13,6 +13,8 @@ public partial class MainWindowViewModel : ObservableObject
     private readonly List<int> progressTransitions = [];
     private const string DefaultStatusText = "Done.";
 
+    public event EventHandler? AddToListRequested;
+
     public MainWindowViewModel()
     {
         var moviesNode = new BrowserTreeNode("movies", "Movies", "🎬");
@@ -200,8 +202,7 @@ public partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private void AddItem()
     {
-        IsDirtyDocument = true;
-        StatusText = "Add dialog is not implemented yet.";
+        AddToListRequested?.Invoke(this, EventArgs.Empty);
     }
 
     [RelayCommand(CanExecute = nameof(IsDeleteEnabled))]

--- a/tests/SkyCD.App.Tests/AddToListDialogViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/AddToListDialogViewModelTests.cs
@@ -1,0 +1,76 @@
+using SkyCD.Presentation.ViewModels;
+
+namespace SkyCD.App.Tests;
+
+public class AddToListDialogViewModelTests
+{
+    [Fact]
+    public void MediaSource_RequiresMediaName()
+    {
+        var vm = new AddToListDialogViewModel
+        {
+            SourceMode = AddToListSourceMode.Media,
+            MediaName = ""
+        };
+
+        Assert.False(vm.CanConfirm);
+        Assert.Equal("Media name is required for media source.", vm.ValidationMessage);
+    }
+
+    [Fact]
+    public void FolderSource_RequiresFolderPath()
+    {
+        var vm = new AddToListDialogViewModel
+        {
+            SourceMode = AddToListSourceMode.Folder,
+            SourceValue = ""
+        };
+
+        Assert.False(vm.CanConfirm);
+        Assert.Equal("Folder path is required for folder source.", vm.ValidationMessage);
+    }
+
+    [Fact]
+    public void InternetSource_RequiresAddress()
+    {
+        var vm = new AddToListDialogViewModel
+        {
+            SourceMode = AddToListSourceMode.Internet,
+            SourceValue = ""
+        };
+
+        Assert.False(vm.CanConfirm);
+        Assert.Equal("Address is required for internet source.", vm.ValidationMessage);
+    }
+
+    [Fact]
+    public void NewMediaTarget_RequiresMediaNameForFolderFlow()
+    {
+        var vm = new AddToListDialogViewModel
+        {
+            SourceMode = AddToListSourceMode.Folder,
+            SourceValue = "C:\\Music",
+            TargetPlacement = AddToListTargetPlacement.NewMedia,
+            MediaName = ""
+        };
+
+        Assert.False(vm.CanConfirm);
+        Assert.Equal("Media name is required when adding as new media.", vm.ValidationMessage);
+    }
+
+    [Fact]
+    public void ValidFolderFlow_CanConfirmAndAccept()
+    {
+        var vm = new AddToListDialogViewModel
+        {
+            SourceMode = AddToListSourceMode.Folder,
+            SourceValue = "C:\\Music",
+            MediaName = "My Media",
+            TargetPlacement = AddToListTargetPlacement.NewMedia
+        };
+
+        Assert.True(vm.CanConfirm);
+        vm.ConfirmCommand.Execute(null);
+        Assert.True(vm.DialogAccepted);
+    }
+}

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -210,4 +210,16 @@ public class MainWindowViewModelTests
         Assert.Equal([0, 60, 100, 0], vm.ProgressTransitions);
         Assert.False(vm.IsProgressVisible);
     }
+
+    [Fact]
+    public void AddItemCommand_RaisesAddToListRequest()
+    {
+        var vm = new MainWindowViewModel();
+        var raised = false;
+        vm.AddToListRequested += (_, _) => raised = true;
+
+        vm.AddItemCommand.Execute(null);
+
+        Assert.True(raised);
+    }
 }


### PR DESCRIPTION
## Summary
Implements issue #137 by adding an Avalonia Add To List dialog with source workflow controls, options, target placement controls, and source-mode validation.

## What changed
- Added new Add To List dialog window:
  - src/SkyCD.App/Views/AddToListWindow.axaml
  - src/SkyCD.App/Views/AddToListWindow.axaml.cs
- Added presentation models for dialog behavior:
  - AddToListDialogViewModel
  - AddToListSourceMode (Media, Folder, Internet)
  - AddToListTargetPlacement (SelectedFolder, NewMedia)
- Implemented source workflow controls in dialog:
  - source buttons: From Media / From Folder / From Internet
  - include options: media info, subfolders, extended info
  - target placement actions: selected folder vs new media
  - inputs: media name + folder/address field
- Implemented OK validation rules per source mode:
  - Media source requires media name
  - Folder source requires folder path
  - Internet source requires address
  - New media target requires media name
- Wired invocation point from main shell:
  - MainWindowViewModel.AddItemCommand raises AddToListRequested
  - MainWindow listens for request and opens dialog
  - successful dialog result marks document dirty and returns status to Done
- Added tests:
  - new AddToListDialogViewModelTests for per-source validation and successful flows
  - MainWindowViewModelTests includes Add command request event test

## Verification
- dotnet build src/SkyCD.App/SkyCD.App.csproj
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj

Closes #137
Part of #129