### PR TITLE
Bind browser tree/list view models to SQLite in-memory data

### DIFF
--- a/src/SkyCD.App/App.axaml.cs
+++ b/src/SkyCD.App/App.axaml.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using SkyCD.App.Services;
 using SkyCD.Presentation.ViewModels;
 using SkyCD.App.Views;
 
@@ -8,6 +9,8 @@ namespace SkyCD.App;
 
 public partial class App : Avalonia.Application
 {
+    private readonly SqliteBrowserDataStore browserDataStore = new();
+
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
@@ -17,9 +20,10 @@ public partial class App : Avalonia.Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
+            desktop.Exit += (_, _) => browserDataStore.Dispose();
             desktop.MainWindow = new MainWindow
             {
-                DataContext = new MainWindowViewModel(),
+                DataContext = new MainWindowViewModel(browserDataStore),
             };
         }
 

--- a/src/SkyCD.App/Services/SqliteBrowserDataStore.cs
+++ b/src/SkyCD.App/Services/SqliteBrowserDataStore.cs
@@ -1,0 +1,136 @@
+using Microsoft.Data.Sqlite;
+using SkyCD.Presentation.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SkyCD.App.Services;
+
+public sealed class SqliteBrowserDataStore : IBrowserDataStore, IDisposable
+{
+    private const string RootKey = "__root__";
+    private readonly SqliteConnection connection;
+
+    public SqliteBrowserDataStore()
+    {
+        connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        InitializeSchema();
+        SeedData();
+    }
+
+    public IReadOnlyList<BrowserTreeNode> GetTreeNodes()
+    {
+        var records = new List<TreeNodeRecord>();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT Key, ParentKey, Title, IconGlyph FROM TreeNodes;";
+
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            records.Add(new TreeNodeRecord(
+                reader.GetString(0),
+                reader.IsDBNull(1) ? null : reader.GetString(1),
+                reader.GetString(2),
+                reader.GetString(3)));
+        }
+
+        var childrenByParent = records
+            .GroupBy(record => record.ParentKey ?? RootKey, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.OrdinalIgnoreCase);
+
+        return BuildTreeNodes(RootKey, childrenByParent);
+    }
+
+    public IReadOnlyList<BrowserItem> GetBrowserItems(string nodeKey)
+    {
+        var items = new List<BrowserItem>();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT Name, Type, Size, IconGlyph FROM BrowserItems WHERE NodeKey = $nodeKey;";
+        command.Parameters.AddWithValue("$nodeKey", nodeKey);
+
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            items.Add(new BrowserItem(
+                reader.GetString(0),
+                reader.GetString(1),
+                reader.GetString(2),
+                reader.GetString(3)));
+        }
+
+        return items;
+    }
+
+    private static IReadOnlyList<BrowserTreeNode> BuildTreeNodes(
+        string parentKey,
+        IReadOnlyDictionary<string, List<TreeNodeRecord>> childrenByParent)
+    {
+        if (!childrenByParent.TryGetValue(parentKey, out var children))
+        {
+            return [];
+        }
+
+        return children
+            .Select(record => new BrowserTreeNode(
+                record.Key,
+                record.Title,
+                record.IconGlyph,
+                BuildTreeNodes(record.Key, childrenByParent),
+                isExpanded: record.ParentKey is null))
+            .ToArray();
+    }
+
+    private void InitializeSchema()
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            CREATE TABLE TreeNodes (
+                Key TEXT PRIMARY KEY,
+                ParentKey TEXT NULL,
+                Title TEXT NOT NULL,
+                IconGlyph TEXT NOT NULL
+            );
+
+            CREATE TABLE BrowserItems (
+                NodeKey TEXT NOT NULL,
+                Name TEXT NOT NULL,
+                Type TEXT NOT NULL,
+                Size TEXT NOT NULL,
+                IconGlyph TEXT NOT NULL
+            );
+            """;
+        command.ExecuteNonQuery();
+    }
+
+    private void SeedData()
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO TreeNodes (Key, ParentKey, Title, IconGlyph) VALUES
+            ('library', NULL, 'Library', '📚'),
+            ('movies', 'library', 'Movies', '🎬'),
+            ('music', 'library', 'Music', '🎵'),
+            ('projects', 'library', 'Projects', '🗂');
+
+            INSERT INTO BrowserItems (NodeKey, Name, Type, Size, IconGlyph) VALUES
+            ('library', 'Movies', 'Folder', '128 items', '📁'),
+            ('library', 'Music', 'Folder', '340 items', '📁'),
+            ('library', 'Projects', 'Folder', '56 items', '📁'),
+            ('movies', 'Interstellar.mkv', 'Video', '12.1 GB', '🎞'),
+            ('movies', 'Arrival.mkv', 'Video', '9.4 GB', '🎞'),
+            ('music', 'Classical Collection', 'Folder', '42 items', '📁'),
+            ('music', 'Concert-2025.flac', 'Audio', '414 MB', '🎧'),
+            ('projects', 'SkyCD v3', 'Folder', '11 items', '📁'),
+            ('projects', 'Plugin Benchmarks', 'Folder', '6 items', '📁');
+            """;
+        command.ExecuteNonQuery();
+    }
+
+    public void Dispose()
+    {
+        connection.Dispose();
+    }
+
+    private sealed record TreeNodeRecord(string Key, string? ParentKey, string Title, string IconGlyph);
+}

--- a/src/SkyCD.App/SkyCD.App.csproj
+++ b/src/SkyCD.App/SkyCD.App.csproj
@@ -22,6 +22,7 @@
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SkyCD.Presentation/ViewModels/IBrowserDataStore.cs
+++ b/src/SkyCD.Presentation/ViewModels/IBrowserDataStore.cs
@@ -1,0 +1,8 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public interface IBrowserDataStore
+{
+    IReadOnlyList<BrowserTreeNode> GetTreeNodes();
+
+    IReadOnlyList<BrowserItem> GetBrowserItems(string nodeKey);
+}

--- a/src/SkyCD.Presentation/ViewModels/InMemoryBrowserDataStore.cs
+++ b/src/SkyCD.Presentation/ViewModels/InMemoryBrowserDataStore.cs
@@ -1,0 +1,49 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public sealed class InMemoryBrowserDataStore : IBrowserDataStore
+{
+    public IReadOnlyList<BrowserTreeNode> GetTreeNodes()
+    {
+        var moviesNode = new BrowserTreeNode("movies", "Movies", "🎬");
+        var musicNode = new BrowserTreeNode("music", "Music", "🎵");
+        var projectsNode = new BrowserTreeNode("projects", "Projects", "🗂");
+
+        var libraryNode = new BrowserTreeNode(
+            "library",
+            "Library",
+            "📚",
+            [moviesNode, musicNode, projectsNode],
+            true);
+
+        return [libraryNode];
+    }
+
+    public IReadOnlyList<BrowserItem> GetBrowserItems(string nodeKey)
+    {
+        return nodeKey.ToLowerInvariant() switch
+        {
+            "library" =>
+            [
+                new BrowserItem("Movies", "Folder", "128 items", "📁"),
+                new BrowserItem("Music", "Folder", "340 items", "📁"),
+                new BrowserItem("Projects", "Folder", "56 items", "📁")
+            ],
+            "movies" =>
+            [
+                new BrowserItem("Interstellar.mkv", "Video", "12.1 GB", "🎞"),
+                new BrowserItem("Arrival.mkv", "Video", "9.4 GB", "🎞")
+            ],
+            "music" =>
+            [
+                new BrowserItem("Classical Collection", "Folder", "42 items", "📁"),
+                new BrowserItem("Concert-2025.flac", "Audio", "414 MB", "🎧")
+            ],
+            "projects" =>
+            [
+                new BrowserItem("SkyCD v3", "Folder", "11 items", "📁"),
+                new BrowserItem("Plugin Benchmarks", "Folder", "6 items", "📁")
+            ],
+            _ => []
+        };
+    }
+}

--- a/src/SkyCD.Presentation/ViewModels/LanguageCultureResolver.cs
+++ b/src/SkyCD.Presentation/ViewModels/LanguageCultureResolver.cs
@@ -1,9 +1,14 @@
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace SkyCD.Presentation.ViewModels;
 
 public static class LanguageCultureResolver
 {
+    private static readonly Regex CultureCodePattern = new(
+        "^[a-zA-Z]{2,3}(?:-[a-zA-Z0-9]{2,8})*$",
+        RegexOptions.Compiled);
+
     public static CultureInfo ResolveCulture(string? languageName)
     {
         if (string.IsNullOrWhiteSpace(languageName))
@@ -22,6 +27,11 @@ public static class LanguageCultureResolver
             return CultureInfo.GetCultureInfo("lt-LT");
         }
 
+        if (!LooksLikeCultureCode(normalized))
+        {
+            return CultureInfo.GetCultureInfo("en-US");
+        }
+
         try
         {
             return CultureInfo.GetCultureInfo(normalized);
@@ -30,5 +40,10 @@ public static class LanguageCultureResolver
         {
             return CultureInfo.GetCultureInfo("en-US");
         }
+    }
+
+    private static bool LooksLikeCultureCode(string value)
+    {
+        return CultureCodePattern.IsMatch(value);
     }
 }

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -7,7 +7,7 @@ namespace SkyCD.Presentation.ViewModels;
 
 public partial class MainWindowViewModel : ObservableObject
 {
-    private readonly IReadOnlyDictionary<string, IReadOnlyList<BrowserItem>> browserItemsByNodeKey;
+    private readonly IBrowserDataStore browserDataStore;
     private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByKey;
     private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByTitle;
     private readonly Dictionary<string, string> commentsByObjectKey = new(StringComparer.OrdinalIgnoreCase);
@@ -24,53 +24,19 @@ public partial class MainWindowViewModel : ObservableObject
     public event EventHandler? ExitRequested;
 
     public MainWindowViewModel()
+        : this(new InMemoryBrowserDataStore())
     {
-        var moviesNode = new BrowserTreeNode("movies", "Movies", "🎬");
-        var musicNode = new BrowserTreeNode("music", "Music", "🎵");
-        var projectsNode = new BrowserTreeNode("projects", "Projects", "🗂");
+    }
 
-        var libraryNode = new BrowserTreeNode(
-            "library",
-            "Library",
-            "📚",
-            [moviesNode, musicNode, projectsNode],
-            true);
-
-        TreeNodes =
-        [
-            libraryNode
-        ];
+    public MainWindowViewModel(IBrowserDataStore browserDataStore)
+    {
+        this.browserDataStore = browserDataStore ?? throw new ArgumentNullException(nameof(browserDataStore));
+        TreeNodes = browserDataStore.GetTreeNodes();
 
         var allTreeNodes = FlattenNodes(TreeNodes).ToArray();
         treeNodesByKey = allTreeNodes.ToDictionary(static node => node.Key, StringComparer.OrdinalIgnoreCase);
         treeNodesByTitle = allTreeNodes.ToDictionary(static node => node.Title, StringComparer.OrdinalIgnoreCase);
-
-        browserItemsByNodeKey = new Dictionary<string, IReadOnlyList<BrowserItem>>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["library"] =
-            [
-                new BrowserItem("Movies", "Folder", "128 items", "📁"),
-                new BrowserItem("Music", "Folder", "340 items", "📁"),
-                new BrowserItem("Projects", "Folder", "56 items", "📁")
-            ],
-            ["movies"] =
-            [
-                new BrowserItem("Interstellar.mkv", "Video", "12.1 GB", "🎞"),
-                new BrowserItem("Arrival.mkv", "Video", "9.4 GB", "🎞")
-            ],
-            ["music"] =
-            [
-                new BrowserItem("Classical Collection", "Folder", "42 items", "📁"),
-                new BrowserItem("Concert-2025.flac", "Audio", "414 MB", "🎧")
-            ],
-            ["projects"] =
-            [
-                new BrowserItem("SkyCD v3", "Folder", "11 items", "📁"),
-                new BrowserItem("Plugin Benchmarks", "Folder", "6 items", "📁")
-            ]
-        };
-
-        SelectedTreeNode = TreeNodes[0];
+        SelectedTreeNode = TreeNodes.FirstOrDefault();
         RefreshBrowserItemsForSelection();
     }
 
@@ -618,7 +584,8 @@ public partial class MainWindowViewModel : ObservableObject
     {
         var previouslySelectedName = SelectedBrowserItem?.Name;
         var nodeKey = SelectedTreeNode?.Key ?? "library";
-        if (!browserItemsByNodeKey.TryGetValue(nodeKey, out var items))
+        var items = browserDataStore.GetBrowserItems(nodeKey);
+        if (items.Count == 0)
         {
             BrowserItems = [];
             SelectedBrowserItem = null;

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -454,4 +454,29 @@ public class MainWindowViewModelTests
             Assert.Equal(mode, vm.CurrentSortMode);
         }
     }
+
+    [Fact]
+    public void Constructor_UsesInjectedDataStoreForTreeAndList()
+    {
+        var vm = new MainWindowViewModel(new StubBrowserDataStore());
+
+        Assert.Equal("root", vm.SelectedTreeNode?.Key);
+        Assert.Single(vm.BrowserItems);
+        Assert.Equal("Sample.txt", vm.BrowserItems[0].Name);
+    }
+
+    private sealed class StubBrowserDataStore : IBrowserDataStore
+    {
+        public IReadOnlyList<BrowserTreeNode> GetTreeNodes()
+        {
+            return [new BrowserTreeNode("root", "Root", "R", [], isExpanded: true)];
+        }
+
+        public IReadOnlyList<BrowserItem> GetBrowserItems(string nodeKey)
+        {
+            return nodeKey == "root"
+                ? [new BrowserItem("Sample.txt", "File", "12 KB", "F")]
+                : [];
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- introduce a browser data store abstraction in presentation and route MainWindowViewModel through it
- keep deterministic test defaults with InMemoryBrowserDataStore while allowing runtime injection
- add SqliteBrowserDataStore in the app layer backed by Data Source=:memory: schema + seed data
- wire desktop app startup to construct the main view model from the SQLite-backed store

## Testing
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj
- dotnet build src/SkyCD.App/SkyCD.App.csproj

Closes #179