### PR TITLE
Fix language switch applying immediately from Options

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -6,8 +6,10 @@ using SkyCD.App.Services;
 using SkyCD.Presentation.ViewModels;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace SkyCD.App.Views;
@@ -95,6 +97,7 @@ public partial class MainWindow : Window
             ParseBrowserViewMode(options.BrowserViewMode),
             ParseBrowserSortMode(options.BrowserSortMode),
             options.IsStatusBarVisible);
+        ApplyLanguage(options.Language);
 
         isSessionStateLoaded = true;
     }
@@ -266,6 +269,7 @@ public partial class MainWindow : Window
             options.Language = e.Dialog.SelectedLanguage.Name;
             options.DisabledPluginIds = e.Dialog.GetDisabledPluginIds().ToList();
             appOptionsStore.Save(options);
+            ApplyLanguage(options.Language);
         }
 
         e.Dialog.BrowsePluginPathRequested -= OnBrowsePluginPathRequested;
@@ -481,5 +485,16 @@ public partial class MainWindow : Window
         };
 
         return candidates.FirstOrDefault(Directory.Exists) ?? string.Empty;
+    }
+
+    private static void ApplyLanguage(string? languageName)
+    {
+        var culture = LanguageCultureResolver.ResolveCulture(languageName);
+        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = culture;
+        CultureInfo.DefaultThreadCurrentCulture = culture;
+        CultureInfo.DefaultThreadCurrentUICulture = culture;
+        Thread.CurrentThread.CurrentCulture = culture;
+        Thread.CurrentThread.CurrentUICulture = culture;
     }
 }

--- a/src/SkyCD.Presentation/ViewModels/LanguageCultureResolver.cs
+++ b/src/SkyCD.Presentation/ViewModels/LanguageCultureResolver.cs
@@ -1,0 +1,34 @@
+using System.Globalization;
+
+namespace SkyCD.Presentation.ViewModels;
+
+public static class LanguageCultureResolver
+{
+    public static CultureInfo ResolveCulture(string? languageName)
+    {
+        if (string.IsNullOrWhiteSpace(languageName))
+        {
+            return CultureInfo.GetCultureInfo("en-US");
+        }
+
+        var normalized = languageName.Trim();
+        if (normalized.Equals("English", StringComparison.OrdinalIgnoreCase))
+        {
+            return CultureInfo.GetCultureInfo("en-US");
+        }
+
+        if (normalized.Equals("Lithuanian", StringComparison.OrdinalIgnoreCase))
+        {
+            return CultureInfo.GetCultureInfo("lt-LT");
+        }
+
+        try
+        {
+            return CultureInfo.GetCultureInfo(normalized);
+        }
+        catch (CultureNotFoundException)
+        {
+            return CultureInfo.GetCultureInfo("en-US");
+        }
+    }
+}

--- a/tests/SkyCD.App.Tests/LanguageCultureResolverTests.cs
+++ b/tests/SkyCD.App.Tests/LanguageCultureResolverTests.cs
@@ -1,0 +1,30 @@
+using SkyCD.Presentation.ViewModels;
+
+namespace SkyCD.App.Tests;
+
+public class LanguageCultureResolverTests
+{
+    [Fact]
+    public void ResolveCulture_KnownLanguageName_ReturnsExpectedCulture()
+    {
+        var culture = LanguageCultureResolver.ResolveCulture("Lithuanian");
+
+        Assert.Equal("lt-LT", culture.Name);
+    }
+
+    [Fact]
+    public void ResolveCulture_CultureCode_ReturnsRequestedCulture()
+    {
+        var culture = LanguageCultureResolver.ResolveCulture("en-GB");
+
+        Assert.Equal("en-GB", culture.Name);
+    }
+
+    [Fact]
+    public void ResolveCulture_UnknownLanguage_FallsBackToEnglishUs()
+    {
+        var culture = LanguageCultureResolver.ResolveCulture("Klingon");
+
+        Assert.Equal("en-US", culture.Name);
+    }
+}


### PR DESCRIPTION
## Summary
- apply selected language immediately when options are loaded and when language is confirmed in Options
- add LanguageCultureResolver for mapping UI language names/culture tags to .NET cultures
- add resolver unit tests for known, code-based, and fallback resolution paths

## Testing
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj

Closes #165