### PR TITLE
Fix #164: ensure language flags display for all option variants

### DIFF
--- a/src/SkyCD.Presentation/ViewModels/LanguageItem.cs
+++ b/src/SkyCD.Presentation/ViewModels/LanguageItem.cs
@@ -50,7 +50,43 @@ public sealed record LanguageItem(string Name, string Flag)
     /// </summary>
     public static LanguageItem Create(string languageName)
     {
-        var flag = FlagMappings.TryGetValue(languageName, out var f) ? f : "🌐";
+        var flag = ResolveFlag(languageName);
         return new LanguageItem(languageName, flag);
+    }
+
+    private static string ResolveFlag(string languageName)
+    {
+        if (FlagMappings.TryGetValue(languageName, out var directMatch))
+        {
+            return directMatch;
+        }
+
+        var normalized = (languageName ?? string.Empty).Trim();
+        if (string.IsNullOrWhiteSpace(normalized))
+        {
+            return "🌐";
+        }
+
+        var bracketIndex = normalized.IndexOf('(');
+        if (bracketIndex > 0)
+        {
+            var baseName = normalized[..bracketIndex].Trim();
+            if (FlagMappings.TryGetValue(baseName, out var baseNameMatch))
+            {
+                return baseNameMatch;
+            }
+        }
+
+        var dashIndex = normalized.IndexOf('-');
+        if (dashIndex > 0)
+        {
+            var baseName = normalized[..dashIndex].Trim();
+            if (FlagMappings.TryGetValue(baseName, out var dashedMatch))
+            {
+                return dashedMatch;
+            }
+        }
+
+        return "🌐";
     }
 }

--- a/tests/SkyCD.App.Tests/LanguageItemTests.cs
+++ b/tests/SkyCD.App.Tests/LanguageItemTests.cs
@@ -1,0 +1,33 @@
+using SkyCD.Presentation.ViewModels;
+
+namespace SkyCD.App.Tests;
+
+public class LanguageItemTests
+{
+    [Fact]
+    public void Create_KnownLanguage_IncludesExpectedFlagInDisplayText()
+    {
+        var language = LanguageItem.Create("Lithuanian");
+
+        Assert.Equal("🇱🇹", language.Flag);
+        Assert.Equal("🇱🇹 Lithuanian", language.DisplayText);
+    }
+
+    [Fact]
+    public void Create_LanguageVariant_ResolvesFlagFromBaseName()
+    {
+        var language = LanguageItem.Create("English (US)");
+
+        Assert.Equal("🇬🇧", language.Flag);
+        Assert.Equal("🇬🇧 English (US)", language.DisplayText);
+    }
+
+    [Fact]
+    public void Create_UnknownLanguage_UsesFallbackFlag()
+    {
+        var language = LanguageItem.Create("Klingon");
+
+        Assert.Equal("🌐", language.Flag);
+        Assert.Equal("🌐 Klingon", language.DisplayText);
+    }
+}


### PR DESCRIPTION
## Summary
- harden LanguageItem.Create(...) to resolve flags for language variants like English (US) and English - UK
- keep fallback 🌐 for unknown languages
- add LanguageItemTests to lock in flag-before-name behavior used by Options language list

## Testing
- dotnet build SkyCD.slnx -c Release
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj -c Release
- dotnet test SkyCD.slnx -c Release --no-build

Closes #164