### PR TITLE
Fix #167: remove minimize button from dialog windows

### DIFF
--- a/src/SkyCD.App/Views/AboutWindow.axaml
+++ b/src/SkyCD.App/Views/AboutWindow.axaml
@@ -6,6 +6,7 @@
         Width="420"
         Height="260"
         CanResize="False"
+        CanMinimize="False"
         WindowStartupLocation="CenterOwner"
         Title="About SkyCD">
 

--- a/src/SkyCD.App/Views/AddToListWindow.axaml
+++ b/src/SkyCD.App/Views/AddToListWindow.axaml
@@ -8,6 +8,7 @@
         MinWidth="520"
         MinHeight="420"
         WindowStartupLocation="CenterOwner"
+        CanMinimize="False"
         Title="Add To List">
 
     <Design.DataContext>

--- a/src/SkyCD.App/Views/AddingProgressWindow.axaml
+++ b/src/SkyCD.App/Views/AddingProgressWindow.axaml
@@ -6,6 +6,7 @@
         Width="470"
         Height="140"
         CanResize="False"
+        CanMinimize="False"
         WindowStartupLocation="CenterOwner"
         WindowDecorations="BorderOnly"
         ShowInTaskbar="False"

--- a/src/SkyCD.App/Views/LoginWindow.axaml
+++ b/src/SkyCD.App/Views/LoginWindow.axaml
@@ -6,6 +6,7 @@
         Width="380"
         Height="210"
         CanResize="False"
+        CanMinimize="False"
         WindowStartupLocation="CenterOwner"
         Title="Server login">
 

--- a/src/SkyCD.App/Views/OptionsWindow.axaml
+++ b/src/SkyCD.App/Views/OptionsWindow.axaml
@@ -9,6 +9,7 @@
         MinHeight="460"
         WindowStartupLocation="CenterOwner"
         CanResize="False"
+        CanMinimize="False"
         Icon="/Assets/skycd.ico"
         Title="Options">
 

--- a/src/SkyCD.App/Views/PropertiesWindow.axaml
+++ b/src/SkyCD.App/Views/PropertiesWindow.axaml
@@ -10,6 +10,7 @@
         MaxWidth="411"
         MaxHeight="426"
         CanResize="False"
+        CanMinimize="False"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
         Icon="/Assets/skycd.ico"

--- a/src/SkyCD.App/Views/UnsavedChangesWindow.axaml
+++ b/src/SkyCD.App/Views/UnsavedChangesWindow.axaml
@@ -4,6 +4,7 @@
         Width="430"
         Height="170"
         CanResize="False"
+        CanMinimize="False"
         ShowInTaskbar="False"
         WindowStartupLocation="CenterOwner"
         Title="Unsaved Changes">


### PR DESCRIPTION
## Summary
- set CanMinimize=False on all dialog windows
- keep main window behavior unchanged (minimize remains available)
- updated dialogs: Add To List, Adding, About, Login, Options, Properties, Unsaved Changes

## Testing
- dotnet build SkyCD.slnx -c Release
- dotnet test SkyCD.slnx -c Release --no-build

Closes #167