### PR TITLE
Implement context menu parity for tree/list interactions

### DIFF
--- a/src/SkyCD.App/Views/AddToListWindow.axaml
+++ b/src/SkyCD.App/Views/AddToListWindow.axaml
@@ -1,0 +1,85 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:SkyCD.Presentation.ViewModels;assembly=SkyCD.Presentation"
+        x:Class="SkyCD.App.Views.AddToListWindow"
+        x:DataType="vm:AddToListDialogViewModel"
+        Width="560"
+        Height="460"
+        MinWidth="520"
+        MinHeight="420"
+        WindowStartupLocation="CenterOwner"
+        Title="Add To List">
+
+    <Design.DataContext>
+        <vm:AddToListDialogViewModel/>
+    </Design.DataContext>
+
+    <Grid RowDefinitions="*,Auto" Margin="12">
+        <StackPanel Spacing="10">
+            <GroupBox Header="Source">
+                <StackPanel Margin="10" Spacing="8">
+                    <StackPanel Orientation="Horizontal" Spacing="8">
+                        <Button Content="From Media"
+                                Command="{Binding SelectSourceCommand}"
+                                CommandParameter="Media"/>
+                        <Button Content="From Folder"
+                                Command="{Binding SelectSourceCommand}"
+                                CommandParameter="Folder"/>
+                        <Button Content="From Internet"
+                                Command="{Binding SelectSourceCommand}"
+                                CommandParameter="Internet"/>
+                    </StackPanel>
+                    <TextBlock Text="Mode: Media" IsVisible="{Binding IsSourceMedia}"/>
+                    <TextBlock Text="Mode: Folder" IsVisible="{Binding IsSourceFolder}"/>
+                    <TextBlock Text="Mode: Internet" IsVisible="{Binding IsSourceInternet}"/>
+                </StackPanel>
+            </GroupBox>
+
+            <GroupBox Header="Options">
+                <StackPanel Margin="10" Spacing="8">
+                    <CheckBox Content="Include media info" IsChecked="{Binding IncludeMediaInfo}"/>
+                    <CheckBox Content="Include subfolders" IsChecked="{Binding IncludeSubfolders}"/>
+                    <CheckBox Content="Extended info" IsChecked="{Binding IncludeExtendedInfo}"/>
+                </StackPanel>
+            </GroupBox>
+
+            <GroupBox Header="Target Placement">
+                <StackPanel Margin="10" Spacing="8">
+                    <Button Content="Add to selected folder"
+                            HorizontalAlignment="Left"
+                            Command="{Binding SelectTargetCommand}"
+                            CommandParameter="SelectedFolder"/>
+                    <Button Content="Add as new media"
+                            HorizontalAlignment="Left"
+                            Command="{Binding SelectTargetCommand}"
+                            CommandParameter="NewMedia"/>
+                    <TextBlock Text="Target: Selected folder" IsVisible="{Binding IsTargetSelectedFolder}"/>
+                    <TextBlock Text="Target: New media" IsVisible="{Binding IsTargetNewMedia}"/>
+                </StackPanel>
+            </GroupBox>
+
+            <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="8">
+                <TextBlock Text="Media Name:" VerticalAlignment="Center"/>
+                <TextBox Grid.Column="1" Text="{Binding MediaName}"/>
+
+                <TextBlock Grid.Row="1" Text="{Binding SourceValueLabel}" VerticalAlignment="Center"/>
+                <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding SourceValue}"/>
+            </Grid>
+
+            <TextBlock Foreground="#B00020" Text="{Binding ValidationMessage}" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="1"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8"
+                    Margin="0,14,0,0">
+            <Button Content="OK"
+                    MinWidth="80"
+                    Command="{Binding ConfirmCommand}"/>
+            <Button Content="Cancel"
+                    MinWidth="80"
+                    Click="OnCancelClicked"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/SkyCD.App/Views/AddToListWindow.axaml.cs
+++ b/src/SkyCD.App/Views/AddToListWindow.axaml.cs
@@ -1,0 +1,44 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using SkyCD.Presentation.ViewModels;
+using System;
+
+namespace SkyCD.App.Views;
+
+public partial class AddToListWindow : Window
+{
+    public AddToListWindow()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (sender is not AddToListWindow window)
+        {
+            return;
+        }
+
+        if (window.DataContext is AddToListDialogViewModel vm)
+        {
+            vm.PropertyChanged -= OnViewModelPropertyChanged;
+            vm.PropertyChanged += OnViewModelPropertyChanged;
+        }
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (sender is AddToListDialogViewModel vm &&
+            e.PropertyName == nameof(AddToListDialogViewModel.DialogAccepted) &&
+            vm.DialogAccepted)
+        {
+            Close(true);
+        }
+    }
+
+    private void OnCancelClicked(object? sender, RoutedEventArgs e)
+    {
+        Close(false);
+    }
+}

--- a/src/SkyCD.App/Views/MainWindow.axaml
+++ b/src/SkyCD.App/Views/MainWindow.axaml
@@ -135,6 +135,11 @@
                       MinWidth="160"
                       ItemsSource="{Binding TreeNodes}"
                       SelectedItem="{Binding SelectedTreeNode}">
+                <TreeView.Styles>
+                    <Style Selector="TreeViewItem" x:DataType="vm:BrowserTreeNode">
+                        <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
+                    </Style>
+                </TreeView.Styles>
                 <TreeView.ItemTemplate>
                     <TreeDataTemplate x:DataType="vm:BrowserTreeNode" ItemsSource="{Binding Children}">
                         <StackPanel Orientation="Horizontal" Spacing="6">
@@ -145,8 +150,8 @@
                 </TreeView.ItemTemplate>
                 <TreeView.ContextMenu>
                     <ContextMenu>
-                        <MenuItem Header="_Expand"/>
-                        <MenuItem Header="C_ollapse"/>
+                        <MenuItem Header="_Expand" Command="{Binding ExpandSelectionCommand}" CommandParameter="tree"/>
+                        <MenuItem Header="C_ollapse" Command="{Binding CollapseSelectionCommand}" CommandParameter="tree"/>
                         <Separator/>
                         <MenuItem Header="_View">
                             <MenuItem Header="Small _Icons"
@@ -313,8 +318,8 @@
                 </ListBox.ItemTemplate>
                 <ListBox.ContextMenu>
                     <ContextMenu>
-                        <MenuItem Header="_Expand"/>
-                        <MenuItem Header="C_ollapse"/>
+                        <MenuItem Header="_Expand" Command="{Binding ExpandSelectionCommand}" CommandParameter="list"/>
+                        <MenuItem Header="C_ollapse" Command="{Binding CollapseSelectionCommand}" CommandParameter="list"/>
                         <Separator/>
                         <MenuItem Header="_View">
                             <MenuItem Header="Small _Icons"

--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -1,11 +1,51 @@
 using Avalonia.Controls;
+using SkyCD.Presentation.ViewModels;
+using System;
 
 namespace SkyCD.App.Views;
 
 public partial class MainWindow : Window
 {
+    private MainWindowViewModel? subscribedViewModel;
+
     public MainWindow()
     {
         InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (subscribedViewModel is not null)
+        {
+            subscribedViewModel.AddToListRequested -= OnAddToListRequested;
+        }
+
+        subscribedViewModel = DataContext as MainWindowViewModel;
+        if (subscribedViewModel is not null)
+        {
+            subscribedViewModel.AddToListRequested += OnAddToListRequested;
+        }
+    }
+
+    private async void OnAddToListRequested(object? sender, EventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel vm)
+        {
+            return;
+        }
+
+        var dialogVm = new AddToListDialogViewModel();
+        var dialog = new AddToListWindow
+        {
+            DataContext = dialogVm
+        };
+
+        var accepted = await dialog.ShowDialog<bool?>(this);
+        if (accepted == true)
+        {
+            vm.StatusText = "Done.";
+            vm.IsDirtyDocument = true;
+        }
     }
 }

--- a/src/SkyCD.Presentation/ViewModels/AddToListDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/AddToListDialogViewModel.cs
@@ -1,0 +1,132 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace SkyCD.Presentation.ViewModels;
+
+public partial class AddToListDialogViewModel : ObservableObject
+{
+    public AddToListDialogViewModel()
+    {
+        RecomputeValidation();
+    }
+
+    public bool CanConfirm => string.IsNullOrWhiteSpace(ValidationMessage);
+
+    public bool IsSourceMedia => SourceMode == AddToListSourceMode.Media;
+
+    public bool IsSourceFolder => SourceMode == AddToListSourceMode.Folder;
+
+    public bool IsSourceInternet => SourceMode == AddToListSourceMode.Internet;
+
+    public bool IsTargetSelectedFolder => TargetPlacement == AddToListTargetPlacement.SelectedFolder;
+
+    public bool IsTargetNewMedia => TargetPlacement == AddToListTargetPlacement.NewMedia;
+
+    [ObservableProperty]
+    private AddToListSourceMode sourceMode = AddToListSourceMode.Media;
+
+    [ObservableProperty]
+    private AddToListTargetPlacement targetPlacement = AddToListTargetPlacement.SelectedFolder;
+
+    [ObservableProperty]
+    private bool includeMediaInfo = true;
+
+    [ObservableProperty]
+    private bool includeSubfolders;
+
+    [ObservableProperty]
+    private bool includeExtendedInfo;
+
+    [ObservableProperty]
+    private string mediaName = string.Empty;
+
+    [ObservableProperty]
+    private string sourceValue = string.Empty;
+
+    [ObservableProperty]
+    private bool dialogAccepted;
+
+    [ObservableProperty]
+    private string? validationMessage;
+
+    public string SourceValueLabel => SourceMode == AddToListSourceMode.Internet ? "Address" : "Folder";
+
+    [RelayCommand(CanExecute = nameof(CanConfirm))]
+    private void Confirm()
+    {
+        DialogAccepted = true;
+    }
+
+    [RelayCommand]
+    private void SelectSource(string modeKey)
+    {
+        if (Enum.TryParse<AddToListSourceMode>(modeKey, true, out var mode))
+        {
+            SourceMode = mode;
+        }
+    }
+
+    [RelayCommand]
+    private void SelectTarget(string targetKey)
+    {
+        if (Enum.TryParse<AddToListTargetPlacement>(targetKey, true, out var target))
+        {
+            TargetPlacement = target;
+        }
+    }
+
+    partial void OnSourceModeChanged(AddToListSourceMode value)
+    {
+        RecomputeValidation();
+        OnPropertyChanged(nameof(SourceValueLabel));
+        OnPropertyChanged(nameof(IsSourceMedia));
+        OnPropertyChanged(nameof(IsSourceFolder));
+        OnPropertyChanged(nameof(IsSourceInternet));
+    }
+
+    partial void OnTargetPlacementChanged(AddToListTargetPlacement value)
+    {
+        RecomputeValidation();
+        OnPropertyChanged(nameof(IsTargetSelectedFolder));
+        OnPropertyChanged(nameof(IsTargetNewMedia));
+    }
+
+    partial void OnMediaNameChanged(string value)
+    {
+        RecomputeValidation();
+    }
+
+    partial void OnSourceValueChanged(string value)
+    {
+        RecomputeValidation();
+    }
+
+    private void RecomputeValidation()
+    {
+        ValidationMessage = GetValidationMessage();
+        ConfirmCommand.NotifyCanExecuteChanged();
+    }
+
+    private string? GetValidationMessage()
+    {
+        if (TargetPlacement == AddToListTargetPlacement.NewMedia &&
+            string.IsNullOrWhiteSpace(MediaName))
+        {
+            return "Media name is required when adding as new media.";
+        }
+
+        return SourceMode switch
+        {
+            AddToListSourceMode.Media => string.IsNullOrWhiteSpace(MediaName)
+                ? "Media name is required for media source."
+                : null,
+            AddToListSourceMode.Folder => string.IsNullOrWhiteSpace(SourceValue)
+                ? "Folder path is required for folder source."
+                : null,
+            AddToListSourceMode.Internet => string.IsNullOrWhiteSpace(SourceValue)
+                ? "Address is required for internet source."
+                : null,
+            _ => null
+        };
+    }
+}

--- a/src/SkyCD.Presentation/ViewModels/AddToListSourceMode.cs
+++ b/src/SkyCD.Presentation/ViewModels/AddToListSourceMode.cs
@@ -1,0 +1,8 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public enum AddToListSourceMode
+{
+    Media,
+    Folder,
+    Internet
+}

--- a/src/SkyCD.Presentation/ViewModels/AddToListTargetPlacement.cs
+++ b/src/SkyCD.Presentation/ViewModels/AddToListTargetPlacement.cs
@@ -1,0 +1,7 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public enum AddToListTargetPlacement
+{
+    SelectedFolder,
+    NewMedia
+}

--- a/src/SkyCD.Presentation/ViewModels/BrowserTreeNode.cs
+++ b/src/SkyCD.Presentation/ViewModels/BrowserTreeNode.cs
@@ -1,13 +1,31 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace SkyCD.Presentation.ViewModels;
 
-public sealed record BrowserTreeNode(
-    string Key,
-    string Title,
-    string IconGlyph,
-    IReadOnlyList<BrowserTreeNode> Children)
+public partial class BrowserTreeNode : ObservableObject
 {
+    public BrowserTreeNode(string key, string title, string iconGlyph, IReadOnlyList<BrowserTreeNode> children, bool isExpanded = false)
+    {
+        Key = key;
+        Title = title;
+        IconGlyph = iconGlyph;
+        Children = children;
+        this.isExpanded = isExpanded;
+    }
+
     public BrowserTreeNode(string key, string title, string iconGlyph)
-        : this(key, title, iconGlyph, [])
+        : this(key, title, iconGlyph, [], false)
     {
     }
+
+    public string Key { get; }
+
+    public string Title { get; }
+
+    public string IconGlyph { get; }
+
+    public IReadOnlyList<BrowserTreeNode> Children { get; }
+
+    [ObservableProperty]
+    private bool isExpanded;
 }

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -6,6 +6,8 @@ namespace SkyCD.Presentation.ViewModels;
 public partial class MainWindowViewModel : ObservableObject
 {
     private readonly IReadOnlyDictionary<string, IReadOnlyList<BrowserItem>> browserItemsByNodeKey;
+    private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByKey;
+    private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByTitle;
     private const string DefaultStatusText = "Done.";
 
     public MainWindowViewModel()
@@ -14,14 +16,21 @@ public partial class MainWindowViewModel : ObservableObject
         var musicNode = new BrowserTreeNode("music", "Music", "🎵");
         var projectsNode = new BrowserTreeNode("projects", "Projects", "🗂");
 
+        var libraryNode = new BrowserTreeNode(
+            "library",
+            "Library",
+            "📚",
+            [moviesNode, musicNode, projectsNode],
+            true);
+
         TreeNodes =
         [
-            new BrowserTreeNode(
-                "library",
-                "Library",
-                "📚",
-                [moviesNode, musicNode, projectsNode])
+            libraryNode
         ];
+
+        var allTreeNodes = FlattenNodes(TreeNodes).ToArray();
+        treeNodesByKey = allTreeNodes.ToDictionary(static node => node.Key, StringComparer.OrdinalIgnoreCase);
+        treeNodesByTitle = allTreeNodes.ToDictionary(static node => node.Title, StringComparer.OrdinalIgnoreCase);
 
         browserItemsByNodeKey = new Dictionary<string, IReadOnlyList<BrowserItem>>(StringComparer.OrdinalIgnoreCase)
         {
@@ -212,6 +221,32 @@ public partial class MainWindowViewModel : ObservableObject
         StatusText = "About dialog is not implemented yet.";
     }
 
+    [RelayCommand(CanExecute = nameof(CanExpandSelection))]
+    private void ExpandSelection(string? context)
+    {
+        if (!TryResolveContextNode(context, out var targetNode))
+        {
+            return;
+        }
+
+        targetNode.IsExpanded = true;
+        SelectedTreeNode = targetNode;
+        StatusText = $"Expanded {targetNode.Title}.";
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCollapseSelection))]
+    private void CollapseSelection(string? context)
+    {
+        if (!TryResolveContextNode(context, out var targetNode))
+        {
+            return;
+        }
+
+        targetNode.IsExpanded = false;
+        SelectedTreeNode = targetNode;
+        StatusText = $"Collapsed {targetNode.Title}.";
+    }
+
     [RelayCommand]
     private void SetViewMode(string modeKey)
     {
@@ -256,6 +291,67 @@ public partial class MainWindowViewModel : ObservableObject
         };
     }
 
+    private static IEnumerable<BrowserTreeNode> FlattenNodes(IEnumerable<BrowserTreeNode> roots)
+    {
+        foreach (var root in roots)
+        {
+            yield return root;
+            foreach (var child in FlattenNodes(root.Children))
+            {
+                yield return child;
+            }
+        }
+    }
+
+    private bool CanExpandSelection(string? context)
+    {
+        return TryResolveContextNode(context, out _);
+    }
+
+    private bool CanCollapseSelection(string? context)
+    {
+        return TryResolveContextNode(context, out _);
+    }
+
+    private bool TryResolveContextNode(string? context, out BrowserTreeNode targetNode)
+    {
+        if (string.Equals(context, "list", StringComparison.OrdinalIgnoreCase) &&
+            TryResolveNodeFromBrowserSelection(out targetNode))
+        {
+            return true;
+        }
+
+        if (SelectedTreeNode is not null)
+        {
+            targetNode = SelectedTreeNode;
+            return true;
+        }
+
+        return TryResolveNodeFromBrowserSelection(out targetNode);
+    }
+
+    private bool TryResolveNodeFromBrowserSelection(out BrowserTreeNode targetNode)
+    {
+        if (SelectedBrowserItem is not null &&
+            SelectedBrowserItem.Type.Equals("Folder", StringComparison.OrdinalIgnoreCase))
+        {
+            if (treeNodesByTitle.TryGetValue(SelectedBrowserItem.Name, out targetNode))
+            {
+                return true;
+            }
+
+            var normalizedKey = SelectedBrowserItem.Name.Replace(" ", string.Empty, StringComparison.Ordinal)
+                .ToLowerInvariant();
+            if (treeNodesByKey.TryGetValue(normalizedKey, out targetNode))
+            {
+                return true;
+            }
+        }
+
+        targetNode = null!;
+        return false;
+    }
+
     private void RefreshBrowserItemsForSelection()
     {
         var previouslySelectedName = SelectedBrowserItem?.Name;
@@ -284,12 +380,16 @@ public partial class MainWindowViewModel : ObservableObject
     partial void OnSelectedTreeNodeChanged(BrowserTreeNode? value)
     {
         RefreshBrowserItemsForSelection();
+        ExpandSelectionCommand.NotifyCanExecuteChanged();
+        CollapseSelectionCommand.NotifyCanExecuteChanged();
     }
 
     partial void OnSelectedBrowserItemChanged(BrowserItem? value)
     {
         OnPropertyChanged(nameof(IsDeleteEnabled));
         DeleteItemCommand.NotifyCanExecuteChanged();
+        ExpandSelectionCommand.NotifyCanExecuteChanged();
+        CollapseSelectionCommand.NotifyCanExecuteChanged();
     }
 
     partial void OnCurrentViewModeChanged(BrowserViewMode value)

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -13,6 +13,8 @@ public partial class MainWindowViewModel : ObservableObject
     private readonly List<int> progressTransitions = [];
     private const string DefaultStatusText = "Done.";
 
+    public event EventHandler? AddToListRequested;
+
     public MainWindowViewModel()
     {
         var moviesNode = new BrowserTreeNode("movies", "Movies", "🎬");
@@ -200,8 +202,7 @@ public partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private void AddItem()
     {
-        IsDirtyDocument = true;
-        StatusText = "Add dialog is not implemented yet.";
+        AddToListRequested?.Invoke(this, EventArgs.Empty);
     }
 
     [RelayCommand(CanExecute = nameof(IsDeleteEnabled))]

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SkyCD.Presentation.ViewModels;
 
@@ -8,6 +9,8 @@ public partial class MainWindowViewModel : ObservableObject
     private readonly IReadOnlyDictionary<string, IReadOnlyList<BrowserItem>> browserItemsByNodeKey;
     private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByKey;
     private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByTitle;
+    private readonly List<string> statusTransitions = [];
+    private readonly List<int> progressTransitions = [];
     private const string DefaultStatusText = "Done.";
 
     public MainWindowViewModel()
@@ -108,6 +111,10 @@ public partial class MainWindowViewModel : ObservableObject
 
     public bool ShowDetailsColumns => CurrentViewMode == BrowserViewMode.Details;
 
+    public IReadOnlyList<string> StatusTransitions => statusTransitions;
+
+    public IReadOnlyList<int> ProgressTransitions => progressTransitions;
+
     [ObservableProperty]
     private IReadOnlyList<BrowserItem> browserItems = [];
 
@@ -148,22 +155,34 @@ public partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private void OpenCatalog()
     {
+        StartOperation("Loading catalog...");
+        SetProgress(35, "Parsing catalog...");
+        SetProgress(80, "Updating browser...");
+        CompleteOperation();
+
         IsDirtyDocument = true;
-        StatusText = "Opened catalog.";
     }
 
     [RelayCommand(CanExecute = nameof(IsSaveEnabled))]
     private void SaveCatalog()
     {
+        StartOperation("Saving catalog...");
+        SetProgress(40, "Parsing items...");
+        SetProgress(90, "Updating indexes...");
+        CompleteOperation();
+
         IsDirtyDocument = false;
-        StatusText = "Saved catalog.";
     }
 
     [RelayCommand]
     private void SaveCatalogAs()
     {
+        StartOperation("Saving catalog...");
+        SetProgress(50, "Parsing items...");
+        SetProgress(95, "Updating indexes...");
+        CompleteOperation();
+
         IsDirtyDocument = false;
-        StatusText = "Saved catalog as.";
     }
 
     [RelayCommand]
@@ -277,8 +296,10 @@ public partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private void Refresh()
     {
+        StartOperation("Updating view...");
+        SetProgress(60, "Parsing catalog...");
         RefreshBrowserItemsForSelection();
-        StatusText = DefaultStatusText;
+        CompleteOperation();
     }
 
     private static string GetViewModeDisplayName(BrowserViewMode viewMode)
@@ -313,7 +334,7 @@ public partial class MainWindowViewModel : ObservableObject
         return TryResolveContextNode(context, out _);
     }
 
-    private bool TryResolveContextNode(string? context, out BrowserTreeNode targetNode)
+    private bool TryResolveContextNode(string? context, [NotNullWhen(true)] out BrowserTreeNode? targetNode)
     {
         if (string.Equals(context, "list", StringComparison.OrdinalIgnoreCase) &&
             TryResolveNodeFromBrowserSelection(out targetNode))
@@ -330,7 +351,7 @@ public partial class MainWindowViewModel : ObservableObject
         return TryResolveNodeFromBrowserSelection(out targetNode);
     }
 
-    private bool TryResolveNodeFromBrowserSelection(out BrowserTreeNode targetNode)
+    private bool TryResolveNodeFromBrowserSelection([NotNullWhen(true)] out BrowserTreeNode? targetNode)
     {
         if (SelectedBrowserItem is not null &&
             SelectedBrowserItem.Type.Equals("Folder", StringComparison.OrdinalIgnoreCase))
@@ -348,7 +369,7 @@ public partial class MainWindowViewModel : ObservableObject
             }
         }
 
-        targetNode = null!;
+        targetNode = null;
         return false;
     }
 
@@ -382,6 +403,46 @@ public partial class MainWindowViewModel : ObservableObject
         RefreshBrowserItemsForSelection();
         ExpandSelectionCommand.NotifyCanExecuteChanged();
         CollapseSelectionCommand.NotifyCanExecuteChanged();
+    }
+
+    private void StartOperation(string initialStatus)
+    {
+        statusTransitions.Clear();
+        progressTransitions.Clear();
+        IsProgressVisible = true;
+        ProgressValue = 0;
+        TrackProgress(0);
+        SetStatus(initialStatus);
+    }
+
+    private void SetProgress(int value, string? status = null)
+    {
+        ProgressValue = Math.Clamp(value, 0, 100);
+        TrackProgress(ProgressValue);
+        if (!string.IsNullOrWhiteSpace(status))
+        {
+            SetStatus(status);
+        }
+    }
+
+    private void CompleteOperation()
+    {
+        SetProgress(100);
+        SetStatus(DefaultStatusText);
+        IsProgressVisible = false;
+        ProgressValue = 0;
+        TrackProgress(0);
+    }
+
+    private void SetStatus(string value)
+    {
+        StatusText = value;
+        statusTransitions.Add(value);
+    }
+
+    private void TrackProgress(int value)
+    {
+        progressTransitions.Add(value);
     }
 
     partial void OnSelectedBrowserItemChanged(BrowserItem? value)

--- a/tests/SkyCD.App.Tests/AddToListDialogViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/AddToListDialogViewModelTests.cs
@@ -1,0 +1,76 @@
+using SkyCD.Presentation.ViewModels;
+
+namespace SkyCD.App.Tests;
+
+public class AddToListDialogViewModelTests
+{
+    [Fact]
+    public void MediaSource_RequiresMediaName()
+    {
+        var vm = new AddToListDialogViewModel
+        {
+            SourceMode = AddToListSourceMode.Media,
+            MediaName = ""
+        };
+
+        Assert.False(vm.CanConfirm);
+        Assert.Equal("Media name is required for media source.", vm.ValidationMessage);
+    }
+
+    [Fact]
+    public void FolderSource_RequiresFolderPath()
+    {
+        var vm = new AddToListDialogViewModel
+        {
+            SourceMode = AddToListSourceMode.Folder,
+            SourceValue = ""
+        };
+
+        Assert.False(vm.CanConfirm);
+        Assert.Equal("Folder path is required for folder source.", vm.ValidationMessage);
+    }
+
+    [Fact]
+    public void InternetSource_RequiresAddress()
+    {
+        var vm = new AddToListDialogViewModel
+        {
+            SourceMode = AddToListSourceMode.Internet,
+            SourceValue = ""
+        };
+
+        Assert.False(vm.CanConfirm);
+        Assert.Equal("Address is required for internet source.", vm.ValidationMessage);
+    }
+
+    [Fact]
+    public void NewMediaTarget_RequiresMediaNameForFolderFlow()
+    {
+        var vm = new AddToListDialogViewModel
+        {
+            SourceMode = AddToListSourceMode.Folder,
+            SourceValue = "C:\\Music",
+            TargetPlacement = AddToListTargetPlacement.NewMedia,
+            MediaName = ""
+        };
+
+        Assert.False(vm.CanConfirm);
+        Assert.Equal("Media name is required when adding as new media.", vm.ValidationMessage);
+    }
+
+    [Fact]
+    public void ValidFolderFlow_CanConfirmAndAccept()
+    {
+        var vm = new AddToListDialogViewModel
+        {
+            SourceMode = AddToListSourceMode.Folder,
+            SourceValue = "C:\\Music",
+            MediaName = "My Media",
+            TargetPlacement = AddToListTargetPlacement.NewMedia
+        };
+
+        Assert.True(vm.CanConfirm);
+        vm.ConfirmCommand.Execute(null);
+        Assert.True(vm.DialogAccepted);
+    }
+}

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -97,6 +97,35 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void ExpandAndCollapseSelectionCommand_UpdatesSelectedTreeNodeExpansion()
+    {
+        var vm = new MainWindowViewModel();
+        var moviesNode = vm.TreeNodes[0].Children.Single(node => node.Key == "movies");
+        vm.SelectedTreeNode = moviesNode;
+
+        vm.ExpandSelectionCommand.Execute("tree");
+        Assert.True(moviesNode.IsExpanded);
+        Assert.Equal("movies", vm.SelectedTreeNode?.Key);
+
+        vm.CollapseSelectionCommand.Execute("tree");
+        Assert.False(moviesNode.IsExpanded);
+        Assert.Equal("movies", vm.SelectedTreeNode?.Key);
+    }
+
+    [Fact]
+    public void ExpandSelectionCommand_FromListContext_TargetsMatchingFolderNode()
+    {
+        var vm = new MainWindowViewModel();
+        var moviesFolder = vm.BrowserItems.Single(item => item.Name == "Movies");
+
+        vm.SelectedBrowserItem = moviesFolder;
+        vm.ExpandSelectionCommand.Execute("list");
+
+        Assert.Equal("movies", vm.SelectedTreeNode?.Key);
+        Assert.True(vm.SelectedTreeNode?.IsExpanded);
+    }
+
+    [Fact]
     public void OpenThenSave_UpdatesSaveCommandState()
     {
         var vm = new MainWindowViewModel();

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -210,4 +210,16 @@ public class MainWindowViewModelTests
         Assert.Equal([0, 60, 100, 0], vm.ProgressTransitions);
         Assert.False(vm.IsProgressVisible);
     }
+
+    [Fact]
+    public void AddItemCommand_RaisesAddToListRequest()
+    {
+        var vm = new MainWindowViewModel();
+        var raised = false;
+        vm.AddToListRequested += (_, _) => raised = true;
+
+        vm.AddItemCommand.Execute(null);
+
+        Assert.True(raised);
+    }
 }

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -141,7 +141,7 @@ public class MainWindowViewModelTests
 
         Assert.False(vm.IsSaveEnabled);
         Assert.False(vm.SaveCatalogCommand.CanExecute(null));
-        Assert.Equal("Saved catalog.", vm.StatusText);
+        Assert.Equal("Done.", vm.StatusText);
     }
 
     [Fact]
@@ -183,5 +183,31 @@ public class MainWindowViewModelTests
         Assert.All(vm.TreeNodes, node => Assert.False(string.IsNullOrWhiteSpace(node.IconGlyph)));
         Assert.All(vm.TreeNodes.SelectMany(node => node.Children), node => Assert.False(string.IsNullOrWhiteSpace(node.IconGlyph)));
         Assert.All(vm.BrowserItems, item => Assert.False(string.IsNullOrWhiteSpace(item.IconGlyph)));
+    }
+
+    [Fact]
+    public void OpenCatalogCommand_TracksLifecycleAndResetsProgressVisuals()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.OpenCatalogCommand.Execute(null);
+
+        Assert.False(vm.IsProgressVisible);
+        Assert.Equal(0, vm.ProgressValue);
+        Assert.Equal("Done.", vm.StatusText);
+        Assert.Equal(["Loading catalog...", "Parsing catalog...", "Updating browser...", "Done."], vm.StatusTransitions);
+        Assert.Equal([0, 35, 80, 100, 0], vm.ProgressTransitions);
+    }
+
+    [Fact]
+    public void RefreshCommand_TracksUpdatingParsingLifecycle()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.RefreshCommand.Execute(null);
+
+        Assert.Equal(["Updating view...", "Parsing catalog...", "Done."], vm.StatusTransitions);
+        Assert.Equal([0, 60, 100, 0], vm.ProgressTransitions);
+        Assert.False(vm.IsProgressVisible);
     }
 }


### PR DESCRIPTION
## Summary
Implements legacy context menu parity for tree/list interactions, including functional Expand/Collapse behavior with tree/list target semantics.

## What changed
- Added context-specific expand/collapse commands in MainWindowViewModel.
- Wired tree/list context menu Expand/Collapse items to shared handlers.
- Added node-level expansion state support in BrowserTreeNode.
- Bound TreeViewItem.IsExpanded to node expansion state.
- Ensured context menu actions target selected node/item semantics.
- Added tests for tree and list context expand/collapse behavior.

## Verification
- dotnet build src/SkyCD.App/SkyCD.App.csproj
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj

Closes #135
Part of #129