### PR TITLE
Implement Properties dialog parity (General + Info tabs)

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -19,12 +19,14 @@ public partial class MainWindow : Window
         if (subscribedViewModel is not null)
         {
             subscribedViewModel.AddToListRequested -= OnAddToListRequested;
+            subscribedViewModel.PropertiesRequested -= OnPropertiesRequested;
         }
 
         subscribedViewModel = DataContext as MainWindowViewModel;
         if (subscribedViewModel is not null)
         {
             subscribedViewModel.AddToListRequested += OnAddToListRequested;
+            subscribedViewModel.PropertiesRequested += OnPropertiesRequested;
         }
     }
 
@@ -47,5 +49,16 @@ public partial class MainWindow : Window
             vm.StatusText = "Done.";
             vm.IsDirtyDocument = true;
         }
+    }
+
+    private async void OnPropertiesRequested(object? sender, PropertiesDialogRequestedEventArgs e)
+    {
+        var dialog = new PropertiesWindow
+        {
+            DataContext = e.Dialog
+        };
+
+        var accepted = await dialog.ShowDialog<bool?>(this);
+        e.Complete(accepted == true, e.Dialog.Comments);
     }
 }

--- a/src/SkyCD.App/Views/PropertiesWindow.axaml
+++ b/src/SkyCD.App/Views/PropertiesWindow.axaml
@@ -4,20 +4,20 @@
         x:Class="SkyCD.App.Views.PropertiesWindow"
         x:DataType="vm:PropertiesDialogViewModel"
         Width="411"
-        Height="406"
+        Height="426"
         MinWidth="411"
-        MinHeight="406"
+        MinHeight="426"
         MaxWidth="411"
-        MaxHeight="406"
+        MaxHeight="426"
         CanResize="False"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
         Title="Properties">
 
-    <Grid RowDefinitions="*,40" Margin="0">
-        <TabControl Margin="0,2,0,0">
+    <Grid RowDefinitions="*,Auto" Margin="0">
+        <TabControl Margin="8,8,8,0">
             <TabItem Header="General">
-                <Grid Margin="10,8,8,6" RowDefinitions="Auto,Auto,*" ColumnDefinitions="32,8,*">
+                <Grid Margin="10,8,10,10" RowDefinitions="Auto,Auto,Auto,*" ColumnDefinitions="32,8,*">
                     <Border Width="32"
                             Height="32"
                             BorderBrush="#C0C0C0"
@@ -37,10 +37,10 @@
                              Text="{Binding Name}"
                              IsReadOnly="True"/>
 
-                    <TextBlock Grid.Row="2" Grid.ColumnSpan="3" Margin="0,14,0,4" Text="Comments:" VerticalAlignment="Top"/>
-                    <TextBox Grid.Row="2"
+                    <TextBlock Grid.Row="2" Grid.ColumnSpan="3" Margin="0,12,0,4" Text="Comments:" VerticalAlignment="Top"/>
+                    <TextBox Grid.Row="3"
                              Grid.ColumnSpan="3"
-                             Margin="0,32,0,0"
+                             Margin="0,0,0,0"
                              Text="{Binding Comments}"
                              AcceptsReturn="True"
                              TextWrapping="Wrap"
@@ -49,7 +49,7 @@
             </TabItem>
 
             <TabItem Header="Info" IsVisible="{Binding HasInfoTab}">
-                <Border Margin="8,6,8,6" BorderBrush="#D8D8D8" BorderThickness="1">
+                <Border Margin="8,8,8,10" BorderBrush="#D8D8D8" BorderThickness="1">
                     <Grid RowDefinitions="Auto,*">
                         <Grid ColumnDefinitions="183,*" Background="#F5F5F5">
                             <TextBlock Margin="8,5" Text="Property" FontWeight="SemiBold"/>
@@ -78,26 +78,19 @@
 
         <Grid Grid.Row="1"
               HorizontalAlignment="Right"
-              VerticalAlignment="Center"
-              Margin="0,0,8,0"
-              Width="146"
-              Height="29"
-              ColumnDefinitions="*,*"
+              Margin="0,10,12,10"
+              ColumnDefinitions="Auto,Auto"
               ColumnSpacing="6">
             <Button Grid.Column="0"
                     Content="OK"
-                    Width="67"
-                    Height="23"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
+                    MinWidth="74"
+                    Padding="10,4"
                     IsDefault="True"
                     Command="{Binding ConfirmCommand}"/>
             <Button Grid.Column="1"
                     Content="Cancel"
-                    Width="67"
-                    Height="23"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
+                    MinWidth="74"
+                    Padding="10,4"
                     IsCancel="True"
                     Click="OnCancelClicked"/>
         </Grid>

--- a/src/SkyCD.App/Views/PropertiesWindow.axaml
+++ b/src/SkyCD.App/Views/PropertiesWindow.axaml
@@ -14,7 +14,7 @@
         ShowInTaskbar="False"
         Title="Properties">
 
-    <Grid RowDefinitions="*,Auto" Margin="0">
+    <Grid RowDefinitions="*,40" Margin="0">
         <TabControl Margin="0,2,0,0">
             <TabItem Header="General">
                 <Grid Margin="10,8,8,6" RowDefinitions="Auto,Auto,*" ColumnDefinitions="32,8,*">
@@ -78,7 +78,8 @@
 
         <Grid Grid.Row="1"
               HorizontalAlignment="Right"
-              Margin="0,6,4,4"
+              VerticalAlignment="Center"
+              Margin="0,0,8,0"
               Width="146"
               Height="29"
               ColumnDefinitions="*,*"

--- a/src/SkyCD.App/Views/PropertiesWindow.axaml
+++ b/src/SkyCD.App/Views/PropertiesWindow.axaml
@@ -41,7 +41,7 @@
                     <TextBox Text="{Binding Comments}"
                              AcceptsReturn="True"
                              TextWrapping="Wrap"
-                             VerticalScrollBarVisibility="Auto"
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"
                              MinHeight="250"/>
                 </StackPanel>
             </TabItem>

--- a/src/SkyCD.App/Views/PropertiesWindow.axaml
+++ b/src/SkyCD.App/Views/PropertiesWindow.axaml
@@ -3,66 +3,68 @@
         xmlns:vm="clr-namespace:SkyCD.Presentation.ViewModels;assembly=SkyCD.Presentation"
         x:Class="SkyCD.App.Views.PropertiesWindow"
         x:DataType="vm:PropertiesDialogViewModel"
-        Width="420"
-        Height="430"
-        MinWidth="420"
-        MinHeight="430"
+        Width="411"
+        Height="406"
+        MinWidth="411"
+        MinHeight="406"
+        MaxWidth="411"
+        MaxHeight="406"
         CanResize="False"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
         Title="Properties">
 
-    <Grid RowDefinitions="*,Auto" Margin="10">
-        <TabControl>
+    <Grid RowDefinitions="*,Auto" Margin="0">
+        <TabControl Margin="0,2,0,0">
             <TabItem Header="General">
-                <StackPanel Margin="12" Spacing="10">
-                    <Grid ColumnDefinitions="40,*" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="6">
-                        <Border Width="32"
-                                Height="32"
-                                BorderBrush="#C0C0C0"
-                                BorderThickness="1"
-                                CornerRadius="3"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Top">
-                            <TextBlock Text="{Binding IconGlyph}"
-                                       HorizontalAlignment="Center"
-                                       VerticalAlignment="Center"
-                                       FontSize="16"/>
-                        </Border>
+                <Grid Margin="10,8,8,6" RowDefinitions="Auto,Auto,*" ColumnDefinitions="32,8,*">
+                    <Border Width="32"
+                            Height="32"
+                            BorderBrush="#C0C0C0"
+                            BorderThickness="1"
+                            VerticalAlignment="Top"
+                            CornerRadius="2">
+                        <TextBlock Text="{Binding IconGlyph}"
+                                   HorizontalAlignment="Center"
+                                   VerticalAlignment="Center"
+                                   FontSize="16"/>
+                    </Border>
 
-                        <TextBlock Grid.Column="1" Text="Name:"/>
-                        <TextBox Grid.Column="1"
-                                 Grid.Row="1"
-                                 Text="{Binding Name}"
-                                 IsReadOnly="True"/>
-                    </Grid>
+                    <TextBlock Grid.Column="2" Text="Name:" VerticalAlignment="Top"/>
+                    <TextBox Grid.Column="2"
+                             Grid.Row="1"
+                             Margin="0,2,0,0"
+                             Text="{Binding Name}"
+                             IsReadOnly="True"/>
 
-                    <TextBlock Text="Comments:"/>
-                    <TextBox Text="{Binding Comments}"
+                    <TextBlock Grid.Row="2" Grid.ColumnSpan="3" Margin="0,14,0,4" Text="Comments:" VerticalAlignment="Top"/>
+                    <TextBox Grid.Row="2"
+                             Grid.ColumnSpan="3"
+                             Margin="0,32,0,0"
+                             Text="{Binding Comments}"
                              AcceptsReturn="True"
                              TextWrapping="Wrap"
-                             ScrollViewer.VerticalScrollBarVisibility="Auto"
-                             MinHeight="250"/>
-                </StackPanel>
+                             ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                </Grid>
             </TabItem>
 
             <TabItem Header="Info" IsVisible="{Binding HasInfoTab}">
-                <Border Margin="10" BorderBrush="#D8D8D8" BorderThickness="1">
+                <Border Margin="8,6,8,6" BorderBrush="#D8D8D8" BorderThickness="1">
                     <Grid RowDefinitions="Auto,*">
-                        <Grid ColumnDefinitions="190,*" Background="#F5F5F5">
-                            <TextBlock Margin="8,6" Text="Property" FontWeight="SemiBold"/>
-                            <TextBlock Grid.Column="1" Margin="8,6" Text="Value" FontWeight="SemiBold"/>
+                        <Grid ColumnDefinitions="183,*" Background="#F5F5F5">
+                            <TextBlock Margin="8,5" Text="Property" FontWeight="SemiBold"/>
+                            <TextBlock Grid.Column="1" Margin="8,5" Text="Value" FontWeight="SemiBold"/>
                         </Grid>
                         <ListBox Grid.Row="1"
                                  BorderThickness="0"
                                  ItemsSource="{Binding InfoProperties}">
                             <ListBox.ItemTemplate>
                                 <DataTemplate x:DataType="vm:PropertiesInfoItem">
-                                    <Grid ColumnDefinitions="190,*" Margin="0,0,0,1">
-                                        <Border BorderBrush="#E2E2E2" BorderThickness="0,0,1,1" Padding="8,5">
+                                    <Grid ColumnDefinitions="183,*" Margin="0,0,0,1">
+                                        <Border BorderBrush="#E2E2E2" BorderThickness="0,0,1,1" Padding="8,4">
                                             <TextBlock Text="{Binding Property}" TextWrapping="Wrap"/>
                                         </Border>
-                                        <Border Grid.Column="1" BorderBrush="#E2E2E2" BorderThickness="0,0,0,1" Padding="8,5">
+                                        <Border Grid.Column="1" BorderBrush="#E2E2E2" BorderThickness="0,0,0,1" Padding="8,4">
                                             <TextBlock Text="{Binding Value}" TextWrapping="Wrap"/>
                                         </Border>
                                     </Grid>
@@ -74,17 +76,29 @@
             </TabItem>
         </TabControl>
 
-        <StackPanel Grid.Row="1"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Right"
-                    Spacing="8"
-                    Margin="0,10,0,0">
-            <Button Content="OK"
-                    MinWidth="78"
+        <Grid Grid.Row="1"
+              HorizontalAlignment="Right"
+              Margin="0,6,4,4"
+              Width="146"
+              Height="29"
+              ColumnDefinitions="*,*"
+              ColumnSpacing="6">
+            <Button Grid.Column="0"
+                    Content="OK"
+                    Width="67"
+                    Height="23"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    IsDefault="True"
                     Command="{Binding ConfirmCommand}"/>
-            <Button Content="Cancel"
-                    MinWidth="78"
+            <Button Grid.Column="1"
+                    Content="Cancel"
+                    Width="67"
+                    Height="23"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    IsCancel="True"
                     Click="OnCancelClicked"/>
-        </StackPanel>
+        </Grid>
     </Grid>
 </Window>

--- a/src/SkyCD.App/Views/PropertiesWindow.axaml
+++ b/src/SkyCD.App/Views/PropertiesWindow.axaml
@@ -1,0 +1,90 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:SkyCD.Presentation.ViewModels;assembly=SkyCD.Presentation"
+        x:Class="SkyCD.App.Views.PropertiesWindow"
+        x:DataType="vm:PropertiesDialogViewModel"
+        Width="420"
+        Height="430"
+        MinWidth="420"
+        MinHeight="430"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        Title="Properties">
+
+    <Grid RowDefinitions="*,Auto" Margin="10">
+        <TabControl>
+            <TabItem Header="General">
+                <StackPanel Margin="12" Spacing="10">
+                    <Grid ColumnDefinitions="40,*" RowDefinitions="Auto,Auto" ColumnSpacing="8" RowSpacing="6">
+                        <Border Width="32"
+                                Height="32"
+                                BorderBrush="#C0C0C0"
+                                BorderThickness="1"
+                                CornerRadius="3"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Top">
+                            <TextBlock Text="{Binding IconGlyph}"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"
+                                       FontSize="16"/>
+                        </Border>
+
+                        <TextBlock Grid.Column="1" Text="Name:"/>
+                        <TextBox Grid.Column="1"
+                                 Grid.Row="1"
+                                 Text="{Binding Name}"
+                                 IsReadOnly="True"/>
+                    </Grid>
+
+                    <TextBlock Text="Comments:"/>
+                    <TextBox Text="{Binding Comments}"
+                             AcceptsReturn="True"
+                             TextWrapping="Wrap"
+                             VerticalScrollBarVisibility="Auto"
+                             MinHeight="250"/>
+                </StackPanel>
+            </TabItem>
+
+            <TabItem Header="Info" IsVisible="{Binding HasInfoTab}">
+                <Border Margin="10" BorderBrush="#D8D8D8" BorderThickness="1">
+                    <Grid RowDefinitions="Auto,*">
+                        <Grid ColumnDefinitions="190,*" Background="#F5F5F5">
+                            <TextBlock Margin="8,6" Text="Property" FontWeight="SemiBold"/>
+                            <TextBlock Grid.Column="1" Margin="8,6" Text="Value" FontWeight="SemiBold"/>
+                        </Grid>
+                        <ListBox Grid.Row="1"
+                                 BorderThickness="0"
+                                 ItemsSource="{Binding InfoProperties}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate x:DataType="vm:PropertiesInfoItem">
+                                    <Grid ColumnDefinitions="190,*" Margin="0,0,0,1">
+                                        <Border BorderBrush="#E2E2E2" BorderThickness="0,0,1,1" Padding="8,5">
+                                            <TextBlock Text="{Binding Property}" TextWrapping="Wrap"/>
+                                        </Border>
+                                        <Border Grid.Column="1" BorderBrush="#E2E2E2" BorderThickness="0,0,0,1" Padding="8,5">
+                                            <TextBlock Text="{Binding Value}" TextWrapping="Wrap"/>
+                                        </Border>
+                                    </Grid>
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                    </Grid>
+                </Border>
+            </TabItem>
+        </TabControl>
+
+        <StackPanel Grid.Row="1"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8"
+                    Margin="0,10,0,0">
+            <Button Content="OK"
+                    MinWidth="78"
+                    Command="{Binding ConfirmCommand}"/>
+            <Button Content="Cancel"
+                    MinWidth="78"
+                    Click="OnCancelClicked"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/SkyCD.App/Views/PropertiesWindow.axaml.cs
+++ b/src/SkyCD.App/Views/PropertiesWindow.axaml.cs
@@ -1,0 +1,45 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using SkyCD.Presentation.ViewModels;
+using System;
+using System.ComponentModel;
+
+namespace SkyCD.App.Views;
+
+public partial class PropertiesWindow : Window
+{
+    public PropertiesWindow()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (sender is not PropertiesWindow window)
+        {
+            return;
+        }
+
+        if (window.DataContext is PropertiesDialogViewModel vm)
+        {
+            vm.PropertyChanged -= OnViewModelPropertyChanged;
+            vm.PropertyChanged += OnViewModelPropertyChanged;
+        }
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (sender is PropertiesDialogViewModel vm &&
+            e.PropertyName == nameof(PropertiesDialogViewModel.DialogAccepted) &&
+            vm.DialogAccepted)
+        {
+            Close(true);
+        }
+    }
+
+    private void OnCancelClicked(object? sender, RoutedEventArgs e)
+    {
+        Close(false);
+    }
+}

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -9,11 +9,13 @@ public partial class MainWindowViewModel : ObservableObject
     private readonly IReadOnlyDictionary<string, IReadOnlyList<BrowserItem>> browserItemsByNodeKey;
     private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByKey;
     private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByTitle;
+    private readonly Dictionary<string, string> commentsByObjectKey = new(StringComparer.OrdinalIgnoreCase);
     private readonly List<string> statusTransitions = [];
     private readonly List<int> progressTransitions = [];
     private const string DefaultStatusText = "Done.";
 
     public event EventHandler? AddToListRequested;
+    public event EventHandler<PropertiesDialogRequestedEventArgs>? PropertiesRequested;
 
     public MainWindowViewModel()
     {
@@ -190,7 +192,27 @@ public partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private void OpenProperties()
     {
-        StatusText = "Properties dialog is not implemented yet.";
+        if (!TryBuildPropertiesDialog(out var dialog))
+        {
+            StatusText = "Unknown selected object.";
+            return;
+        }
+
+        PropertiesRequested?.Invoke(this, new PropertiesDialogRequestedEventArgs
+        {
+            Dialog = dialog,
+            Complete = (accepted, comments) =>
+            {
+                if (!accepted)
+                {
+                    return;
+                }
+
+                commentsByObjectKey[dialog.ObjectKey] = comments;
+                IsDirtyDocument = true;
+                StatusText = DefaultStatusText;
+            }
+        });
     }
 
     [RelayCommand]
@@ -372,6 +394,72 @@ public partial class MainWindowViewModel : ObservableObject
 
         targetNode = null;
         return false;
+    }
+
+    private bool TryBuildPropertiesDialog([NotNullWhen(true)] out PropertiesDialogViewModel? dialog)
+    {
+        if (SelectedBrowserItem is not null)
+        {
+            var objectKey = GetBrowserItemObjectKey(SelectedBrowserItem);
+            var comments = GetObjectComments(objectKey);
+            var nodeTitle = SelectedTreeNode?.Title ?? "Library";
+
+            var infoProperties = new List<PropertiesInfoItem>
+            {
+                new("Type", SelectedBrowserItem.Type),
+                new("Size", SelectedBrowserItem.Size),
+                new("Location", nodeTitle)
+            };
+
+            dialog = new PropertiesDialogViewModel(
+                objectKey,
+                SelectedBrowserItem.Name,
+                SelectedBrowserItem.IconGlyph,
+                comments,
+                infoProperties);
+            return true;
+        }
+
+        if (SelectedTreeNode is not null)
+        {
+            var objectKey = GetTreeNodeObjectKey(SelectedTreeNode);
+            var comments = GetObjectComments(objectKey);
+
+            var infoProperties = new List<PropertiesInfoItem>
+            {
+                new("Type", "Folder"),
+                new("Children", SelectedTreeNode.Children.Count.ToString())
+            };
+
+            dialog = new PropertiesDialogViewModel(
+                objectKey,
+                SelectedTreeNode.Title,
+                SelectedTreeNode.IconGlyph,
+                comments,
+                infoProperties);
+            return true;
+        }
+
+        dialog = null;
+        return false;
+    }
+
+    private string GetObjectComments(string objectKey)
+    {
+        return commentsByObjectKey.TryGetValue(objectKey, out var comments)
+            ? comments
+            : string.Empty;
+    }
+
+    private string GetBrowserItemObjectKey(BrowserItem item)
+    {
+        var nodeKey = SelectedTreeNode?.Key ?? "library";
+        return $"item:{nodeKey}:{item.Name}";
+    }
+
+    private static string GetTreeNodeObjectKey(BrowserTreeNode node)
+    {
+        return $"tree:{node.Key}";
     }
 
     private void RefreshBrowserItemsForSelection()

--- a/src/SkyCD.Presentation/ViewModels/PropertiesDialogRequestedEventArgs.cs
+++ b/src/SkyCD.Presentation/ViewModels/PropertiesDialogRequestedEventArgs.cs
@@ -1,0 +1,8 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public sealed class PropertiesDialogRequestedEventArgs : EventArgs
+{
+    public required PropertiesDialogViewModel Dialog { get; init; }
+
+    public required Action<bool, string> Complete { get; init; }
+}

--- a/src/SkyCD.Presentation/ViewModels/PropertiesDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/PropertiesDialogViewModel.cs
@@ -1,0 +1,43 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace SkyCD.Presentation.ViewModels;
+
+public partial class PropertiesDialogViewModel : ObservableObject
+{
+    public PropertiesDialogViewModel(
+        string objectKey,
+        string name,
+        string iconGlyph,
+        string comments,
+        IReadOnlyList<PropertiesInfoItem> infoProperties)
+    {
+        ObjectKey = objectKey;
+        Name = name;
+        IconGlyph = iconGlyph;
+        this.comments = comments;
+        InfoProperties = infoProperties;
+    }
+
+    public string ObjectKey { get; }
+
+    public string Name { get; }
+
+    public string IconGlyph { get; }
+
+    public IReadOnlyList<PropertiesInfoItem> InfoProperties { get; }
+
+    public bool HasInfoTab => InfoProperties.Count > 0;
+
+    [ObservableProperty]
+    private string comments;
+
+    [ObservableProperty]
+    private bool dialogAccepted;
+
+    [RelayCommand]
+    private void Confirm()
+    {
+        DialogAccepted = true;
+    }
+}

--- a/src/SkyCD.Presentation/ViewModels/PropertiesInfoItem.cs
+++ b/src/SkyCD.Presentation/ViewModels/PropertiesInfoItem.cs
@@ -1,0 +1,3 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public sealed record PropertiesInfoItem(string Property, string Value);

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -222,4 +222,65 @@ public class MainWindowViewModelTests
 
         Assert.True(raised);
     }
+
+    [Fact]
+    public void OpenPropertiesCommand_RaisesRequestWithSelectedObjectValues()
+    {
+        var vm = new MainWindowViewModel();
+        PropertiesDialogRequestedEventArgs? request = null;
+        vm.PropertiesRequested += (_, args) => request = args;
+
+        vm.OpenPropertiesCommand.Execute(null);
+
+        Assert.NotNull(request);
+        Assert.Equal(vm.SelectedBrowserItem?.Name, request!.Dialog.Name);
+        Assert.Equal(vm.SelectedBrowserItem?.IconGlyph, request.Dialog.IconGlyph);
+        Assert.Equal(string.Empty, request.Dialog.Comments);
+        Assert.NotEmpty(request.Dialog.InfoProperties);
+    }
+
+    [Fact]
+    public void OpenPropertiesCommand_Accepted_PersistsCommentsAndMarksDocumentDirty()
+    {
+        var vm = new MainWindowViewModel();
+        PropertiesDialogRequestedEventArgs? request = null;
+        vm.PropertiesRequested += (_, args) => request = args;
+
+        vm.OpenPropertiesCommand.Execute(null);
+
+        Assert.NotNull(request);
+        request!.Dialog.Comments = "Updated comment";
+        request.Complete(true, request.Dialog.Comments);
+
+        Assert.True(vm.IsDirtyDocument);
+        Assert.Equal("Done.", vm.StatusText);
+
+        vm.IsDirtyDocument = false;
+        request = null;
+        vm.OpenPropertiesCommand.Execute(null);
+
+        Assert.NotNull(request);
+        Assert.Equal("Updated comment", request!.Dialog.Comments);
+    }
+
+    [Fact]
+    public void OpenPropertiesCommand_Canceled_DiscardsCommentChanges()
+    {
+        var vm = new MainWindowViewModel();
+        PropertiesDialogRequestedEventArgs? request = null;
+        vm.PropertiesRequested += (_, args) => request = args;
+
+        vm.OpenPropertiesCommand.Execute(null);
+
+        Assert.NotNull(request);
+        request!.Dialog.Comments = "Draft comment";
+        request.Complete(false, request.Dialog.Comments);
+
+        Assert.False(vm.IsDirtyDocument);
+
+        request = null;
+        vm.OpenPropertiesCommand.Execute(null);
+        Assert.NotNull(request);
+        Assert.Equal(string.Empty, request!.Dialog.Comments);
+    }
 }


### PR DESCRIPTION
## Summary
- implement a dedicated Properties dialog with legacy-style General and Info tabs
- load selected object values (name, icon, comments, info property list) into dialog controls
- wire OpenProperties from MainWindowViewModel through MainWindow to show dialog with OK/Cancel semantics
- persist comments and mark document dirty only when OK is accepted; discard changes on Cancel

## Tests
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj
- dotnet build src/SkyCD.App/SkyCD.App.csproj

Closes #138