### PR TITLE
Implement File -> Save As with real file picker flow

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -38,6 +38,7 @@ public partial class MainWindow : Window
             subscribedViewModel.AddToListRequested -= OnAddToListRequested;
             subscribedViewModel.NewCatalogRequested -= OnNewCatalogRequested;
             subscribedViewModel.OpenCatalogRequested -= OnOpenCatalogRequested;
+            subscribedViewModel.SaveCatalogAsRequested -= OnSaveCatalogAsRequested;
             subscribedViewModel.AboutRequested -= OnAboutRequested;
             subscribedViewModel.OptionsRequested -= OnOptionsRequested;
             subscribedViewModel.PropertiesRequested -= OnPropertiesRequested;
@@ -51,6 +52,7 @@ public partial class MainWindow : Window
             subscribedViewModel.AddToListRequested += OnAddToListRequested;
             subscribedViewModel.NewCatalogRequested += OnNewCatalogRequested;
             subscribedViewModel.OpenCatalogRequested += OnOpenCatalogRequested;
+            subscribedViewModel.SaveCatalogAsRequested += OnSaveCatalogAsRequested;
             subscribedViewModel.AboutRequested += OnAboutRequested;
             subscribedViewModel.OptionsRequested += OnOptionsRequested;
             subscribedViewModel.PropertiesRequested += OnPropertiesRequested;
@@ -225,6 +227,52 @@ public partial class MainWindow : Window
         }
 
         vm.OpenCatalogCommand.Execute(null);
+    }
+
+    private async void OnSaveCatalogAsRequested(object? sender, EventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel vm)
+        {
+            return;
+        }
+
+        var file = await StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = "Save catalog as",
+            SuggestedFileName = "catalog.scd",
+            DefaultExtension = "scd",
+            FileTypeChoices =
+            [
+                new FilePickerFileType("SkyCD Catalog")
+                {
+                    Patterns = ["*.scd"]
+                },
+                new FilePickerFileType("All files")
+                {
+                    Patterns = ["*.*"]
+                }
+            ]
+        });
+
+        var localPath = file?.TryGetLocalPath();
+        if (string.IsNullOrWhiteSpace(localPath))
+        {
+            return;
+        }
+
+        try
+        {
+            var content = """
+                # SkyCD catalog placeholder
+                # TODO: replace with full catalog serialization pipeline
+                """;
+            File.WriteAllText(localPath, content);
+            vm.CompleteSaveCatalogAs(localPath);
+        }
+        catch (Exception ex)
+        {
+            vm.StatusText = $"Failed to save catalog: {ex.Message}";
+        }
     }
 
     private async void OnPropertiesRequested(object? sender, PropertiesDialogRequestedEventArgs e)

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -247,7 +247,7 @@ public partial class MainWindowViewModel : ObservableObject
         CompleteOperation();
 
         CurrentCatalogPath = filePath;
-        StatusText = $"Saved catalog to {Path.GetFileName(filePath)}.";
+        StatusText = $"Saved catalog to {GetDisplayFileName(filePath)}.";
         IsDirtyDocument = false;
     }
 

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -249,7 +249,7 @@ public partial class MainWindowViewModel : ObservableObject
         CompleteOperation();
 
         CurrentCatalogPath = filePath;
-        StatusText = $"Saved catalog as {Path.GetFileName(filePath)}.";
+        StatusText = $"Saved catalog as {GetDisplayFileName(filePath)}.";
         IsDirtyDocument = false;
     }
 
@@ -624,6 +624,13 @@ public partial class MainWindowViewModel : ObservableObject
     private static string GetTreeNodeObjectKey(BrowserTreeNode node)
     {
         return $"tree:{node.Key}";
+    }
+
+    private static string GetDisplayFileName(string filePath)
+    {
+        var normalizedPath = filePath.Replace('\\', '/');
+        var fileName = Path.GetFileName(normalizedPath);
+        return string.IsNullOrWhiteSpace(fileName) ? filePath : fileName;
     }
 
     private void RefreshBrowserItemsForSelection()

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 
 namespace SkyCD.Presentation.ViewModels;
 
@@ -18,6 +19,7 @@ public partial class MainWindowViewModel : ObservableObject
     public event EventHandler? AddToListRequested;
     public event EventHandler? NewCatalogRequested;
     public event EventHandler? OpenCatalogRequested;
+    public event EventHandler? SaveCatalogAsRequested;
     public event EventHandler? AboutRequested;
     public event EventHandler<OptionsDialogRequestedEventArgs>? OptionsRequested;
     public event EventHandler<PropertiesDialogRequestedEventArgs>? PropertiesRequested;
@@ -161,6 +163,9 @@ public partial class MainWindowViewModel : ObservableObject
     [ObservableProperty]
     private BrowserItem? clipboardItem;
 
+    [ObservableProperty]
+    private string? currentCatalogPath;
+
     public bool IsCopyEnabled => SelectedBrowserItem is not null;
 
     public bool IsPasteEnabled => ClipboardItem is not null;
@@ -201,11 +206,29 @@ public partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private void SaveCatalogAs()
     {
+        if (SaveCatalogAsRequested is not null)
+        {
+            SaveCatalogAsRequested.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
+        CompleteSaveCatalogAs("catalog.scd");
+    }
+
+    public void CompleteSaveCatalogAs(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            return;
+        }
+
         StartOperation("Saving catalog...");
         SetProgress(50, "Parsing items...");
         SetProgress(95, "Updating indexes...");
         CompleteOperation();
 
+        CurrentCatalogPath = filePath;
+        StatusText = $"Saved catalog as {Path.GetFileName(filePath)}.";
         IsDirtyDocument = false;
     }
 

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -428,6 +428,16 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void CompleteSaveCatalogAs_UsesFileNameForUnixStylePath()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.CompleteSaveCatalogAs("/tmp/catalog.scd");
+
+        Assert.Equal("Saved catalog as catalog.scd.", vm.StatusText);
+    }
+
+    [Fact]
     public void OpenPropertiesCommand_RaisesRequestWithSelectedObjectValues()
     {
         var vm = new MainWindowViewModel();

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -364,6 +364,34 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void SaveCatalogAsCommand_WithSubscriber_OnlyRaisesRequest()
+    {
+        var vm = new MainWindowViewModel();
+        var raised = false;
+        vm.SaveCatalogAsRequested += (_, _) => raised = true;
+
+        vm.SaveCatalogAsCommand.Execute(null);
+
+        Assert.True(raised);
+        Assert.Null(vm.CurrentCatalogPath);
+    }
+
+    [Fact]
+    public void CompleteSaveCatalogAs_SetsCurrentPathAndClearsDirtyFlag()
+    {
+        var vm = new MainWindowViewModel
+        {
+            IsDirtyDocument = true
+        };
+
+        vm.CompleteSaveCatalogAs(@"C:\tmp\catalog.scd");
+
+        Assert.False(vm.IsDirtyDocument);
+        Assert.Equal(@"C:\tmp\catalog.scd", vm.CurrentCatalogPath);
+        Assert.Equal("Saved catalog as catalog.scd.", vm.StatusText);
+    }
+
+    [Fact]
     public void OpenPropertiesCommand_RaisesRequestWithSelectedObjectValues()
     {
         var vm = new MainWindowViewModel();

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -260,6 +260,16 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void CompleteSaveCatalog_UsesFileNameForUnixStylePath()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.CompleteSaveCatalog("/tmp/catalog.scd");
+
+        Assert.Equal("Saved catalog to catalog.scd.", vm.StatusText);
+    }
+
+    [Fact]
     public void DeleteCommand_EnabledOnlyWhenItemIsSelected()
     {
         var vm = new MainWindowViewModel();


### PR DESCRIPTION
## Summary
- add a dedicated save-as request event from MainWindowViewModel
- handle Save As in MainWindow using Avalonia SaveFilePickerAsync
- write catalog placeholder output to selected file path and execute completion path
- track selected catalog path in view model and clear dirty state after successful Save As
- add tests for request path and completion behavior

## Testing
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj
- dotnet build src/SkyCD.App/SkyCD.App.csproj

Closes #174