### PR TITLE
Fix #169 and #170: Make Help menu items work and Status Bar toggle

### DIFF
--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace SkyCD.Presentation.ViewModels;
@@ -269,13 +270,37 @@ public partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private void OpenProjectWebsite()
     {
-        StatusText = "Open SourceForge project website.";
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "https://sourceforge.net/projects/skycd/",
+                UseShellExecute = true
+            });
+            StatusText = "Opening SourceForge project website...";
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Failed to open SourceForge website: {ex.Message}";
+        }
     }
 
     [RelayCommand]
     private void OpenGithubArea()
     {
-        StatusText = "Open GitHub project area.";
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "https://github.com/SkyCD/SkyCD",
+                UseShellExecute = true
+            });
+            StatusText = "Opening GitHub project area...";
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Failed to open GitHub area: {ex.Message}";
+        }
     }
 
     [RelayCommand]


### PR DESCRIPTION
Fixes issues #169 and #170:

1. **#169**: Make Help menu items work - Updated OpenProjectWebsite() and OpenGithubArea() commands to open external URLs in the default browser with error handling
2. **#170**: Make View -> Status Bar toggle visibility - Added command binding to ToggleStatusBarCommand for the Status Bar menu item