### PR TITLE
Fix #178: Make File -> Exit work

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -36,6 +36,7 @@ public partial class MainWindow : Window
             subscribedViewModel.AboutRequested -= OnAboutRequested;
             subscribedViewModel.OptionsRequested -= OnOptionsRequested;
             subscribedViewModel.PropertiesRequested -= OnPropertiesRequested;
+            subscribedViewModel.ExitRequested -= OnExitRequested;
         }
 
         subscribedViewModel = DataContext as MainWindowViewModel;
@@ -45,7 +46,13 @@ public partial class MainWindow : Window
             subscribedViewModel.AboutRequested += OnAboutRequested;
             subscribedViewModel.OptionsRequested += OnOptionsRequested;
             subscribedViewModel.PropertiesRequested += OnPropertiesRequested;
+            subscribedViewModel.ExitRequested += OnExitRequested;
         }
+    }
+
+    private void OnExitRequested(object? sender, EventArgs e)
+    {
+        Close();
     }
 
     private void OnOpened(object? sender, EventArgs e)

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -19,6 +19,7 @@ public partial class MainWindowViewModel : ObservableObject
     public event EventHandler? AboutRequested;
     public event EventHandler<OptionsDialogRequestedEventArgs>? OptionsRequested;
     public event EventHandler<PropertiesDialogRequestedEventArgs>? PropertiesRequested;
+    public event EventHandler? ExitRequested;
 
     public MainWindowViewModel()
     {
@@ -222,6 +223,7 @@ public partial class MainWindowViewModel : ObservableObject
     private void ExitApplication()
     {
         StatusText = "Exit requested.";
+        ExitRequested?.Invoke(this, EventArgs.Empty);
     }
 
     [RelayCommand]


### PR DESCRIPTION
Fixes issue #178: File -> Exit doesn't work

**Changes made**:
1. Added ExitRequested event to MainWindowViewModel
2. Updated ExitApplication() command to raise this event
3. Added OnExitRequested handler in MainWindow to call Close()
4. Updated OnDataContextChanged in MainWindow to subscribe/unsubscribe from the new event

The fix ensures that the File -> Exit menu item works correctly with the existing closing logic (including unsaved changes prompt).