### PR TITLE
[188] Add WindowState persistence and off-screen validation

### DIFF
--- a/src/SkyCD.App/Models/AppOptions.cs
+++ b/src/SkyCD.App/Models/AppOptions.cs
@@ -12,6 +12,8 @@ public sealed class AppOptions
 
     public double? WindowHeight { get; set; }
 
+    public string WindowState { get; set; } = "Normal";
+
     public bool IsStatusBarVisible { get; set; } = true;
 
     public string BrowserViewMode { get; set; } = "Details";

--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -270,7 +270,7 @@ public partial class MainWindow : Window
     private void SaveUiState(MainWindowViewModel vm)
     {
         var options = appOptionsStore.Load();
-        
+
         // Don't save window position if window is minimized
         if (WindowState == WindowState.Normal)
         {
@@ -306,7 +306,7 @@ public partial class MainWindow : Window
         if (options.WindowLeft.HasValue && options.WindowTop.HasValue)
         {
             var position = new PixelPoint(options.WindowLeft.Value, options.WindowTop.Value);
-            
+
             // Validate position is not off-screen
             if (IsPositionOnScreen(position))
             {
@@ -327,7 +327,7 @@ public partial class MainWindow : Window
         foreach (var screen in screens)
         {
             var screenBounds = screen.WorkingArea;
-            if (position.X >= screenBounds.X && 
+            if (position.X >= screenBounds.X &&
                 position.Y >= screenBounds.Y &&
                 position.X < screenBounds.Right &&
                 position.Y < screenBounds.Bottom)

--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -270,12 +270,19 @@ public partial class MainWindow : Window
     private void SaveUiState(MainWindowViewModel vm)
     {
         var options = appOptionsStore.Load();
+        
+        // Don't save window position if window is minimized
         if (WindowState == WindowState.Normal)
         {
             options.WindowLeft = Position.X;
             options.WindowTop = Position.Y;
             options.WindowWidth = Width;
             options.WindowHeight = Height;
+            options.WindowState = "Normal";
+        }
+        else if (WindowState == WindowState.Maximized)
+        {
+            options.WindowState = "Maximized";
         }
 
         options.IsStatusBarVisible = vm.IsStatusBarVisible;
@@ -298,8 +305,37 @@ public partial class MainWindow : Window
 
         if (options.WindowLeft.HasValue && options.WindowTop.HasValue)
         {
-            Position = new PixelPoint(options.WindowLeft.Value, options.WindowTop.Value);
+            var position = new PixelPoint(options.WindowLeft.Value, options.WindowTop.Value);
+            
+            // Validate position is not off-screen
+            if (IsPositionOnScreen(position))
+            {
+                Position = position;
+            }
         }
+
+        // Restore window state
+        if (string.Equals(options.WindowState, "Maximized", StringComparison.OrdinalIgnoreCase))
+        {
+            WindowState = WindowState.Maximized;
+        }
+    }
+
+    private bool IsPositionOnScreen(PixelPoint position)
+    {
+        var screens = Screens.All;
+        foreach (var screen in screens)
+        {
+            var screenBounds = screen.WorkingArea;
+            if (position.X >= screenBounds.X && 
+                position.Y >= screenBounds.Y &&
+                position.X < screenBounds.Right &&
+                position.Y < screenBounds.Bottom)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static BrowserViewMode ParseBrowserViewMode(string? value)


### PR DESCRIPTION
Solves #188: UI - Window State Persistence Implementation

## Changes
- Added WindowState property to AppOptions model for persisting maximized state
- Updated SaveUiState to save WindowState and prevent saving when window is minimized
- Updated ApplyWindowBounds to restore WindowState (maximized state)
- Added IsPositionOnScreen method to validate window position
- Added off-screen coordinate validation before applying saved window position

## Requirements Met
- ✅ Window properties to persist (Width, Height, Left, Top, WindowState)
- ✅ Save to application configuration file (already implemented via AppOptionsStore)
- ✅ Load on application startup (already implemented via OnOpened)
- ✅ Prevent saving minimized state (implemented in SaveUiState)
- ✅ Handle invalid positions gracefully (off-screen validation added)
- ✅ Restore to last known position (already implemented)

## Edge Cases Handled
- Window position is validated to ensure it's on-screen before applying
- Minimized state is not saved (only Normal and Maximized states are saved)
- Maximized state is properly restored on application startup

## Testing
- Project builds successfully with no errors
