### PR TITLE
Feature #164: Add language flags to Options dialog

### DIFF
--- a/src/SkyCD.App/Views/OptionsWindow.axaml
+++ b/src/SkyCD.App/Views/OptionsWindow.axaml
@@ -79,7 +79,13 @@
                     <TextBlock Text="Select interface language"/>
                     <ListBox Grid.Row="1"
                              ItemsSource="{Binding Languages}"
-                             SelectedItem="{Binding SelectedLanguage}"/>
+                             SelectedItem="{Binding SelectedLanguage}">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate x:DataType="vm:LanguageItem">
+                                <TextBlock Text="{Binding DisplayText}"/>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
                 </Grid>
             </TabItem>
         </TabControl>

--- a/src/SkyCD.Presentation/ViewModels/LanguageItem.cs
+++ b/src/SkyCD.Presentation/ViewModels/LanguageItem.cs
@@ -1,0 +1,56 @@
+namespace SkyCD.Presentation.ViewModels;
+
+/// <summary>
+/// Represents a language option with display name and flag emoji.
+/// </summary>
+public sealed record LanguageItem(string Name, string Flag)
+{
+    /// <summary>
+    /// Gets the display text combining flag and language name.
+    /// </summary>
+    public string DisplayText => $"{Flag} {Name}";
+
+    /// <summary>
+    /// Gets common language flag mappings.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> FlagMappings =>
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "English", "🇬🇧" },
+            { "Lithuanian", "🇱🇹" },
+            { "Russian", "🇷🇺" },
+            { "Polish", "🇵🇱" },
+            { "German", "🇩🇪" },
+            { "French", "🇫🇷" },
+            { "Spanish", "🇪🇸" },
+            { "Italian", "🇮🇹" },
+            { "Portuguese", "🇵🇹" },
+            { "Dutch", "🇳🇱" },
+            { "Swedish", "🇸🇪" },
+            { "Norwegian", "🇳🇴" },
+            { "Danish", "🇩🇰" },
+            { "Finnish", "🇫🇮" },
+            { "Greek", "🇬🇷" },
+            { "Czech", "🇨🇿" },
+            { "Slovak", "🇸🇰" },
+            { "Hungarian", "🇭🇺" },
+            { "Romanian", "🇷🇴" },
+            { "Bulgarian", "🇧🇬" },
+            { "Croatian", "🇭🇷" },
+            { "Serbian", "🇷🇸" },
+            { "Ukrainian", "🇺🇦" },
+            { "Turkish", "🇹🇷" },
+            { "Japanese", "🇯🇵" },
+            { "Chinese", "🇨🇳" },
+            { "Korean", "🇰🇷" },
+        };
+
+    /// <summary>
+    /// Creates a LanguageItem from a language name, auto-detecting the flag.
+    /// </summary>
+    public static LanguageItem Create(string languageName)
+    {
+        var flag = FlagMappings.TryGetValue(languageName, out var f) ? f : "🌐";
+        return new LanguageItem(languageName, flag);
+    }
+}

--- a/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
@@ -15,12 +15,12 @@ public partial class OptionsDialogViewModel : ObservableObject
     {
         foreach (var language in availableLanguages.Distinct(StringComparer.OrdinalIgnoreCase))
         {
-            Languages.Add(language);
+            Languages.Add(LanguageItem.Create(language));
         }
 
         if (Languages.Count == 0)
         {
-            Languages.Add("English");
+            Languages.Add(LanguageItem.Create("English"));
         }
 
         selectedLanguage = Languages[0];
@@ -28,7 +28,7 @@ public partial class OptionsDialogViewModel : ObservableObject
 
     public ObservableCollection<OptionsPluginItem> Plugins { get; } = [];
 
-    public ObservableCollection<string> Languages { get; } = [];
+    public ObservableCollection<LanguageItem> Languages { get; } = [];
 
     [ObservableProperty]
     private string pluginPath = string.Empty;
@@ -37,7 +37,7 @@ public partial class OptionsDialogViewModel : ObservableObject
     private OptionsPluginItem? selectedPlugin;
 
     [ObservableProperty]
-    private string selectedLanguage;
+    private LanguageItem selectedLanguage;
 
     [ObservableProperty]
     private string infoMessage = string.Empty;


### PR DESCRIPTION
## Issue
Implements #164 - Language selection in Options dialog should display flags before language names.

## Solution
- Created new LanguageItem record with Name and Flag properties
- Added DisplayText property that combines flag emoji with language name
- Includes comprehensive flag mappings for 25+ common languages
- Updated OptionsDialogViewModel to use LanguageItem instead of plain strings
- Updated language ListBox in OptionsWindow to display flags using template

## Implementation
- New file: src/SkyCD.Presentation/ViewModels/LanguageItem.cs
- Uses Unicode flag emojis for visual appeal and clarity
- Falls back to globe emoji 🌐 for unknown languages
- Provides extensible FlagMappings dictionary for easy customization