### PR TITLE
Fix browser/tree context menu behavior for item-only operations

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml
+++ b/src/SkyCD.App/Views/MainWindow.axaml
@@ -196,7 +196,8 @@
             <TreeView Grid.Column="0"
                       MinWidth="160"
                       ItemsSource="{Binding TreeNodes}"
-                      SelectedItem="{Binding SelectedTreeNode}">
+                      SelectedItem="{Binding SelectedTreeNode}"
+                      ContextRequested="OnTreeContextRequested">
                 <TreeView.Styles>
                     <Style Selector="TreeViewItem" x:DataType="vm:BrowserTreeNode">
                         <Setter Property="IsExpanded" Value="{Binding IsExpanded, Mode=TwoWay}"/>
@@ -298,6 +299,7 @@
                          MinWidth="240"
                          ItemsSource="{Binding BrowserItems}"
                          SelectedItem="{Binding SelectedBrowserItem}"
+                         ContextRequested="OnBrowserContextRequested"
                          ContextMenu="{DynamicResource BrowserContextMenu}">
                     <ListBox.ItemTemplate>
                         <DataTemplate>
@@ -318,6 +320,7 @@
                      IsVisible="{Binding IsListMode}"
                      ItemsSource="{Binding BrowserItems}"
                      SelectedItem="{Binding SelectedBrowserItem}"
+                     ContextRequested="OnBrowserContextRequested"
                      ContextMenu="{DynamicResource BrowserContextMenu}">
                 <ListBox.ItemsPanel>
                     <ItemsPanelTemplate>
@@ -340,6 +343,7 @@
                      IsVisible="{Binding IsIconGridMode}"
                      ItemsSource="{Binding BrowserItems}"
                      SelectedItem="{Binding SelectedBrowserItem}"
+                     ContextRequested="OnBrowserContextRequested"
                      ContextMenu="{DynamicResource BrowserContextMenu}">
                 <ListBox.ItemsPanel>
                     <ItemsPanelTemplate>

--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -1,6 +1,8 @@
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Platform.Storage;
+using Avalonia.VisualTree;
 using SkyCD.App.Models;
 using SkyCD.App.Services;
 using SkyCD.Presentation.ViewModels;
@@ -68,6 +70,54 @@ public partial class MainWindow : Window
         {
             UpdateWindowTitle();
         }
+    }
+
+    private void OnTreeContextRequested(object? sender, ContextRequestedEventArgs e)
+    {
+        if (sender is not TreeView treeView || subscribedViewModel is null)
+        {
+            return;
+        }
+
+        if (!e.TryGetPosition(treeView, out var point))
+        {
+            e.Handled = subscribedViewModel.SelectedTreeNode is null;
+            return;
+        }
+
+        var hit = treeView.InputHitTest(point) as Visual;
+        var treeViewItem = FindAncestor<TreeViewItem>(hit);
+        if (treeViewItem?.DataContext is BrowserTreeNode node)
+        {
+            subscribedViewModel.SelectedTreeNode = node;
+            return;
+        }
+
+        e.Handled = true;
+    }
+
+    private void OnBrowserContextRequested(object? sender, ContextRequestedEventArgs e)
+    {
+        if (sender is not ListBox listBox || subscribedViewModel is null)
+        {
+            return;
+        }
+
+        if (!e.TryGetPosition(listBox, out var point))
+        {
+            e.Handled = subscribedViewModel.SelectedBrowserItem is null;
+            return;
+        }
+
+        var hit = listBox.InputHitTest(point) as Visual;
+        var listBoxItem = FindAncestor<ListBoxItem>(hit);
+        if (listBoxItem?.DataContext is BrowserItem item)
+        {
+            subscribedViewModel.SelectedBrowserItem = item;
+            return;
+        }
+
+        e.Handled = true;
     }
 
     private void UpdateWindowTitle()
@@ -481,5 +531,21 @@ public partial class MainWindow : Window
         };
 
         return candidates.FirstOrDefault(Directory.Exists) ?? string.Empty;
+    }
+
+    private static T? FindAncestor<T>(Visual? visual) where T : class
+    {
+        var current = visual;
+        while (current is not null)
+        {
+            if (current is T target)
+            {
+                return target;
+            }
+
+            current = current.GetVisualParent();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- handle context requests for tree and browser lists in MainWindow
- block context menu opening when right-clicking empty list/tree space
- update selected item/node from right-click hit target so commands execute against the intended object
- preserve keyboard context-menu support by allowing menu open on current selection

## Testing
- dotnet build src/SkyCD.App/SkyCD.App.csproj
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj

Closes #190