### PR TITLE
fix: add consistent skycd.ico icon to all dialog windows

### DIFF
--- a/src/SkyCD.App/Views/AboutWindow.axaml
+++ b/src/SkyCD.App/Views/AboutWindow.axaml
@@ -8,6 +8,7 @@
         CanResize="False"
         CanMinimize="False"
         WindowStartupLocation="CenterOwner"
+        Icon="/Assets/skycd.ico"
         Title="About SkyCD">
 
     <Design.DataContext>

--- a/src/SkyCD.App/Views/AddToListWindow.axaml
+++ b/src/SkyCD.App/Views/AddToListWindow.axaml
@@ -9,6 +9,7 @@
         MinHeight="420"
         WindowStartupLocation="CenterOwner"
         CanMinimize="False"
+        Icon="/Assets/skycd.ico"
         Title="Add To List">
 
     <Design.DataContext>

--- a/src/SkyCD.App/Views/AddingProgressWindow.axaml
+++ b/src/SkyCD.App/Views/AddingProgressWindow.axaml
@@ -10,6 +10,7 @@
         WindowStartupLocation="CenterOwner"
         WindowDecorations="BorderOnly"
         ShowInTaskbar="False"
+        Icon="/Assets/skycd.ico"
         Title="Adding">
 
     <Design.DataContext>

--- a/src/SkyCD.App/Views/LoginWindow.axaml
+++ b/src/SkyCD.App/Views/LoginWindow.axaml
@@ -8,6 +8,7 @@
         CanResize="False"
         CanMinimize="False"
         WindowStartupLocation="CenterOwner"
+        Icon="/Assets/skycd.ico"
         Title="Server login">
 
     <Design.DataContext>

--- a/src/SkyCD.App/Views/UnsavedChangesWindow.axaml
+++ b/src/SkyCD.App/Views/UnsavedChangesWindow.axaml
@@ -7,6 +7,7 @@
         CanMinimize="False"
         ShowInTaskbar="False"
         WindowStartupLocation="CenterOwner"
+        Icon="/Assets/skycd.ico"
         Title="Unsaved Changes">
 
     <Grid RowDefinitions="*,Auto" Margin="16">


### PR DESCRIPTION
Closes #168

## Summary

Adds the `skycd.ico` application icon to all dialog windows that were missing it, ensuring visual consistency with the main window.

## Changes

- Added `Icon="/Assets/skycd.ico"` to: AboutWindow, AddToListWindow, AddingProgressWindow, LoginWindow, UnsavedChangesWindow
- MainWindow, OptionsWindow, and PropertiesWindow already had the icon

## Test Results

- 125 tests pass, 0 failures
