### PR TITLE
Feature #168: Set consistent window icons for all dialogs

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml
+++ b/src/SkyCD.App/Views/MainWindow.axaml
@@ -6,7 +6,7 @@
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
         x:Class="SkyCD.App.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
-        Icon="/Assets/avalonia-logo.ico"
+        Icon="/Assets/skycd.ico"
         MinWidth="700"
         MinHeight="450"
         Title="SkyCD">

--- a/src/SkyCD.App/Views/OptionsWindow.axaml
+++ b/src/SkyCD.App/Views/OptionsWindow.axaml
@@ -8,6 +8,7 @@
         MinWidth="700"
         MinHeight="460"
         WindowStartupLocation="CenterOwner"
+        Icon="/Assets/skycd.ico"
         Title="Options">
 
     <Design.DataContext>

--- a/src/SkyCD.App/Views/PropertiesWindow.axaml
+++ b/src/SkyCD.App/Views/PropertiesWindow.axaml
@@ -12,6 +12,7 @@
         CanResize="False"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
+        Icon="/Assets/skycd.ico"
         Title="Properties">
 
     <Grid RowDefinitions="*,Auto" Margin="0">


### PR DESCRIPTION
## Issue
Implements #168 - All window forms should have consistent icons like in the previous version for consistency.

## Solution
- Added Icon property to OptionsWindow pointing to /Assets/skycd.ico
- Added Icon property to PropertiesWindow pointing to /Assets/skycd.ico  
- Updated MainWindow to use /Assets/skycd.ico instead of avalonia-logo.ico
- All windows now display consistent SkyCD application branding

## Benefits
- Professional appearance with consistent branding
- Users see familiar SkyCD icon in taskbar and window decorations
- Matches legacy application presentation
- Helps differentiate from other applications