### PR TITLE
Fix issue #162: Disable Configure button when plugin doesn't support configuration

### DIFF
--- a/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
@@ -80,7 +80,7 @@ public partial class OptionsDialogViewModel : ObservableObject
 
     private bool CanConfigure()
     {
-        return SelectedPlugin is not null;
+        return SelectedPlugin is not null && SelectedPlugin.SupportsConfiguration;
     }
 
     public void SetPlugins(IEnumerable<OptionsPluginItem> plugins)

--- a/src/SkyCD.Presentation/ViewModels/OptionsPluginItem.cs
+++ b/src/SkyCD.Presentation/ViewModels/OptionsPluginItem.cs
@@ -1,6 +1,10 @@
 namespace SkyCD.Presentation.ViewModels;
 
+/// <summary>
+/// Represents a plugin item in the Options dialog.
+/// </summary>
 public sealed record OptionsPluginItem(
     string Name,
     string Type,
-    string ExtendedInfo);
+    string ExtendedInfo,
+    bool SupportsConfiguration = false);

--- a/tests/SkyCD.App.Tests/OptionsDialogViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/OptionsDialogViewModelTests.cs
@@ -31,8 +31,8 @@ public class OptionsDialogViewModelTests
         var vm = new OptionsDialogViewModel(["English"]);
         var plugins = new[]
         {
-            new OptionsPluginItem("JSON", "IFileFormatPluginCapability", "skycd.plugin.sample.json v2.0.0"),
-            new OptionsPluginItem("XML", "IFileFormatPluginCapability", "skycd.plugin.sample.xml v2.0.0")
+            new OptionsPluginItem("JSON", "IFileFormatPluginCapability", "skycd.plugin.sample.json v2.0.0", SupportsConfiguration: true),
+            new OptionsPluginItem("XML", "IFileFormatPluginCapability", "skycd.plugin.sample.xml v2.0.0", SupportsConfiguration: true)
         };
 
         vm.SetPlugins(plugins);
@@ -40,5 +40,22 @@ public class OptionsDialogViewModelTests
         Assert.Equal(2, vm.Plugins.Count);
         Assert.Equal("JSON", vm.SelectedPlugin?.Name);
         Assert.True(vm.ConfigurePluginCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void SetPlugins_DisablesConfigureWhenPluginDoesntSupportConfiguration()
+    {
+        var vm = new OptionsDialogViewModel(["English"]);
+        var plugins = new[]
+        {
+            new OptionsPluginItem("JSON", "IFileFormatPluginCapability", "skycd.plugin.sample.json v2.0.0", SupportsConfiguration: false),
+            new OptionsPluginItem("XML", "IFileFormatPluginCapability", "skycd.plugin.sample.xml v2.0.0", SupportsConfiguration: false)
+        };
+
+        vm.SetPlugins(plugins);
+
+        Assert.Equal(2, vm.Plugins.Count);
+        Assert.Equal("JSON", vm.SelectedPlugin?.Name);
+        Assert.False(vm.ConfigurePluginCommand.CanExecute(null));
     }
 }


### PR DESCRIPTION
## Issue
Fixes #162 - The 'configure' button in the options dialog should be disabled for plugins that don't support configuration.

## Solution
- Added SupportsConfiguration boolean property to OptionsPluginItem record (defaults to false)
- Updated CanConfigure() method in OptionsDialogViewModel to check:
  1. A plugin is selected
  2. The selected plugin supports configuration
- Updated existing tests and added new test case
- All tests pass (60/60)

## Testing
- Updated SetPlugins_SelectsFirstPluginAndEnablesConfigure test to pass SupportsConfiguration: true
- Added new SetPlugins_DisablesConfigureWhenPluginDoesntSupportConfiguration test
- Verified all 60 unit tests pass