### PR TITLE
Fix issue #166: Disable maximize button on Options window

### DIFF
--- a/src/SkyCD.App/Views/OptionsWindow.axaml
+++ b/src/SkyCD.App/Views/OptionsWindow.axaml
@@ -8,6 +8,7 @@
         MinWidth="700"
         MinHeight="460"
         WindowStartupLocation="CenterOwner"
+        CanResize="False"
         Title="Options">
 
     <Design.DataContext>


### PR DESCRIPTION
## Issue
Fixes #166 - The Options dialog window has a working maximize button, but it's a dialog and should not allow maximizing.

## Solution
- Set CanResize='False' on the OptionsWindow in XAML
- This prevents the maximize button from being functional
- Maintains dialog-like behavior consistent with other dialogs in the application