### PR TITLE
Fix issue #175: Improve Properties dialog Info tab header readability

### DIFF
--- a/src/SkyCD.App/Views/PropertiesWindow.axaml
+++ b/src/SkyCD.App/Views/PropertiesWindow.axaml
@@ -51,9 +51,9 @@
             <TabItem Header="Info" IsVisible="{Binding HasInfoTab}">
                 <Border Margin="8,8,8,10" BorderBrush="#D8D8D8" BorderThickness="1">
                     <Grid RowDefinitions="Auto,*">
-                        <Grid ColumnDefinitions="183,*" Background="#F5F5F5">
-                            <TextBlock Margin="8,5" Text="Property" FontWeight="SemiBold"/>
-                            <TextBlock Grid.Column="1" Margin="8,5" Text="Value" FontWeight="SemiBold"/>
+                        <Grid ColumnDefinitions="183,*" Background="#E8E8E8">
+                            <TextBlock Margin="8,5" Text="Property" FontWeight="SemiBold" Foreground="#000000"/>
+                            <TextBlock Grid.Column="1" Margin="8,5" Text="Value" FontWeight="SemiBold" Foreground="#000000"/>
                         </Grid>
                         <ListBox Grid.Row="1"
                                  BorderThickness="0"


### PR DESCRIPTION
## Issue
Fixes #175 - The header text in the Properties dialog's Info tab is not readable and needs better visibility.

## Solution
- Changed header background color from #F5F5F5 to #E8E8E8 for better contrast
- Added explicit black text color (#000000) to the header TextBlocks
- Improves visual distinction and ensures header text is clearly readable
- Consistent with standard Windows dialog styling