### PR TITLE
Fix Edit -> Add so it performs an actual add operation

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -175,8 +175,7 @@ public partial class MainWindow : Window
 
         await ShowAddProgressAsync(dialogVm);
 
-        vm.StatusText = "Done.";
-        vm.IsDirtyDocument = true;
+        vm.AddImportedItem(ResolveImportedName(dialogVm));
     }
 
     private async void OnNewCatalogRequested(object? sender, EventArgs e)
@@ -514,6 +513,27 @@ public partial class MainWindow : Window
         };
 
         return candidates.FirstOrDefault(Directory.Exists) ?? string.Empty;
+    }
+
+    private static string? ResolveImportedName(AddToListDialogViewModel dialogVm)
+    {
+        if (!string.IsNullOrWhiteSpace(dialogVm.MediaName))
+        {
+            return dialogVm.MediaName;
+        }
+
+        if (!string.IsNullOrWhiteSpace(dialogVm.SourceValue))
+        {
+            var value = dialogVm.SourceValue.Trim();
+            if (dialogVm.SourceMode == AddToListSourceMode.Internet)
+            {
+                return value;
+            }
+
+            return Path.GetFileName(value.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        }
+
+        return null;
     }
 
     private static void ApplyLanguage(string? languageName)

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -11,6 +11,7 @@ public partial class MainWindowViewModel : ObservableObject
     private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByKey;
     private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByTitle;
     private readonly Dictionary<string, string> commentsByObjectKey = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, List<BrowserItem>> addedItemsByNodeKey = new(StringComparer.OrdinalIgnoreCase);
     private readonly List<string> statusTransitions = [];
     private readonly List<int> progressTransitions = [];
     private const string DefaultStatusText = "Done.";
@@ -246,6 +247,28 @@ public partial class MainWindowViewModel : ObservableObject
     private void AddItem()
     {
         AddToListRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void AddImportedItem(string? suggestedName)
+    {
+        var nodeKey = SelectedTreeNode?.Key ?? "library";
+        var itemName = string.IsNullOrWhiteSpace(suggestedName)
+            ? $"Imported Item {DateTime.Now:HHmmss}"
+            : suggestedName.Trim();
+
+        if (!addedItemsByNodeKey.TryGetValue(nodeKey, out var addedItems))
+        {
+            addedItems = [];
+            addedItemsByNodeKey[nodeKey] = addedItems;
+        }
+
+        var importedItem = new BrowserItem(itemName, "Folder", "1 item", "📁");
+        addedItems.Add(importedItem);
+        RefreshBrowserItemsForSelection();
+        SelectedBrowserItem = BrowserItems.FirstOrDefault(item =>
+            item.Name.Equals(itemName, StringComparison.OrdinalIgnoreCase));
+        IsDirtyDocument = true;
+        StatusText = $"Added {itemName}.";
     }
 
     [RelayCommand(CanExecute = nameof(IsDeleteEnabled))]
@@ -584,8 +607,13 @@ public partial class MainWindowViewModel : ObservableObject
     {
         var previouslySelectedName = SelectedBrowserItem?.Name;
         var nodeKey = SelectedTreeNode?.Key ?? "library";
-        var items = browserDataStore.GetBrowserItems(nodeKey);
-        if (items.Count == 0)
+        var baseItems = browserDataStore.GetBrowserItems(nodeKey);
+        var addedItems = addedItemsByNodeKey.TryGetValue(nodeKey, out var runtimeItems)
+            ? runtimeItems
+            : [];
+
+        var items = baseItems.Concat(addedItems).ToArray();
+        if (items.Length == 0)
         {
             BrowserItems = [];
             SelectedBrowserItem = null;

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -313,6 +313,20 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void AddImportedItem_AddsVisibleItemAndMarksDocumentDirty()
+    {
+        var vm = new MainWindowViewModel();
+        var originalCount = vm.BrowserItems.Count;
+
+        vm.AddImportedItem("Imported Folder");
+
+        Assert.Equal(originalCount + 1, vm.BrowserItems.Count);
+        Assert.Contains(vm.BrowserItems, item => item.Name == "Imported Folder");
+        Assert.True(vm.IsDirtyDocument);
+        Assert.Equal("Imported Folder", vm.SelectedBrowserItem?.Name);
+    }
+
+    [Fact]
     public void OpenAboutCommand_RaisesAboutRequest_WhenSubscriberIsPresent()
     {
         var vm = new MainWindowViewModel();


### PR DESCRIPTION
## Summary
- add AddImportedItem flow in MainWindowViewModel that appends imported items to current node view
- integrate MainWindow add-dialog completion with imported item name resolution
- ensure add operation updates selection, marks document dirty, and shows action status
- add unit test verifying added item appears in the browser list

## Testing
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj
- dotnet build src/SkyCD.App/SkyCD.App.csproj

Closes #177