### PR TITLE
[184] Add Properties menu item to Edit menu

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml
+++ b/src/SkyCD.App/Views/MainWindow.axaml
@@ -86,7 +86,7 @@
                 <MenuItem Header="_Add..." HotKey="F2" Command="{Binding AddItemCommand}"/>
                 <MenuItem Header="_Delete" HotKey="Delete" Command="{Binding DeleteItemCommand}"/>
                 <Separator/>
-                <MenuItem Header="Propert_ies" HotKey="Alt+Enter" Command="{Binding OpenPropertiesCommand}"/>
+                <MenuItem Header="_Properties" HotKey="Alt+Enter" Command="{Binding OpenPropertiesCommand}"/>
             </MenuItem>
             <MenuItem Header="_View">
                 <MenuItem Header="_StatusBar"

--- a/src/SkyCD.App/Views/MainWindow.axaml
+++ b/src/SkyCD.App/Views/MainWindow.axaml
@@ -85,6 +85,8 @@
             <MenuItem Header="_Edit">
                 <MenuItem Header="_Add..." HotKey="F2" Command="{Binding AddItemCommand}"/>
                 <MenuItem Header="_Delete" HotKey="Delete" Command="{Binding DeleteItemCommand}"/>
+                <Separator/>
+                <MenuItem Header="Propert_ies" HotKey="Alt+Enter" Command="{Binding OpenPropertiesCommand}"/>
             </MenuItem>
             <MenuItem Header="_View">
                 <MenuItem Header="_StatusBar"

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -78,6 +78,8 @@ public partial class MainWindowViewModel : ObservableObject
 
     public bool IsDeleteEnabled => SelectedBrowserItem is not null;
 
+    public bool IsPropertiesEnabled => SelectedBrowserItem is not null || SelectedTreeNode is not null;
+
     public string ProgressText => $"{ProgressValue}%";
 
     public bool IsTilesViewChecked => CurrentViewMode == BrowserViewMode.Tiles;
@@ -226,7 +228,7 @@ public partial class MainWindowViewModel : ObservableObject
         IsDirtyDocument = false;
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(IsPropertiesEnabled))]
     private void OpenProperties()
     {
         if (!TryBuildPropertiesDialog(out var dialog))
@@ -586,6 +588,8 @@ public partial class MainWindowViewModel : ObservableObject
     partial void OnSelectedTreeNodeChanged(BrowserTreeNode? value)
     {
         RefreshBrowserItemsForSelection();
+        OnPropertyChanged(nameof(IsPropertiesEnabled));
+        OpenPropertiesCommand.NotifyCanExecuteChanged();
         ExpandSelectionCommand.NotifyCanExecuteChanged();
         CollapseSelectionCommand.NotifyCanExecuteChanged();
     }
@@ -633,7 +637,9 @@ public partial class MainWindowViewModel : ObservableObject
     partial void OnSelectedBrowserItemChanged(BrowserItem? value)
     {
         OnPropertyChanged(nameof(IsDeleteEnabled));
+        OnPropertyChanged(nameof(IsPropertiesEnabled));
         DeleteItemCommand.NotifyCanExecuteChanged();
+        OpenPropertiesCommand.NotifyCanExecuteChanged();
         ExpandSelectionCommand.NotifyCanExecuteChanged();
         CollapseSelectionCommand.NotifyCanExecuteChanged();
     }


### PR DESCRIPTION
Solves #184: Edit -> Properties Menu Item Implementation

## Changes
- Added Properties menu item to Edit menu with Alt+Enter keyboard shortcut
- Added IsPropertiesEnabled property to MainWindowViewModel
- Added CanExecute condition to OpenPropertiesCommand (enabled when item or tree node is selected)
- Updated OnSelectedBrowserItemChanged to notify OpenPropertiesCommand
- Updated OnSelectedTreeNodeChanged to notify OpenPropertiesCommand

## Requirements Met
- ✅ Properties menu item in Edit menu
- ✅ Alt+Enter keyboard shortcut
- ✅ Command: OpenPropertiesCommand
- ✅ Enabled only when item is selected
- ✅ Dialog integration already exists
- ✅ Context menu already has Properties option
- ✅ Dialog result handling already exists

## Testing
- Project builds successfully with no errors
