### PR TITLE
Fix #169 and #170: Make Help menu items work and Status Bar toggle

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml
+++ b/src/SkyCD.App/Views/MainWindow.axaml
@@ -35,7 +35,8 @@
             <MenuItem Header="_View">
                 <MenuItem Header="_StatusBar"
                           ToggleType="CheckBox"
-                          IsChecked="{Binding IsStatusBarVisible}"/>
+                          IsChecked="{Binding IsStatusBarVisible}"
+                          Command="{Binding ToggleStatusBarCommand}"/>
                 <Separator/>
                 <MenuItem Header="_Tiles"
                           Command="{Binding SetViewModeCommand}"


### PR DESCRIPTION
Fixes issues #169 and #170:

1. **#169**: Make Help menu items work - Updated OpenProjectWebsite() and OpenGithubArea() commands to open external URLs in the default browser with error handling
2. **#170**: Make View -> Status Bar toggle visibility - Added command binding to ToggleStatusBarCommand for the Status Bar menu item