### PR TITLE
Implement Options dialog parity (Plug-Ins + Language tabs)

### DIFF
--- a/src/SkyCD.App/Models/AppOptions.cs
+++ b/src/SkyCD.App/Models/AppOptions.cs
@@ -1,0 +1,8 @@
+namespace SkyCD.App.Models;
+
+public sealed class AppOptions
+{
+    public string PluginPath { get; set; } = string.Empty;
+
+    public string Language { get; set; } = "English";
+}

--- a/src/SkyCD.App/Services/AppOptionsStore.cs
+++ b/src/SkyCD.App/Services/AppOptionsStore.cs
@@ -1,0 +1,53 @@
+using SkyCD.App.Models;
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace SkyCD.App.Services;
+
+public sealed class AppOptionsStore
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private readonly string optionsFilePath;
+
+    public AppOptionsStore()
+    {
+        var appDataRoot = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var optionsDirectory = Path.Combine(appDataRoot, "SkyCD");
+        optionsFilePath = Path.Combine(optionsDirectory, "options.json");
+    }
+
+    public AppOptions Load()
+    {
+        if (!File.Exists(optionsFilePath))
+        {
+            return new AppOptions();
+        }
+
+        try
+        {
+            var json = File.ReadAllText(optionsFilePath);
+            return JsonSerializer.Deserialize<AppOptions>(json) ?? new AppOptions();
+        }
+        catch
+        {
+            return new AppOptions();
+        }
+    }
+
+    public void Save(AppOptions options)
+    {
+        var directory = Path.GetDirectoryName(optionsFilePath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var json = JsonSerializer.Serialize(options, SerializerOptions);
+        File.WriteAllText(optionsFilePath, json);
+    }
+}

--- a/src/SkyCD.App/Services/RuntimePluginDiscoveryService.cs
+++ b/src/SkyCD.App/Services/RuntimePluginDiscoveryService.cs
@@ -1,0 +1,80 @@
+using SkyCD.Presentation.ViewModels;
+using SkyCD.Plugin.Runtime.Discovery;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace SkyCD.App.Services;
+
+public sealed class RuntimePluginDiscoveryService
+{
+    private readonly PluginDiscoveryService discoveryService = new();
+    private readonly Version hostVersion = new(3, 0, 0);
+
+    public IReadOnlyList<OptionsPluginItem> Discover(string pluginPath)
+    {
+        if (string.IsNullOrWhiteSpace(pluginPath) || !Directory.Exists(pluginPath))
+        {
+            return [];
+        }
+
+        var discovered = new List<OptionsPluginItem>();
+        var seenPluginIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var dllPaths = Directory.GetFiles(pluginPath, "*.dll", SearchOption.AllDirectories);
+        foreach (var dllPath in dllPaths)
+        {
+            TryDiscoverFromAssembly(dllPath, seenPluginIds, discovered);
+        }
+
+        return discovered
+            .OrderBy(static plugin => plugin.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private void TryDiscoverFromAssembly(
+        string dllPath,
+        ISet<string> seenPluginIds,
+        ICollection<OptionsPluginItem> output)
+    {
+        Assembly assembly;
+        try
+        {
+            assembly = Assembly.LoadFrom(dllPath);
+        }
+        catch
+        {
+            return;
+        }
+
+        IReadOnlyList<DiscoveredPlugin> plugins;
+        try
+        {
+            plugins = discoveryService.DiscoverFromAssembly(assembly, hostVersion);
+        }
+        catch
+        {
+            return;
+        }
+
+        foreach (var plugin in plugins)
+        {
+            var descriptor = plugin.Plugin.Descriptor;
+            if (!seenPluginIds.Add(descriptor.Id))
+            {
+                continue;
+            }
+
+            var capabilitySummary = plugin.Capabilities.Count == 0
+                ? "Generic"
+                : string.Join(", ", plugin.Capabilities
+                    .Select(static capability => capability.GetType().Name)
+                    .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase));
+
+            var extendedInfo = $"{descriptor.Id} v{descriptor.Version}";
+            output.Add(new OptionsPluginItem(descriptor.DisplayName, capabilitySummary, extendedInfo));
+        }
+    }
+}

--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -1,13 +1,20 @@
 using Avalonia.Controls;
+using Avalonia.Platform.Storage;
+using SkyCD.App.Models;
+using SkyCD.App.Services;
 using SkyCD.Presentation.ViewModels;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace SkyCD.App.Views;
 
 public partial class MainWindow : Window
 {
+    private readonly AppOptionsStore appOptionsStore = new();
+    private readonly RuntimePluginDiscoveryService pluginDiscoveryService = new();
     private MainWindowViewModel? subscribedViewModel;
 
     public MainWindow()
@@ -22,6 +29,7 @@ public partial class MainWindow : Window
         {
             subscribedViewModel.AddToListRequested -= OnAddToListRequested;
             subscribedViewModel.AboutRequested -= OnAboutRequested;
+            subscribedViewModel.OptionsRequested -= OnOptionsRequested;
             subscribedViewModel.PropertiesRequested -= OnPropertiesRequested;
         }
 
@@ -30,6 +38,7 @@ public partial class MainWindow : Window
         {
             subscribedViewModel.AddToListRequested += OnAddToListRequested;
             subscribedViewModel.AboutRequested += OnAboutRequested;
+            subscribedViewModel.OptionsRequested += OnOptionsRequested;
             subscribedViewModel.PropertiesRequested += OnPropertiesRequested;
         }
     }
@@ -84,6 +93,45 @@ public partial class MainWindow : Window
 
         var accepted = await dialog.ShowDialog<bool?>(this);
         e.Complete(accepted == true, e.Dialog.Comments);
+    }
+
+    private async void OnOptionsRequested(object? sender, OptionsDialogRequestedEventArgs e)
+    {
+        var options = appOptionsStore.Load();
+        var pluginPath = string.IsNullOrWhiteSpace(options.PluginPath)
+            ? ResolveDefaultPluginPath()
+            : options.PluginPath;
+
+        e.Dialog.PluginPath = pluginPath;
+        if (!string.IsNullOrWhiteSpace(options.Language) &&
+            e.Dialog.Languages.Any(language => language.Equals(options.Language, StringComparison.OrdinalIgnoreCase)))
+        {
+            e.Dialog.SelectedLanguage = options.Language;
+        }
+
+        e.Dialog.BrowsePluginPathRequested += OnBrowsePluginPathRequested;
+        e.Dialog.RefreshPluginsRequested += OnRefreshPluginsRequested;
+        RefreshPlugins(e.Dialog);
+
+        var dialog = new OptionsWindow
+        {
+            DataContext = e.Dialog
+        };
+
+        var accepted = await dialog.ShowDialog<bool?>(this);
+        if (accepted == true)
+        {
+            appOptionsStore.Save(new AppOptions
+            {
+                PluginPath = e.Dialog.PluginPath,
+                Language = e.Dialog.SelectedLanguage
+            });
+        }
+
+        e.Dialog.BrowsePluginPathRequested -= OnBrowsePluginPathRequested;
+        e.Dialog.RefreshPluginsRequested -= OnRefreshPluginsRequested;
+
+        e.Complete(accepted == true, e.Dialog.PluginPath, e.Dialog.SelectedLanguage);
     }
 
     private async void OnAboutRequested(object? sender, EventArgs e)
@@ -145,5 +193,60 @@ public partial class MainWindow : Window
                 ("Updating indexes...", 100)
             ]
         };
+    }
+
+    private async void OnBrowsePluginPathRequested(object? sender, EventArgs e)
+    {
+        if (sender is not OptionsDialogViewModel dialogVm)
+        {
+            return;
+        }
+
+        var picked = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Select plug-in directory",
+            AllowMultiple = false
+        });
+
+        if (picked.Count == 0)
+        {
+            return;
+        }
+
+        var pickedPath = picked[0].TryGetLocalPath();
+        if (string.IsNullOrWhiteSpace(pickedPath))
+        {
+            return;
+        }
+
+        dialogVm.PluginPath = pickedPath;
+        RefreshPlugins(dialogVm);
+    }
+
+    private void OnRefreshPluginsRequested(object? sender, EventArgs e)
+    {
+        if (sender is not OptionsDialogViewModel dialogVm)
+        {
+            return;
+        }
+
+        RefreshPlugins(dialogVm);
+    }
+
+    private void RefreshPlugins(OptionsDialogViewModel dialogVm)
+    {
+        var plugins = pluginDiscoveryService.Discover(dialogVm.PluginPath);
+        dialogVm.SetPlugins(plugins);
+    }
+
+    private static string ResolveDefaultPluginPath()
+    {
+        var candidates = new[]
+        {
+            Path.Combine(Environment.CurrentDirectory, "Plugins", "samples"),
+            Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "Plugins", "samples"))
+        };
+
+        return candidates.FirstOrDefault(Directory.Exists) ?? string.Empty;
     }
 }

--- a/src/SkyCD.App/Views/OptionsWindow.axaml
+++ b/src/SkyCD.App/Views/OptionsWindow.axaml
@@ -1,0 +1,100 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:SkyCD.Presentation.ViewModels;assembly=SkyCD.Presentation"
+        x:Class="SkyCD.App.Views.OptionsWindow"
+        x:DataType="vm:OptionsDialogViewModel"
+        Width="760"
+        Height="520"
+        MinWidth="700"
+        MinHeight="460"
+        WindowStartupLocation="CenterOwner"
+        Title="Options">
+
+    <Design.DataContext>
+        <vm:OptionsDialogViewModel/>
+    </Design.DataContext>
+
+    <Grid RowDefinitions="*,Auto" Margin="14">
+        <TabControl>
+            <TabItem Header="Plug-Ins">
+                <Grid RowDefinitions="Auto,Auto,*,Auto,Auto" RowSpacing="8" Margin="10">
+                    <TextBlock Text="Plug-In Path"/>
+                    <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                        <TextBox Text="{Binding PluginPath}"/>
+                        <Button Grid.Column="1"
+                                Content="Browse..."
+                                MinWidth="90"
+                                Command="{Binding BrowsePluginPathCommand}"/>
+                    </Grid>
+
+                    <Border Grid.Row="2"
+                            Margin="0,4,0,0"
+                            BorderBrush="#D4D4D4"
+                            BorderThickness="1">
+                        <Grid RowDefinitions="Auto,*">
+                            <Border BorderBrush="#D4D4D4" BorderThickness="0,0,0,1" Background="#F5F5F5" Padding="8,6">
+                                <Grid ColumnDefinitions="2*,2*,3*">
+                                    <TextBlock Text="Name" FontWeight="SemiBold"/>
+                                    <TextBlock Grid.Column="1" Text="Type" FontWeight="SemiBold"/>
+                                    <TextBlock Grid.Column="2" Text="Extended Info" FontWeight="SemiBold"/>
+                                </Grid>
+                            </Border>
+
+                            <ListBox Grid.Row="1"
+                                     ItemsSource="{Binding Plugins}"
+                                     SelectedItem="{Binding SelectedPlugin}">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:OptionsPluginItem">
+                                        <Border BorderBrush="#E6E6E6" BorderThickness="0,0,0,1" Padding="8,5">
+                                            <Grid ColumnDefinitions="2*,2*,3*">
+                                                <TextBlock Text="{Binding Name}"/>
+                                                <TextBlock Grid.Column="1" Text="{Binding Type}"/>
+                                                <TextBlock Grid.Column="2" Text="{Binding ExtendedInfo}"/>
+                                            </Grid>
+                                        </Border>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </Grid>
+                    </Border>
+
+                    <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8">
+                        <Button Content="Refresh"
+                                MinWidth="90"
+                                Command="{Binding RefreshPluginsCommand}"/>
+                        <Button Content="Configure"
+                                MinWidth="90"
+                                Command="{Binding ConfigurePluginCommand}"/>
+                    </StackPanel>
+
+                    <TextBlock Grid.Row="4"
+                               Foreground="#404040"
+                               Text="{Binding InfoMessage}"
+                               TextWrapping="Wrap"/>
+                </Grid>
+            </TabItem>
+
+            <TabItem Header="Language">
+                <Grid Margin="10" RowDefinitions="Auto,*" RowSpacing="8">
+                    <TextBlock Text="Select interface language"/>
+                    <ListBox Grid.Row="1"
+                             ItemsSource="{Binding Languages}"
+                             SelectedItem="{Binding SelectedLanguage}"/>
+                </Grid>
+            </TabItem>
+        </TabControl>
+
+        <StackPanel Grid.Row="1"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="8"
+                    Margin="0,12,0,0">
+            <Button Content="OK"
+                    MinWidth="90"
+                    Command="{Binding ConfirmCommand}"/>
+            <Button Content="Cancel"
+                    MinWidth="90"
+                    Click="OnCancelClicked"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/SkyCD.App/Views/OptionsWindow.axaml.cs
+++ b/src/SkyCD.App/Views/OptionsWindow.axaml.cs
@@ -1,0 +1,45 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using SkyCD.Presentation.ViewModels;
+using System;
+using System.ComponentModel;
+
+namespace SkyCD.App.Views;
+
+public partial class OptionsWindow : Window
+{
+    public OptionsWindow()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (sender is not OptionsWindow window)
+        {
+            return;
+        }
+
+        if (window.DataContext is OptionsDialogViewModel vm)
+        {
+            vm.PropertyChanged -= OnViewModelPropertyChanged;
+            vm.PropertyChanged += OnViewModelPropertyChanged;
+        }
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (sender is OptionsDialogViewModel vm &&
+            e.PropertyName == nameof(OptionsDialogViewModel.DialogAccepted) &&
+            vm.DialogAccepted)
+        {
+            Close(true);
+        }
+    }
+
+    private void OnCancelClicked(object? sender, RoutedEventArgs e)
+    {
+        Close(false);
+    }
+}

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -16,6 +16,7 @@ public partial class MainWindowViewModel : ObservableObject
 
     public event EventHandler? AddToListRequested;
     public event EventHandler? AboutRequested;
+    public event EventHandler<OptionsDialogRequestedEventArgs>? OptionsRequested;
     public event EventHandler<PropertiesDialogRequestedEventArgs>? PropertiesRequested;
 
     public MainWindowViewModel()
@@ -243,7 +244,26 @@ public partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private void OpenOptions()
     {
-        StatusText = "Options dialog is not implemented yet.";
+        if (OptionsRequested is null)
+        {
+            StatusText = "Options dialog is not implemented yet.";
+            return;
+        }
+
+        var dialog = new OptionsDialogViewModel(["English", "Lithuanian"]);
+        OptionsRequested.Invoke(this, new OptionsDialogRequestedEventArgs
+        {
+            Dialog = dialog,
+            Complete = (accepted, pluginPath, language) =>
+            {
+                if (!accepted)
+                {
+                    return;
+                }
+
+                StatusText = $"Options saved (Language: {language}).";
+            }
+        });
     }
 
     [RelayCommand]

--- a/src/SkyCD.Presentation/ViewModels/OptionsDialogRequestedEventArgs.cs
+++ b/src/SkyCD.Presentation/ViewModels/OptionsDialogRequestedEventArgs.cs
@@ -1,0 +1,8 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public sealed class OptionsDialogRequestedEventArgs : EventArgs
+{
+    public required OptionsDialogViewModel Dialog { get; init; }
+
+    public required Action<bool, string, string> Complete { get; init; }
+}

--- a/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
@@ -1,0 +1,104 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Collections.ObjectModel;
+
+namespace SkyCD.Presentation.ViewModels;
+
+public partial class OptionsDialogViewModel : ObservableObject
+{
+    public OptionsDialogViewModel()
+        : this(["English", "Lithuanian"])
+    {
+    }
+
+    public OptionsDialogViewModel(IEnumerable<string> availableLanguages)
+    {
+        foreach (var language in availableLanguages.Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            Languages.Add(language);
+        }
+
+        if (Languages.Count == 0)
+        {
+            Languages.Add("English");
+        }
+
+        selectedLanguage = Languages[0];
+    }
+
+    public ObservableCollection<OptionsPluginItem> Plugins { get; } = [];
+
+    public ObservableCollection<string> Languages { get; } = [];
+
+    [ObservableProperty]
+    private string pluginPath = string.Empty;
+
+    [ObservableProperty]
+    private OptionsPluginItem? selectedPlugin;
+
+    [ObservableProperty]
+    private string selectedLanguage;
+
+    [ObservableProperty]
+    private string infoMessage = string.Empty;
+
+    [ObservableProperty]
+    private bool dialogAccepted;
+
+    public event EventHandler? BrowsePluginPathRequested;
+
+    public event EventHandler? RefreshPluginsRequested;
+
+    [RelayCommand]
+    private void BrowsePluginPath()
+    {
+        BrowsePluginPathRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    [RelayCommand]
+    private void RefreshPlugins()
+    {
+        RefreshPluginsRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanConfigure))]
+    private void ConfigurePlugin()
+    {
+        if (SelectedPlugin is null)
+        {
+            return;
+        }
+
+        InfoMessage = $"Configure '{SelectedPlugin.Name}' is not implemented yet.";
+    }
+
+    [RelayCommand]
+    private void Confirm()
+    {
+        DialogAccepted = true;
+    }
+
+    private bool CanConfigure()
+    {
+        return SelectedPlugin is not null;
+    }
+
+    public void SetPlugins(IEnumerable<OptionsPluginItem> plugins)
+    {
+        var snapshot = plugins.ToArray();
+        Plugins.Clear();
+        foreach (var plugin in snapshot)
+        {
+            Plugins.Add(plugin);
+        }
+
+        SelectedPlugin = Plugins.FirstOrDefault();
+        InfoMessage = $"Loaded {Plugins.Count} plugin(s).";
+        ConfigurePluginCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnSelectedPluginChanged(OptionsPluginItem? value)
+    {
+        ConfigurePluginCommand.NotifyCanExecuteChanged();
+    }
+}

--- a/src/SkyCD.Presentation/ViewModels/OptionsPluginItem.cs
+++ b/src/SkyCD.Presentation/ViewModels/OptionsPluginItem.cs
@@ -1,0 +1,6 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public sealed record OptionsPluginItem(
+    string Name,
+    string Type,
+    string ExtendedInfo);

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -247,6 +247,32 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void OpenOptionsCommand_RaisesRequest_WhenSubscriberIsPresent()
+    {
+        var vm = new MainWindowViewModel();
+        OptionsDialogRequestedEventArgs? request = null;
+        vm.OptionsRequested += (_, args) => request = args;
+
+        vm.OpenOptionsCommand.Execute(null);
+
+        Assert.NotNull(request);
+        Assert.Equal(["English", "Lithuanian"], request!.Dialog.Languages);
+
+        request.Complete(true, @"C:\Plugins", "Lithuanian");
+        Assert.Equal("Options saved (Language: Lithuanian).", vm.StatusText);
+    }
+
+    [Fact]
+    public void OpenOptionsCommand_WithoutSubscriber_UsesFallbackStatus()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.OpenOptionsCommand.Execute(null);
+
+        Assert.Equal("Options dialog is not implemented yet.", vm.StatusText);
+    }
+
+    [Fact]
     public void OpenPropertiesCommand_RaisesRequestWithSelectedObjectValues()
     {
         var vm = new MainWindowViewModel();

--- a/tests/SkyCD.App.Tests/OptionsDialogViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/OptionsDialogViewModelTests.cs
@@ -1,0 +1,44 @@
+using SkyCD.Presentation.ViewModels;
+
+namespace SkyCD.App.Tests;
+
+public class OptionsDialogViewModelTests
+{
+    [Fact]
+    public void Constructor_InitializesLanguageSelection()
+    {
+        var vm = new OptionsDialogViewModel(["English", "Lithuanian"]);
+
+        Assert.Equal(["English", "Lithuanian"], vm.Languages);
+        Assert.Equal("English", vm.SelectedLanguage);
+    }
+
+    [Fact]
+    public void RefreshPluginsCommand_RaisesRefreshRequest()
+    {
+        var vm = new OptionsDialogViewModel(["English"]);
+        var raised = false;
+        vm.RefreshPluginsRequested += (_, _) => raised = true;
+
+        vm.RefreshPluginsCommand.Execute(null);
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public void SetPlugins_SelectsFirstPluginAndEnablesConfigure()
+    {
+        var vm = new OptionsDialogViewModel(["English"]);
+        var plugins = new[]
+        {
+            new OptionsPluginItem("JSON", "IFileFormatPluginCapability", "skycd.plugin.sample.json v2.0.0"),
+            new OptionsPluginItem("XML", "IFileFormatPluginCapability", "skycd.plugin.sample.xml v2.0.0")
+        };
+
+        vm.SetPlugins(plugins);
+
+        Assert.Equal(2, vm.Plugins.Count);
+        Assert.Equal("JSON", vm.SelectedPlugin?.Name);
+        Assert.True(vm.ConfigurePluginCommand.CanExecute(null));
+    }
+}


### PR DESCRIPTION
## Summary
Implements issue #139 by recreating the legacy Options flow with Plug-Ins and Language tabs, wiring it into the main shell command path, and persisting the selected settings.

## What changed
- Added Options dialog support in presentation layer:
  - OptionsDialogViewModel
  - OptionsPluginItem
  - OptionsDialogRequestedEventArgs
- Wired OpenOptionsCommand in MainWindowViewModel to request the dialog from the app layer.
- Added new Avalonia OptionsWindow with two tabs:
  - Plug-Ins tab: plugin path field + browse action, plugin list with Name/Type/Extended Info columns, Refresh and Configure actions.
  - Language tab: language selection list.
- Added app-level options persistence:
  - AppOptions model
  - AppOptionsStore saving/loading %AppData%/SkyCD/options.json
- Added runtime plugin refresh service:
  - RuntimePluginDiscoveryService discovers plugin implementations by scanning assemblies in the configured plugin path.
- Hooked dialog behavior in MainWindow:
  - loads saved options before showing dialog
  - refreshes plugin list on open and via Refresh button
  - handles Browse folder selection
  - saves selected plugin path and language on OK

## Validation
- dotnet build src/SkyCD.App/SkyCD.App.csproj
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj

Fixes #139