### PR TITLE
feat: implement view mode options (Details, List, Tiles, Small Icons, Large Icons)

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml
+++ b/src/SkyCD.App/Views/MainWindow.axaml
@@ -15,6 +15,60 @@
         <vm:MainWindowViewModel/>
     </Design.DataContext>
 
+    <Window.Resources>
+        <ContextMenu x:Key="BrowserContextMenu">
+            <MenuItem Header="_Expand" Command="{Binding ExpandSelectionCommand}" CommandParameter="list"/>
+            <MenuItem Header="C_ollapse" Command="{Binding CollapseSelectionCommand}" CommandParameter="list"/>
+            <Separator/>
+            <MenuItem Header="_View">
+                <MenuItem Header="Small _Icons"
+                          Command="{Binding SetViewModeCommand}"
+                          CommandParameter="SmallIcons"
+                          ToggleType="CheckBox"
+                          IsChecked="{Binding IsSmallIconsViewChecked}"/>
+                <MenuItem Header="L_arge Icons"
+                          Command="{Binding SetViewModeCommand}"
+                          CommandParameter="LargeIcons"
+                          ToggleType="CheckBox"
+                          IsChecked="{Binding IsLargeIconsViewChecked}"/>
+                <MenuItem Header="_List"
+                          Command="{Binding SetViewModeCommand}"
+                          CommandParameter="List"
+                          ToggleType="CheckBox"
+                          IsChecked="{Binding IsListViewChecked}"/>
+                <MenuItem Header="_Details"
+                          Command="{Binding SetViewModeCommand}"
+                          CommandParameter="Details"
+                          ToggleType="CheckBox"
+                          IsChecked="{Binding IsDetailsViewChecked}"/>
+                <MenuItem Header="_Tiles"
+                          Command="{Binding SetViewModeCommand}"
+                          CommandParameter="Tiles"
+                          ToggleType="CheckBox"
+                          IsChecked="{Binding IsTilesViewChecked}"/>
+            </MenuItem>
+            <Separator/>
+            <MenuItem Header="Arrange Icons By">
+                <MenuItem Header="_Name"
+                          Command="{Binding SetSortModeCommand}"
+                          CommandParameter="Name"
+                          ToggleType="CheckBox"
+                          IsChecked="{Binding IsSortByNameChecked}"/>
+                <MenuItem Header="_Type"
+                          Command="{Binding SetSortModeCommand}"
+                          CommandParameter="Type"
+                          ToggleType="CheckBox"
+                          IsChecked="{Binding IsSortByTypeChecked}"/>
+            </MenuItem>
+            <MenuItem Header="_Refresh" Command="{Binding RefreshCommand}"/>
+            <Separator/>
+            <MenuItem Header="_Add..." Command="{Binding AddItemCommand}"/>
+            <MenuItem Header="_Delete" Command="{Binding DeleteItemCommand}"/>
+            <Separator/>
+            <MenuItem Header="_Properties..." Command="{Binding OpenPropertiesCommand}"/>
+        </ContextMenu>
+    </Window.Resources>
+
     <DockPanel LastChildFill="True">
         <Menu DockPanel.Dock="Top">
             <MenuItem Header="_File">
@@ -210,86 +264,67 @@
                           Background="#CFCFCF"
                           ShowsPreview="True"/>
 
+            <!-- Details View: tabular list with column headers -->
+            <Grid Grid.Column="2" IsVisible="{Binding IsDetailsMode}">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Border BorderBrush="#D0D0D0" BorderThickness="0,0,0,1" Background="#F0F0F0" Padding="4,2">
+                    <Grid ColumnDefinitions="24,*,150,120">
+                        <TextBlock Text="" FontWeight="SemiBold" FontSize="12"/>
+                        <TextBlock Grid.Column="1" Text="Name" FontWeight="SemiBold" FontSize="12"/>
+                        <TextBlock Grid.Column="2" Text="Type" FontWeight="SemiBold" FontSize="12"/>
+                        <TextBlock Grid.Column="3" Text="Size" FontWeight="SemiBold" FontSize="12" HorizontalAlignment="Right"/>
+                    </Grid>
+                </Border>
+                <ListBox Grid.Row="1"
+                         MinWidth="240"
+                         ItemsSource="{Binding BrowserItems}"
+                         SelectedItem="{Binding SelectedBrowserItem}"
+                         ContextMenu="{DynamicResource BrowserContextMenu}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <Grid ColumnDefinitions="24,*,150,120" Margin="4,2">
+                                <TextBlock Text="{Binding IconGlyph}" FontSize="16"/>
+                                <TextBlock Grid.Column="1" Text="{Binding Name}"/>
+                                <TextBlock Grid.Column="2" Text="{Binding Type}"/>
+                                <TextBlock Grid.Column="3" Text="{Binding Size}" HorizontalAlignment="Right"/>
+                            </Grid>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Grid>
+
+            <!-- List View: wrapping simple icon+name layout -->
             <ListBox Grid.Column="2"
                      MinWidth="240"
-                     IsVisible="{Binding IsListLikeMode}"
+                     IsVisible="{Binding IsListMode}"
                      ItemsSource="{Binding BrowserItems}"
-                     SelectedItem="{Binding SelectedBrowserItem}">
+                     SelectedItem="{Binding SelectedBrowserItem}"
+                     ContextMenu="{DynamicResource BrowserContextMenu}">
+                <ListBox.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <WrapPanel Orientation="Horizontal"/>
+                    </ItemsPanelTemplate>
+                </ListBox.ItemsPanel>
                 <ListBox.ItemTemplate>
                     <DataTemplate>
-                        <Grid ColumnDefinitions="24,*,150,120" Margin="4,2">
-                            <TextBlock Text="{Binding IconGlyph}" FontSize="{Binding $parent[Window].DataContext.BrowserIconFontSize}"/>
-                            <TextBlock Grid.Column="1" Text="{Binding Name}"/>
-                            <TextBlock Grid.Column="2"
-                                       IsVisible="{Binding $parent[Window].DataContext.ShowDetailsColumns}"
-                                       Text="{Binding Type}"/>
-                            <TextBlock Grid.Column="3"
-                                       IsVisible="{Binding $parent[Window].DataContext.ShowDetailsColumns}"
-                                       Text="{Binding Size}"
-                                       HorizontalAlignment="Right"/>
-                        </Grid>
+                        <StackPanel Orientation="Horizontal" Spacing="6" Margin="4,2">
+                            <TextBlock Text="{Binding IconGlyph}" FontSize="14"/>
+                            <TextBlock Text="{Binding Name}" FontSize="13"/>
+                        </StackPanel>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
-                <ListBox.ContextMenu>
-                    <ContextMenu>
-                        <MenuItem Header="_Expand"/>
-                        <MenuItem Header="C_ollapse"/>
-                        <Separator/>
-                        <MenuItem Header="_View">
-                            <MenuItem Header="Small _Icons"
-                                      Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="SmallIcons"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding IsSmallIconsViewChecked}"/>
-                            <MenuItem Header="L_arge Icons"
-                                      Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="LargeIcons"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding IsLargeIconsViewChecked}"/>
-                            <MenuItem Header="_List"
-                                      Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="List"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding IsListViewChecked}"/>
-                            <MenuItem Header="_Details"
-                                      Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="Details"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding IsDetailsViewChecked}"/>
-                            <MenuItem Header="_Tiles"
-                                      Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="Tiles"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding IsTilesViewChecked}"/>
-                        </MenuItem>
-                        <Separator/>
-                        <MenuItem Header="Arrange Icons By">
-                            <MenuItem Header="_Name"
-                                      Command="{Binding SetSortModeCommand}"
-                                      CommandParameter="Name"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding IsSortByNameChecked}"/>
-                            <MenuItem Header="_Type"
-                                      Command="{Binding SetSortModeCommand}"
-                                      CommandParameter="Type"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding IsSortByTypeChecked}"/>
-                        </MenuItem>
-                        <MenuItem Header="_Refresh" Command="{Binding RefreshCommand}"/>
-                        <Separator/>
-                        <MenuItem Header="_Add..." Command="{Binding AddItemCommand}"/>
-                        <MenuItem Header="_Delete" Command="{Binding DeleteItemCommand}"/>
-                        <Separator/>
-                        <MenuItem Header="_Properties..." Command="{Binding OpenPropertiesCommand}"/>
-                    </ContextMenu>
-                </ListBox.ContextMenu>
             </ListBox>
 
+            <!-- Icon Grid View: Tiles / Small Icons / Large Icons -->
             <ListBox Grid.Column="2"
                      MinWidth="240"
                      IsVisible="{Binding IsIconGridMode}"
                      ItemsSource="{Binding BrowserItems}"
-                     SelectedItem="{Binding SelectedBrowserItem}">
+                     SelectedItem="{Binding SelectedBrowserItem}"
+                     ContextMenu="{DynamicResource BrowserContextMenu}">
                 <ListBox.ItemsPanel>
                     <ItemsPanelTemplate>
                         <WrapPanel Orientation="Horizontal"/>
@@ -298,6 +333,7 @@
                 <ListBox.ItemTemplate>
                     <DataTemplate>
                         <Border Width="{Binding $parent[Window].DataContext.BrowserGridItemWidth}"
+                                Height="{Binding $parent[Window].DataContext.BrowserGridItemHeight}"
                                 Margin="6"
                                 Padding="8"
                                 BorderBrush="#D0D0D0"
@@ -310,66 +346,13 @@
                                 <TextBlock Text="{Binding Name}" TextAlignment="Center" TextWrapping="Wrap"/>
                                 <StackPanel Margin="0,4,0,0"
                                             IsVisible="{Binding $parent[Window].DataContext.IsTilesMode}">
-                                    <TextBlock Text="{Binding Type}" HorizontalAlignment="Center"/>
-                                    <TextBlock Text="{Binding Size}" HorizontalAlignment="Center"/>
+                                    <TextBlock Text="{Binding Type}" HorizontalAlignment="Center" FontSize="12"/>
+                                    <TextBlock Text="{Binding Size}" HorizontalAlignment="Center" FontSize="12"/>
                                 </StackPanel>
                             </StackPanel>
                         </Border>
                     </DataTemplate>
                 </ListBox.ItemTemplate>
-                <ListBox.ContextMenu>
-                    <ContextMenu>
-                        <MenuItem Header="_Expand" Command="{Binding ExpandSelectionCommand}" CommandParameter="list"/>
-                        <MenuItem Header="C_ollapse" Command="{Binding CollapseSelectionCommand}" CommandParameter="list"/>
-                        <Separator/>
-                        <MenuItem Header="_View">
-                            <MenuItem Header="Small _Icons"
-                                      Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="SmallIcons"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding IsSmallIconsViewChecked}"/>
-                            <MenuItem Header="L_arge Icons"
-                                      Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="LargeIcons"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding IsLargeIconsViewChecked}"/>
-                            <MenuItem Header="_List"
-                                      Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="List"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding IsListViewChecked}"/>
-                            <MenuItem Header="_Details"
-                                      Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="Details"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding IsDetailsViewChecked}"/>
-                            <MenuItem Header="_Tiles"
-                                      Command="{Binding SetViewModeCommand}"
-                                      CommandParameter="Tiles"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding IsTilesViewChecked}"/>
-                        </MenuItem>
-                        <Separator/>
-                        <MenuItem Header="Arrange Icons By">
-                            <MenuItem Header="_Name"
-                                      Command="{Binding SetSortModeCommand}"
-                                      CommandParameter="Name"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding IsSortByNameChecked}"/>
-                            <MenuItem Header="_Type"
-                                      Command="{Binding SetSortModeCommand}"
-                                      CommandParameter="Type"
-                                      ToggleType="CheckBox"
-                                      IsChecked="{Binding IsSortByTypeChecked}"/>
-                        </MenuItem>
-                        <MenuItem Header="_Refresh" Command="{Binding RefreshCommand}"/>
-                        <Separator/>
-                        <MenuItem Header="_Add..." Command="{Binding AddItemCommand}"/>
-                        <MenuItem Header="_Delete" Command="{Binding DeleteItemCommand}"/>
-                        <Separator/>
-                        <MenuItem Header="_Properties..." Command="{Binding OpenPropertiesCommand}"/>
-                    </ContextMenu>
-                </ListBox.ContextMenu>
             </ListBox>
         </Grid>
     </DockPanel>

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -94,6 +94,14 @@ public partial class MainWindowViewModel : ObservableObject
 
     public bool IsSortByTypeChecked => CurrentSortMode == BrowserSortMode.Type;
 
+    public bool IsDetailsMode => CurrentViewMode == BrowserViewMode.Details;
+
+    public bool IsListMode => CurrentViewMode == BrowserViewMode.List;
+
+    public bool IsSmallIconsMode => CurrentViewMode == BrowserViewMode.SmallIcons;
+
+    public bool IsLargeIconsMode => CurrentViewMode == BrowserViewMode.LargeIcons;
+
     public bool IsIconGridMode =>
         CurrentViewMode is BrowserViewMode.Tiles or BrowserViewMode.SmallIcons or BrowserViewMode.LargeIcons;
 
@@ -117,6 +125,13 @@ public partial class MainWindowViewModel : ObservableObject
         _ => 220
     };
 
+    public double BrowserGridItemHeight => CurrentViewMode switch
+    {
+        BrowserViewMode.LargeIcons => 90,
+        BrowserViewMode.Tiles => 80,
+        _ => 60
+    };
+
     public bool ShowDetailsColumns => CurrentViewMode == BrowserViewMode.Details;
 
     public IReadOnlyList<string> StatusTransitions => statusTransitions;
@@ -133,9 +148,27 @@ public partial class MainWindowViewModel : ObservableObject
     private BrowserItem? selectedBrowserItem;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsTilesViewChecked))]
+    [NotifyPropertyChangedFor(nameof(IsSmallIconsViewChecked))]
+    [NotifyPropertyChangedFor(nameof(IsLargeIconsViewChecked))]
+    [NotifyPropertyChangedFor(nameof(IsListViewChecked))]
+    [NotifyPropertyChangedFor(nameof(IsDetailsViewChecked))]
+    [NotifyPropertyChangedFor(nameof(IsDetailsMode))]
+    [NotifyPropertyChangedFor(nameof(IsListMode))]
+    [NotifyPropertyChangedFor(nameof(IsSmallIconsMode))]
+    [NotifyPropertyChangedFor(nameof(IsLargeIconsMode))]
+    [NotifyPropertyChangedFor(nameof(IsIconGridMode))]
+    [NotifyPropertyChangedFor(nameof(IsListLikeMode))]
+    [NotifyPropertyChangedFor(nameof(IsTilesMode))]
+    [NotifyPropertyChangedFor(nameof(BrowserIconFontSize))]
+    [NotifyPropertyChangedFor(nameof(BrowserGridItemWidth))]
+    [NotifyPropertyChangedFor(nameof(BrowserGridItemHeight))]
+    [NotifyPropertyChangedFor(nameof(ShowDetailsColumns))]
     private BrowserViewMode currentViewMode = BrowserViewMode.Details;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsSortByNameChecked))]
+    [NotifyPropertyChangedFor(nameof(IsSortByTypeChecked))]
     private BrowserSortMode currentSortMode = BrowserSortMode.Name;
 
     [ObservableProperty]
@@ -612,11 +645,16 @@ public partial class MainWindowViewModel : ObservableObject
         OnPropertyChanged(nameof(IsLargeIconsViewChecked));
         OnPropertyChanged(nameof(IsListViewChecked));
         OnPropertyChanged(nameof(IsDetailsViewChecked));
+        OnPropertyChanged(nameof(IsDetailsMode));
+        OnPropertyChanged(nameof(IsListMode));
+        OnPropertyChanged(nameof(IsSmallIconsMode));
+        OnPropertyChanged(nameof(IsLargeIconsMode));
         OnPropertyChanged(nameof(IsIconGridMode));
         OnPropertyChanged(nameof(IsListLikeMode));
         OnPropertyChanged(nameof(IsTilesMode));
         OnPropertyChanged(nameof(BrowserIconFontSize));
         OnPropertyChanged(nameof(BrowserGridItemWidth));
+        OnPropertyChanged(nameof(BrowserGridItemHeight));
         OnPropertyChanged(nameof(ShowDetailsColumns));
     }
 

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -97,6 +97,77 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void SetViewModeCommand_UpdatesPerModeVisibilityProperties()
+    {
+        var vm = new MainWindowViewModel();
+
+        // Default: Details mode
+        Assert.True(vm.IsDetailsMode);
+        Assert.False(vm.IsListMode);
+        Assert.False(vm.IsSmallIconsMode);
+        Assert.False(vm.IsLargeIconsMode);
+        Assert.False(vm.IsTilesMode);
+
+        vm.SetViewModeCommand.Execute("List");
+        Assert.False(vm.IsDetailsMode);
+        Assert.True(vm.IsListMode);
+        Assert.False(vm.IsSmallIconsMode);
+        Assert.False(vm.IsLargeIconsMode);
+        Assert.False(vm.IsTilesMode);
+
+        vm.SetViewModeCommand.Execute("SmallIcons");
+        Assert.False(vm.IsDetailsMode);
+        Assert.False(vm.IsListMode);
+        Assert.True(vm.IsSmallIconsMode);
+        Assert.False(vm.IsLargeIconsMode);
+        Assert.False(vm.IsTilesMode);
+
+        vm.SetViewModeCommand.Execute("LargeIcons");
+        Assert.False(vm.IsDetailsMode);
+        Assert.False(vm.IsListMode);
+        Assert.False(vm.IsSmallIconsMode);
+        Assert.True(vm.IsLargeIconsMode);
+        Assert.False(vm.IsTilesMode);
+
+        vm.SetViewModeCommand.Execute("Tiles");
+        Assert.False(vm.IsDetailsMode);
+        Assert.False(vm.IsListMode);
+        Assert.False(vm.IsSmallIconsMode);
+        Assert.False(vm.IsLargeIconsMode);
+        Assert.True(vm.IsTilesMode);
+    }
+
+    [Fact]
+    public void SetViewModeCommand_UpdatesBrowserGridItemHeight()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.SetViewModeCommand.Execute("LargeIcons");
+        Assert.Equal(90, vm.BrowserGridItemHeight);
+
+        vm.SetViewModeCommand.Execute("Tiles");
+        Assert.Equal(80, vm.BrowserGridItemHeight);
+
+        vm.SetViewModeCommand.Execute("SmallIcons");
+        Assert.Equal(60, vm.BrowserGridItemHeight);
+    }
+
+    [Fact]
+    public void AllViewModes_HaveExactlyOneCheckedState()
+    {
+        var vm = new MainWindowViewModel();
+        var modes = new[] { "Details", "List", "SmallIcons", "LargeIcons", "Tiles" };
+
+        foreach (var mode in modes)
+        {
+            vm.SetViewModeCommand.Execute(mode);
+            var checkedCount = new[] { vm.IsDetailsViewChecked, vm.IsListViewChecked, vm.IsSmallIconsViewChecked, vm.IsLargeIconsViewChecked, vm.IsTilesViewChecked }
+                .Count(c => c);
+            Assert.Equal(1, checkedCount);
+        }
+    }
+
+    [Fact]
     public void ExpandAndCollapseSelectionCommand_UpdatesSelectedTreeNodeExpansion()
     {
         var vm = new MainWindowViewModel();


### PR DESCRIPTION
Closes #181

## Summary

Implements proper visual rendering for all 5 view modes in the browser panel. Previously, the View menu options existed but the browser panel did not render each mode distinctly.

## Changes

### ViewModel (MainWindowViewModel.cs)
- Added IsDetailsMode, IsListMode, IsSmallIconsMode, IsLargeIconsMode per-mode visibility properties
- Added BrowserGridItemHeight for variable-height icon cards (60/80/90px by mode)
- Updated change notification for all new properties

### View (MainWindow.axaml)
- Details view: Tabular list with a header row showing Name/Type/Size columns
- List view: Wrapping layout with compact icon + name items
- Icon grid view: Card layout with icon + name; Tiles mode also shows Type and Size
- Extracted shared browser context menu into Window.Resources to eliminate duplication

### Tests (MainWindowViewModelTests.cs)
- SetViewModeCommand_UpdatesPerModeVisibilityProperties - validates all 5 mode switches
- SetViewModeCommand_UpdatesBrowserGridItemHeight - validates height per mode
- AllViewModes_HaveExactlyOneCheckedState - ensures radio-like exclusive check behavior

## Test Results
128 tests pass, 0 failures (including 3 new view mode tests)
