### PR TITLE
Fix #163: persist plugin enable/disable checkboxes in Options

### DIFF
--- a/src/SkyCD.App/Models/AppOptions.cs
+++ b/src/SkyCD.App/Models/AppOptions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace SkyCD.App.Models;
 
 public sealed class AppOptions
@@ -19,4 +21,6 @@ public sealed class AppOptions
     public string PluginPath { get; set; } = string.Empty;
 
     public string Language { get; set; } = "English";
+
+    public List<string> DisabledPluginIds { get; set; } = [];
 }

--- a/src/SkyCD.App/Services/RuntimePluginDiscoveryService.cs
+++ b/src/SkyCD.App/Services/RuntimePluginDiscoveryService.cs
@@ -74,7 +74,11 @@ public sealed class RuntimePluginDiscoveryService
                     .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase));
 
             var extendedInfo = $"{descriptor.Id} v{descriptor.Version}";
-            output.Add(new OptionsPluginItem(descriptor.DisplayName, capabilitySummary, extendedInfo));
+            output.Add(new OptionsPluginItem(
+                descriptor.DisplayName,
+                capabilitySummary,
+                extendedInfo,
+                id: descriptor.Id));
         }
     }
 }

--- a/src/SkyCD.App/Styles/IconStyles.axaml
+++ b/src/SkyCD.App/Styles/IconStyles.axaml
@@ -22,10 +22,4 @@
         <Setter Property="VerticalAlignment" Value="Center"/>
     </Style>
 
-    <!-- Proper grid column for icons in list views -->
-    <Style Selector="Grid.ListViewRow">
-        <!-- First column is icon -->
-        <Setter Property="ColumnDefinitions" Value="40,*"/>
-    </Style>
-
 </Styles>

--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -161,11 +161,13 @@ public partial class MainWindow : Window
 
         e.Dialog.PluginPath = pluginPath;
         if (!string.IsNullOrWhiteSpace(options.Language) &&
-            e.Dialog.Languages.Any(language => language.Equals(options.Language, StringComparison.OrdinalIgnoreCase)))
+            e.Dialog.Languages.FirstOrDefault(language =>
+                string.Equals(language.Name, options.Language, StringComparison.OrdinalIgnoreCase)) is { } language)
         {
-            e.Dialog.SelectedLanguage = options.Language;
+            e.Dialog.SelectedLanguage = language;
         }
 
+        e.Dialog.SetDisabledPluginIds(options.DisabledPluginIds);
         e.Dialog.BrowsePluginPathRequested += OnBrowsePluginPathRequested;
         e.Dialog.RefreshPluginsRequested += OnRefreshPluginsRequested;
         RefreshPlugins(e.Dialog);
@@ -178,17 +180,16 @@ public partial class MainWindow : Window
         var accepted = await dialog.ShowDialog<bool?>(this);
         if (accepted == true)
         {
-            appOptionsStore.Save(new AppOptions
-            {
-                PluginPath = e.Dialog.PluginPath,
-                Language = e.Dialog.SelectedLanguage
-            });
+            options.PluginPath = e.Dialog.PluginPath;
+            options.Language = e.Dialog.SelectedLanguage.Name;
+            options.DisabledPluginIds = e.Dialog.GetDisabledPluginIds().ToList();
+            appOptionsStore.Save(options);
         }
 
         e.Dialog.BrowsePluginPathRequested -= OnBrowsePluginPathRequested;
         e.Dialog.RefreshPluginsRequested -= OnRefreshPluginsRequested;
 
-        e.Complete(accepted == true, e.Dialog.PluginPath, e.Dialog.SelectedLanguage);
+        e.Complete(accepted == true, e.Dialog.PluginPath, e.Dialog.SelectedLanguage.Name);
     }
 
     private async void OnAboutRequested(object? sender, EventArgs e)
@@ -348,6 +349,7 @@ public partial class MainWindow : Window
 
     private void RefreshPlugins(OptionsDialogViewModel dialogVm)
     {
+        dialogVm.CapturePluginStates();
         var plugins = pluginDiscoveryService.Discover(dialogVm.PluginPath);
         dialogVm.SetPlugins(plugins);
     }

--- a/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
@@ -6,6 +6,8 @@ namespace SkyCD.Presentation.ViewModels;
 
 public partial class OptionsDialogViewModel : ObservableObject
 {
+    private readonly HashSet<string> disabledPluginIds = new(StringComparer.OrdinalIgnoreCase);
+
     public OptionsDialogViewModel()
         : this(["English", "Lithuanian"])
     {
@@ -89,12 +91,49 @@ public partial class OptionsDialogViewModel : ObservableObject
         Plugins.Clear();
         foreach (var plugin in snapshot)
         {
+            plugin.IsEnabled = !disabledPluginIds.Contains(plugin.Id);
             Plugins.Add(plugin);
         }
 
         SelectedPlugin = Plugins.FirstOrDefault();
         InfoMessage = $"Loaded {Plugins.Count} plugin(s).";
         ConfigurePluginCommand.NotifyCanExecuteChanged();
+    }
+
+    public void SetDisabledPluginIds(IEnumerable<string>? pluginIds)
+    {
+        disabledPluginIds.Clear();
+        if (pluginIds is null)
+        {
+            return;
+        }
+
+        foreach (var pluginId in pluginIds.Where(static id => !string.IsNullOrWhiteSpace(id)))
+        {
+            disabledPluginIds.Add(pluginId);
+        }
+    }
+
+    public void CapturePluginStates()
+    {
+        if (Plugins.Count == 0)
+        {
+            return;
+        }
+
+        disabledPluginIds.Clear();
+        foreach (var plugin in Plugins.Where(static plugin => !plugin.IsEnabled))
+        {
+            disabledPluginIds.Add(plugin.Id);
+        }
+    }
+
+    public IReadOnlyList<string> GetDisabledPluginIds()
+    {
+        CapturePluginStates();
+        return disabledPluginIds
+            .OrderBy(static id => id, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
     }
 
     partial void OnSelectedPluginChanged(OptionsPluginItem? value)

--- a/src/SkyCD.Presentation/ViewModels/OptionsPluginItem.cs
+++ b/src/SkyCD.Presentation/ViewModels/OptionsPluginItem.cs
@@ -1,11 +1,38 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
 namespace SkyCD.Presentation.ViewModels;
 
 /// <summary>
 /// Represents a plugin item in the Options dialog.
 /// </summary>
-public sealed record OptionsPluginItem(
-    string Name,
-    string Type,
-    string ExtendedInfo,
-    bool SupportsConfiguration = false,
-    bool IsEnabled = true);
+public sealed partial class OptionsPluginItem : ObservableObject
+{
+    public OptionsPluginItem(
+        string name,
+        string type,
+        string extendedInfo,
+        bool supportsConfiguration = false,
+        bool isEnabled = true,
+        string? id = null)
+    {
+        Name = name;
+        Type = type;
+        ExtendedInfo = extendedInfo;
+        SupportsConfiguration = supportsConfiguration;
+        this.isEnabled = isEnabled;
+        Id = string.IsNullOrWhiteSpace(id) ? name : id;
+    }
+
+    public string Id { get; }
+
+    public string Name { get; }
+
+    public string Type { get; }
+
+    public string ExtendedInfo { get; }
+
+    public bool SupportsConfiguration { get; }
+
+    [ObservableProperty]
+    private bool isEnabled;
+}

--- a/tests/SkyCD.App.Tests/OptionsDialogViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/OptionsDialogViewModelTests.cs
@@ -31,8 +31,8 @@ public class OptionsDialogViewModelTests
         var vm = new OptionsDialogViewModel(["English"]);
         var plugins = new[]
         {
-            new OptionsPluginItem("JSON", "IFileFormatPluginCapability", "skycd.plugin.sample.json v2.0.0", SupportsConfiguration: true),
-            new OptionsPluginItem("XML", "IFileFormatPluginCapability", "skycd.plugin.sample.xml v2.0.0", SupportsConfiguration: true)
+            new OptionsPluginItem("JSON", "IFileFormatPluginCapability", "skycd.plugin.sample.json v2.0.0", supportsConfiguration: true),
+            new OptionsPluginItem("XML", "IFileFormatPluginCapability", "skycd.plugin.sample.xml v2.0.0", supportsConfiguration: true)
         };
 
         vm.SetPlugins(plugins);
@@ -48,8 +48,8 @@ public class OptionsDialogViewModelTests
         var vm = new OptionsDialogViewModel(["English"]);
         var plugins = new[]
         {
-            new OptionsPluginItem("JSON", "IFileFormatPluginCapability", "skycd.plugin.sample.json v2.0.0", SupportsConfiguration: false),
-            new OptionsPluginItem("XML", "IFileFormatPluginCapability", "skycd.plugin.sample.xml v2.0.0", SupportsConfiguration: false)
+            new OptionsPluginItem("JSON", "IFileFormatPluginCapability", "skycd.plugin.sample.json v2.0.0", supportsConfiguration: false),
+            new OptionsPluginItem("XML", "IFileFormatPluginCapability", "skycd.plugin.sample.xml v2.0.0", supportsConfiguration: false)
         };
 
         vm.SetPlugins(plugins);
@@ -57,5 +57,38 @@ public class OptionsDialogViewModelTests
         Assert.Equal(2, vm.Plugins.Count);
         Assert.Equal("JSON", vm.SelectedPlugin?.Name);
         Assert.False(vm.ConfigurePluginCommand.CanExecute(null));
+    }
+
+    [Fact]
+    public void SetPlugins_RespectsPreviouslyDisabledPluginIds()
+    {
+        var vm = new OptionsDialogViewModel(["English"]);
+        vm.SetDisabledPluginIds(["plugin.xml"]);
+
+        vm.SetPlugins(
+        [
+            new OptionsPluginItem("JSON", "IFileFormatPluginCapability", "json v2.0.0", id: "plugin.json"),
+            new OptionsPluginItem("XML", "IFileFormatPluginCapability", "xml v2.0.0", id: "plugin.xml")
+        ]);
+
+        Assert.True(vm.Plugins.Single(plugin => plugin.Id == "plugin.json").IsEnabled);
+        Assert.False(vm.Plugins.Single(plugin => plugin.Id == "plugin.xml").IsEnabled);
+    }
+
+    [Fact]
+    public void GetDisabledPluginIds_ReturnsUncheckedPluginIds()
+    {
+        var vm = new OptionsDialogViewModel(["English"]);
+        vm.SetPlugins(
+        [
+            new OptionsPluginItem("JSON", "IFileFormatPluginCapability", "json v2.0.0", id: "plugin.json"),
+            new OptionsPluginItem("XML", "IFileFormatPluginCapability", "xml v2.0.0", id: "plugin.xml")
+        ]);
+
+        vm.Plugins.Single(plugin => plugin.Id == "plugin.xml").IsEnabled = false;
+
+        var disabled = vm.GetDisabledPluginIds();
+
+        Assert.Equal(["plugin.xml"], disabled);
     }
 }


### PR DESCRIPTION
## Summary
- make OptionsPluginItem mutable/observable so checkbox changes in Options are captured
- persist disabled plugin IDs in AppOptions and reapply them when plugin list is reloaded
- preserve checkbox state across plugin refreshes and save disabled plugins on OK
- fix language selection type handling in MainWindow so the app builds from main
- remove invalid ColumnDefinitions style setter that failed Avalonia compilation

## Testing
- dotnet build SkyCD.slnx -c Release
- dotnet test SkyCD.slnx -c Release --no-build

Closes #163