### PR TITLE
Implement auxiliary dialog parity (About, Login, Adding progress)

### DIFF
--- a/src/SkyCD.App/Views/AboutWindow.axaml
+++ b/src/SkyCD.App/Views/AboutWindow.axaml
@@ -1,0 +1,33 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:SkyCD.Presentation.ViewModels;assembly=SkyCD.Presentation"
+        x:Class="SkyCD.App.Views.AboutWindow"
+        x:DataType="vm:AboutDialogViewModel"
+        Width="420"
+        Height="260"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner"
+        Title="About SkyCD">
+
+    <Design.DataContext>
+        <vm:AboutDialogViewModel ProductName="SkyCD" Version="3.0.0" Website="https://github.com/SkyCD/SkyCD"/>
+    </Design.DataContext>
+
+    <Grid RowDefinitions="*,Auto" Margin="16">
+        <StackPanel Spacing="10">
+            <TextBlock Text="{Binding ProductName}" FontSize="24" FontWeight="Bold"/>
+            <TextBlock Text="{Binding Version, StringFormat='Version: {0}'}"/>
+            <TextBlock Text="CD/DVD media catalog manager"/>
+            <TextBlock Text="{Binding Website}"/>
+        </StackPanel>
+
+        <StackPanel Grid.Row="1"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,14,0,0">
+            <Button Content="OK"
+                    MinWidth="90"
+                    Command="{Binding ConfirmCommand}"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/SkyCD.App/Views/AboutWindow.axaml.cs
+++ b/src/SkyCD.App/Views/AboutWindow.axaml.cs
@@ -1,0 +1,39 @@
+using Avalonia.Controls;
+using SkyCD.Presentation.ViewModels;
+using System;
+using System.ComponentModel;
+
+namespace SkyCD.App.Views;
+
+public partial class AboutWindow : Window
+{
+    public AboutWindow()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (sender is not AboutWindow window)
+        {
+            return;
+        }
+
+        if (window.DataContext is AboutDialogViewModel vm)
+        {
+            vm.PropertyChanged -= OnViewModelPropertyChanged;
+            vm.PropertyChanged += OnViewModelPropertyChanged;
+        }
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (sender is AboutDialogViewModel vm &&
+            e.PropertyName == nameof(AboutDialogViewModel.DialogAccepted) &&
+            vm.DialogAccepted)
+        {
+            Close(true);
+        }
+    }
+}

--- a/src/SkyCD.App/Views/AddingProgressWindow.axaml
+++ b/src/SkyCD.App/Views/AddingProgressWindow.axaml
@@ -1,0 +1,25 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:SkyCD.Presentation.ViewModels;assembly=SkyCD.Presentation"
+        x:Class="SkyCD.App.Views.AddingProgressWindow"
+        x:DataType="vm:AddingProgressDialogViewModel"
+        Width="470"
+        Height="140"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner"
+        WindowDecorations="BorderOnly"
+        ShowInTaskbar="False"
+        Title="Adding">
+
+    <Design.DataContext>
+        <vm:AddingProgressDialogViewModel/>
+    </Design.DataContext>
+
+    <Grid RowDefinitions="Auto,Auto" RowSpacing="10" Margin="16">
+        <TextBlock Text="{Binding OperationText}" TextWrapping="Wrap"/>
+        <ProgressBar Grid.Row="1"
+                     Minimum="0"
+                     Maximum="100"
+                     Value="{Binding ProgressValue}"/>
+    </Grid>
+</Window>

--- a/src/SkyCD.App/Views/AddingProgressWindow.axaml.cs
+++ b/src/SkyCD.App/Views/AddingProgressWindow.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace SkyCD.App.Views;
+
+public partial class AddingProgressWindow : Window
+{
+    public AddingProgressWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/SkyCD.App/Views/LoginWindow.axaml
+++ b/src/SkyCD.App/Views/LoginWindow.axaml
@@ -1,0 +1,38 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:SkyCD.Presentation.ViewModels;assembly=SkyCD.Presentation"
+        x:Class="SkyCD.App.Views.LoginWindow"
+        x:DataType="vm:LoginDialogViewModel"
+        Width="380"
+        Height="210"
+        CanResize="False"
+        WindowStartupLocation="CenterOwner"
+        Title="Server login">
+
+    <Design.DataContext>
+        <vm:LoginDialogViewModel/>
+    </Design.DataContext>
+
+    <Grid RowDefinitions="*,Auto" Margin="14">
+        <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="110,*" ColumnSpacing="10" RowSpacing="8">
+            <TextBlock Grid.Row="0" Grid.ColumnSpan="2" Text="Enter server credentials."/>
+            <TextBlock Grid.Row="1" Text="User name" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Username}"/>
+            <TextBlock Grid.Row="2" Text="Password" VerticalAlignment="Center"/>
+            <TextBox Grid.Row="2" Grid.Column="1" PasswordChar="*" Text="{Binding Password}"/>
+        </Grid>
+
+        <StackPanel Grid.Row="1"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8"
+                    Margin="0,12,0,0">
+            <Button Content="OK"
+                    MinWidth="90"
+                    Command="{Binding ConfirmCommand}"/>
+            <Button Content="Cancel"
+                    MinWidth="90"
+                    Click="OnCancelClicked"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/SkyCD.App/Views/LoginWindow.axaml.cs
+++ b/src/SkyCD.App/Views/LoginWindow.axaml.cs
@@ -1,0 +1,45 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using SkyCD.Presentation.ViewModels;
+using System;
+using System.ComponentModel;
+
+namespace SkyCD.App.Views;
+
+public partial class LoginWindow : Window
+{
+    public LoginWindow()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (sender is not LoginWindow window)
+        {
+            return;
+        }
+
+        if (window.DataContext is LoginDialogViewModel vm)
+        {
+            vm.PropertyChanged -= OnViewModelPropertyChanged;
+            vm.PropertyChanged += OnViewModelPropertyChanged;
+        }
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (sender is LoginDialogViewModel vm &&
+            e.PropertyName == nameof(LoginDialogViewModel.DialogAccepted) &&
+            vm.DialogAccepted)
+        {
+            Close(true);
+        }
+    }
+
+    private void OnCancelClicked(object? sender, RoutedEventArgs e)
+    {
+        Close(false);
+    }
+}

--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -1,6 +1,8 @@
 using Avalonia.Controls;
 using SkyCD.Presentation.ViewModels;
 using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace SkyCD.App.Views;
 
@@ -19,6 +21,7 @@ public partial class MainWindow : Window
         if (subscribedViewModel is not null)
         {
             subscribedViewModel.AddToListRequested -= OnAddToListRequested;
+            subscribedViewModel.AboutRequested -= OnAboutRequested;
             subscribedViewModel.PropertiesRequested -= OnPropertiesRequested;
         }
 
@@ -26,6 +29,7 @@ public partial class MainWindow : Window
         if (subscribedViewModel is not null)
         {
             subscribedViewModel.AddToListRequested += OnAddToListRequested;
+            subscribedViewModel.AboutRequested += OnAboutRequested;
             subscribedViewModel.PropertiesRequested += OnPropertiesRequested;
         }
     }
@@ -44,11 +48,31 @@ public partial class MainWindow : Window
         };
 
         var accepted = await dialog.ShowDialog<bool?>(this);
-        if (accepted == true)
+        if (accepted != true)
         {
-            vm.StatusText = "Done.";
-            vm.IsDirtyDocument = true;
+            return;
         }
+
+        if (dialogVm.SourceMode == AddToListSourceMode.Internet)
+        {
+            var loginVm = new LoginDialogViewModel();
+            var loginDialog = new LoginWindow
+            {
+                DataContext = loginVm
+            };
+
+            var loginAccepted = await loginDialog.ShowDialog<bool?>(this);
+            if (loginAccepted != true)
+            {
+                vm.StatusText = "Login canceled.";
+                return;
+            }
+        }
+
+        await ShowAddProgressAsync(dialogVm);
+
+        vm.StatusText = "Done.";
+        vm.IsDirtyDocument = true;
     }
 
     private async void OnPropertiesRequested(object? sender, PropertiesDialogRequestedEventArgs e)
@@ -60,5 +84,66 @@ public partial class MainWindow : Window
 
         var accepted = await dialog.ShowDialog<bool?>(this);
         e.Complete(accepted == true, e.Dialog.Comments);
+    }
+
+    private async void OnAboutRequested(object? sender, EventArgs e)
+    {
+        var version = typeof(App).Assembly.GetName().Version?.ToString(3) ?? "3.0.0";
+        var dialogVm = new AboutDialogViewModel("SkyCD", version, "https://github.com/SkyCD/SkyCD");
+        var dialog = new AboutWindow
+        {
+            DataContext = dialogVm
+        };
+
+        await dialog.ShowDialog<bool?>(this);
+    }
+
+    private async Task ShowAddProgressAsync(AddToListDialogViewModel addDialog)
+    {
+        var progressVm = new AddingProgressDialogViewModel();
+        var progressDialog = new AddingProgressWindow
+        {
+            DataContext = progressVm
+        };
+
+        progressDialog.Show(this);
+        try
+        {
+            foreach (var (text, value) in BuildAddProgressSteps(addDialog))
+            {
+                progressVm.OperationText = text;
+                progressVm.ProgressValue = value;
+                await Task.Delay(140);
+            }
+        }
+        finally
+        {
+            progressDialog.Close();
+        }
+    }
+
+    private static IReadOnlyList<(string Text, int Value)> BuildAddProgressSteps(AddToListDialogViewModel addDialog)
+    {
+        return addDialog.SourceMode switch
+        {
+            AddToListSourceMode.Internet =>
+            [
+                ("Reading directory from remote server...", 20),
+                ("Preparing database for modifications...", 55),
+                ("Updating indexes...", 100)
+            ],
+            AddToListSourceMode.Folder =>
+            [
+                ("Reading source folder...", 25),
+                ("Preparing database for modifications...", 60),
+                ("Updating indexes...", 100)
+            ],
+            _ =>
+            [
+                ("Reading media metadata...", 35),
+                ("Preparing database for modifications...", 70),
+                ("Updating indexes...", 100)
+            ]
+        };
     }
 }

--- a/src/SkyCD.Presentation/ViewModels/AboutDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/AboutDialogViewModel.cs
@@ -1,0 +1,34 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace SkyCD.Presentation.ViewModels;
+
+public partial class AboutDialogViewModel : ObservableObject
+{
+    public AboutDialogViewModel()
+        : this("SkyCD", "3.0.0", "https://github.com/SkyCD/SkyCD")
+    {
+    }
+
+    public AboutDialogViewModel(string productName, string version, string website)
+    {
+        ProductName = productName;
+        Version = version;
+        Website = website;
+    }
+
+    public string ProductName { get; }
+
+    public string Version { get; }
+
+    public string Website { get; }
+
+    [ObservableProperty]
+    private bool dialogAccepted;
+
+    [RelayCommand]
+    private void Confirm()
+    {
+        DialogAccepted = true;
+    }
+}

--- a/src/SkyCD.Presentation/ViewModels/AddingProgressDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/AddingProgressDialogViewModel.cs
@@ -1,0 +1,12 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace SkyCD.Presentation.ViewModels;
+
+public partial class AddingProgressDialogViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string operationText = "Preparing database for modifications...";
+
+    [ObservableProperty]
+    private int progressValue;
+}

--- a/src/SkyCD.Presentation/ViewModels/LoginDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/LoginDialogViewModel.cs
@@ -1,0 +1,36 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace SkyCD.Presentation.ViewModels;
+
+public partial class LoginDialogViewModel : ObservableObject
+{
+    public bool CanConfirm =>
+        !string.IsNullOrWhiteSpace(Username) &&
+        !string.IsNullOrWhiteSpace(Password);
+
+    [ObservableProperty]
+    private string username = string.Empty;
+
+    [ObservableProperty]
+    private string password = string.Empty;
+
+    [ObservableProperty]
+    private bool dialogAccepted;
+
+    [RelayCommand(CanExecute = nameof(CanConfirm))]
+    private void Confirm()
+    {
+        DialogAccepted = true;
+    }
+
+    partial void OnUsernameChanged(string value)
+    {
+        ConfirmCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnPasswordChanged(string value)
+    {
+        ConfirmCommand.NotifyCanExecuteChanged();
+    }
+}

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -15,6 +15,7 @@ public partial class MainWindowViewModel : ObservableObject
     private const string DefaultStatusText = "Done.";
 
     public event EventHandler? AddToListRequested;
+    public event EventHandler? AboutRequested;
     public event EventHandler<PropertiesDialogRequestedEventArgs>? PropertiesRequested;
 
     public MainWindowViewModel()
@@ -260,7 +261,14 @@ public partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private void OpenAbout()
     {
-        StatusText = "About dialog is not implemented yet.";
+        if (AboutRequested is null)
+        {
+            StatusText = "About dialog is not implemented yet.";
+            return;
+        }
+
+        AboutRequested.Invoke(this, EventArgs.Empty);
+        StatusText = DefaultStatusText;
     }
 
     [RelayCommand(CanExecute = nameof(CanExpandSelection))]

--- a/tests/SkyCD.App.Tests/LoginDialogViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/LoginDialogViewModelTests.cs
@@ -1,0 +1,34 @@
+using SkyCD.Presentation.ViewModels;
+
+namespace SkyCD.App.Tests;
+
+public class LoginDialogViewModelTests
+{
+    [Fact]
+    public void ConfirmCommand_RequiresBothUsernameAndPassword()
+    {
+        var vm = new LoginDialogViewModel();
+
+        Assert.False(vm.ConfirmCommand.CanExecute(null));
+
+        vm.Username = "user";
+        Assert.False(vm.ConfirmCommand.CanExecute(null));
+
+        vm.Password = "secret";
+        Assert.True(vm.ConfirmCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void ConfirmCommand_SetsDialogAccepted_WhenCredentialsArePresent()
+    {
+        var vm = new LoginDialogViewModel
+        {
+            Username = "user",
+            Password = "secret"
+        };
+
+        vm.ConfirmCommand.Execute(null);
+
+        Assert.True(vm.DialogAccepted);
+    }
+}

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -224,6 +224,29 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void OpenAboutCommand_RaisesAboutRequest_WhenSubscriberIsPresent()
+    {
+        var vm = new MainWindowViewModel();
+        var raised = false;
+        vm.AboutRequested += (_, _) => raised = true;
+
+        vm.OpenAboutCommand.Execute(null);
+
+        Assert.True(raised);
+        Assert.Equal("Done.", vm.StatusText);
+    }
+
+    [Fact]
+    public void OpenAboutCommand_WithoutSubscriber_UsesFallbackStatus()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.OpenAboutCommand.Execute(null);
+
+        Assert.Equal("About dialog is not implemented yet.", vm.StatusText);
+    }
+
+    [Fact]
     public void OpenPropertiesCommand_RaisesRequestWithSelectedObjectValues()
     {
         var vm = new MainWindowViewModel();


### PR DESCRIPTION
## Summary
Implements issue #140 by porting the remaining auxiliary legacy dialogs and wiring them into the active Avalonia flows.

## What changed
- Added About dialog window and view model.
- Added Login dialog window and view model with username/password validation.
- Added Adding progress window and view model with operation text + progress bar updates.
- Wired OpenAboutCommand to raise an AboutRequested event, and handle it from MainWindow.
- Updated add flow in MainWindow:
  - Prompt login when source mode is Internet.
  - Show a progress dialog with staged updates during the add/import-style operation.
- Added/updated tests for:
  - About command invocation behavior.
  - Login dialog command validation and acceptance behavior.

## Validation
- dotnet build src/SkyCD.App/SkyCD.App.csproj
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj

Fixes #140