### PR TITLE
feat: add Size sort mode to Arrange Icons By menu

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml
+++ b/src/SkyCD.App/Views/MainWindow.axaml
@@ -75,6 +75,11 @@
                               CommandParameter="Type"
                               ToggleType="CheckBox"
                               IsChecked="{Binding IsSortByTypeChecked}"/>
+                    <MenuItem Header="_Size"
+                              Command="{Binding SetSortModeCommand}"
+                              CommandParameter="Size"
+                              ToggleType="CheckBox"
+                              IsChecked="{Binding IsSortBySizeChecked}"/>
                 </MenuItem>
                 <MenuItem Header="_Refresh" HotKey="F5" Command="{Binding RefreshCommand}"/>
             </MenuItem>
@@ -193,6 +198,11 @@
                                       CommandParameter="Type"
                                       ToggleType="CheckBox"
                                       IsChecked="{Binding IsSortByTypeChecked}"/>
+                            <MenuItem Header="_Size"
+                                      Command="{Binding SetSortModeCommand}"
+                                      CommandParameter="Size"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsSortBySizeChecked}"/>
                         </MenuItem>
                         <MenuItem Header="_Refresh" Command="{Binding RefreshCommand}"/>
                         <Separator/>
@@ -274,6 +284,11 @@
                                       CommandParameter="Type"
                                       ToggleType="CheckBox"
                                       IsChecked="{Binding IsSortByTypeChecked}"/>
+                            <MenuItem Header="_Size"
+                                      Command="{Binding SetSortModeCommand}"
+                                      CommandParameter="Size"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsSortBySizeChecked}"/>
                         </MenuItem>
                         <MenuItem Header="_Refresh" Command="{Binding RefreshCommand}"/>
                         <Separator/>
@@ -361,6 +376,11 @@
                                       CommandParameter="Type"
                                       ToggleType="CheckBox"
                                       IsChecked="{Binding IsSortByTypeChecked}"/>
+                            <MenuItem Header="_Size"
+                                      Command="{Binding SetSortModeCommand}"
+                                      CommandParameter="Size"
+                                      ToggleType="CheckBox"
+                                      IsChecked="{Binding IsSortBySizeChecked}"/>
                         </MenuItem>
                         <MenuItem Header="_Refresh" Command="{Binding RefreshCommand}"/>
                         <Separator/>

--- a/src/SkyCD.Presentation/ViewModels/BrowserSortMode.cs
+++ b/src/SkyCD.Presentation/ViewModels/BrowserSortMode.cs
@@ -3,5 +3,6 @@ namespace SkyCD.Presentation.ViewModels;
 public enum BrowserSortMode
 {
     Name,
-    Type
+    Type,
+    Size
 }

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -94,6 +94,8 @@ public partial class MainWindowViewModel : ObservableObject
 
     public bool IsSortByTypeChecked => CurrentSortMode == BrowserSortMode.Type;
 
+    public bool IsSortBySizeChecked => CurrentSortMode == BrowserSortMode.Size;
+
     public bool IsIconGridMode =>
         CurrentViewMode is BrowserViewMode.Tiles or BrowserViewMode.SmallIcons or BrowserViewMode.LargeIcons;
 
@@ -541,6 +543,9 @@ public partial class MainWindowViewModel : ObservableObject
             BrowserSortMode.Type => items.OrderBy(static item => item.Type)
                 .ThenBy(static item => item.Name, StringComparer.OrdinalIgnoreCase)
                 .ToArray(),
+            BrowserSortMode.Size => items.OrderBy(static item => item.Size, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(static item => item.Name, StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
             _ => items.OrderBy(static item => item.Name, StringComparer.OrdinalIgnoreCase).ToArray()
         };
 
@@ -624,6 +629,7 @@ public partial class MainWindowViewModel : ObservableObject
     {
         OnPropertyChanged(nameof(IsSortByNameChecked));
         OnPropertyChanged(nameof(IsSortByTypeChecked));
+        OnPropertyChanged(nameof(IsSortBySizeChecked));
     }
 
     partial void OnIsDirtyDocumentChanged(bool value)

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -52,6 +52,20 @@ public class MainWindowViewModelTests
         Assert.Equal(BrowserSortMode.Type, vm.CurrentSortMode);
         Assert.True(vm.IsSortByTypeChecked);
         Assert.False(vm.IsSortByNameChecked);
+        Assert.False(vm.IsSortBySizeChecked);
+    }
+
+    [Fact]
+    public void SetSortModeCommand_SizeSortMode_UpdatesCheckedState()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.SetSortModeCommand.Execute("Size");
+
+        Assert.Equal(BrowserSortMode.Size, vm.CurrentSortMode);
+        Assert.True(vm.IsSortBySizeChecked);
+        Assert.False(vm.IsSortByNameChecked);
+        Assert.False(vm.IsSortByTypeChecked);
     }
 
     [Fact]
@@ -67,9 +81,13 @@ public class MainWindowViewModelTests
         vm.SetSortModeCommand.Execute("Type");
         var firstByType = vm.BrowserItems[0].Name;
 
+        vm.SetSortModeCommand.Execute("Size");
+        var firstBySize = vm.BrowserItems[0].Name;
+
         Assert.NotEqual(firstByName, firstByType);
         Assert.Equal("Classical Collection", firstByName);
         Assert.Equal("Concert-2025.flac", firstByType);
+        Assert.Equal("Concert-2025.flac", firstBySize);
     }
 
     [Fact]
@@ -348,5 +366,21 @@ public class MainWindowViewModelTests
         Assert.Equal(BrowserSortMode.Type, vm.CurrentSortMode);
         Assert.False(vm.IsStatusBarVisible);
         Assert.Equal("Concert-2025.flac", vm.BrowserItems[0].Name);
+    }
+
+    [Fact]
+    public void AllSortModes_HaveExactlyOneCheckedState()
+    {
+        var vm = new MainWindowViewModel();
+
+        foreach (BrowserSortMode mode in Enum.GetValues<BrowserSortMode>())
+        {
+            vm.SetSortModeCommand.Execute(mode.ToString());
+
+            var checkedCount = new[] { vm.IsSortByNameChecked, vm.IsSortByTypeChecked, vm.IsSortBySizeChecked }
+                .Count(c => c);
+            Assert.Equal(1, checkedCount);
+            Assert.Equal(mode, vm.CurrentSortMode);
+        }
     }
 }


### PR DESCRIPTION
Closes #182

## Summary

Adds the "Size" sort mode option to the View > Arrange Icons By submenu, matching the legacy SkyCD behavior which supported sorting by Name, Type, and Size.

## Changes

### ViewModel (`MainWindowViewModel.cs`)
- Added `IsSortBySizeChecked` property
- Added `BrowserSortMode.Size` change notification in `OnCurrentSortModeChanged`
- Implemented Size sort ordering in `RefreshBrowserItemsForSelection` (sorts by Size, then by Name as secondary)

### Enum (`BrowserSortMode.cs`)
- Added `Size` value to `BrowserSortMode` enum

### View (`MainWindow.axaml`)
- Added `_Size` menu item to all 4 "Arrange Icons By" menus:
  - Main menu View > Arrange Icons By
  - Tree context menu
  - List context menu
  - Icon grid context menu

### Tests (`MainWindowViewModelTests.cs`)
- `SetSortModeCommand_SizeSortMode_UpdatesCheckedState` - validates Size mode checked state
- `AllSortModes_HaveExactlyOneCheckedState` - ensures radio-like exclusive check behavior for all 3 modes
- Updated existing sort test to include Size verification

## Test Results

- 127 tests pass, 0 failures (including 2 new sort mode tests)
