### PR TITLE
Fix unsaved-changes tracking and open/new request flow

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -196,7 +196,7 @@ public partial class MainWindow : Window
             }
         }
 
-        vm.NewCatalogCommand.Execute(null);
+        vm.CompleteNewCatalog();
     }
 
     private async void OnOpenCatalogRequested(object? sender, EventArgs e)
@@ -220,7 +220,7 @@ public partial class MainWindow : Window
             }
         }
 
-        vm.OpenCatalogCommand.Execute(null);
+        vm.CompleteOpenCatalog();
     }
 
     private async void OnPropertiesRequested(object? sender, PropertiesDialogRequestedEventArgs e)

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -204,7 +204,17 @@ public partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private void NewCatalog()
     {
-        NewCatalogRequested?.Invoke(this, EventArgs.Empty);
+        if (NewCatalogRequested is not null)
+        {
+            NewCatalogRequested.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
+        CompleteNewCatalog();
+    }
+
+    public void CompleteNewCatalog()
+    {
         IsDirtyDocument = false;
         StatusText = "Created a new catalog.";
     }
@@ -212,13 +222,23 @@ public partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private void OpenCatalog()
     {
-        OpenCatalogRequested?.Invoke(this, EventArgs.Empty);
+        if (OpenCatalogRequested is not null)
+        {
+            OpenCatalogRequested.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
+        CompleteOpenCatalog();
+    }
+
+    public void CompleteOpenCatalog()
+    {
         StartOperation("Loading catalog...");
         SetProgress(35, "Parsing catalog...");
         SetProgress(80, "Updating browser...");
         CompleteOperation();
 
-        IsDirtyDocument = true;
+        IsDirtyDocument = false;
     }
 
     [RelayCommand(CanExecute = nameof(IsSaveEnabled))]

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -215,13 +215,23 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
-    public void OpenThenSave_UpdatesSaveCommandState()
+    public void OpenCatalogCommand_DoesNotMarkDocumentDirty()
     {
         var vm = new MainWindowViewModel();
 
-        Assert.False(vm.SaveCatalogCommand.CanExecute(null));
-
         vm.OpenCatalogCommand.Execute(null);
+
+        Assert.False(vm.IsSaveEnabled);
+        Assert.False(vm.SaveCatalogCommand.CanExecute(null));
+        Assert.Equal("Done.", vm.StatusText);
+    }
+
+    [Fact]
+    public void DeleteThenSave_UpdatesSaveCommandState()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.DeleteItemCommand.Execute(null);
 
         Assert.True(vm.IsSaveEnabled);
         Assert.True(vm.SaveCatalogCommand.CanExecute(null));
@@ -230,7 +240,6 @@ public class MainWindowViewModelTests
 
         Assert.False(vm.IsSaveEnabled);
         Assert.False(vm.SaveCatalogCommand.CanExecute(null));
-        Assert.Equal("Done.", vm.StatusText);
     }
 
     [Fact]
@@ -310,6 +319,33 @@ public class MainWindowViewModelTests
         vm.AddItemCommand.Execute(null);
 
         Assert.True(raised);
+    }
+
+    [Fact]
+    public void NewCatalogCommand_WithSubscriber_OnlyRaisesRequest()
+    {
+        var vm = new MainWindowViewModel();
+        var raised = false;
+        vm.NewCatalogRequested += (_, _) => raised = true;
+        vm.IsDirtyDocument = true;
+
+        vm.NewCatalogCommand.Execute(null);
+
+        Assert.True(raised);
+        Assert.True(vm.IsDirtyDocument);
+    }
+
+    [Fact]
+    public void OpenCatalogCommand_WithSubscriber_OnlyRaisesRequest()
+    {
+        var vm = new MainWindowViewModel();
+        var raised = false;
+        vm.OpenCatalogRequested += (_, _) => raised = true;
+
+        vm.OpenCatalogCommand.Execute(null);
+
+        Assert.True(raised);
+        Assert.False(vm.IsDirtyDocument);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- split NewCatalog/OpenCatalog into request phase and completion phase to avoid recursive command re-entry
- update main window handlers to run unsaved-change prompt logic and then invoke completion methods
- fix open-catalog completion so loading a catalog no longer marks the document dirty
- extend view-model tests to cover the corrected save-enable and request behavior

## Testing
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj
- dotnet build src/SkyCD.App/SkyCD.App.csproj

Closes #189