### PR TITLE
Implement Edit -> Delete with real item removal

### DIFF
--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -11,6 +11,7 @@ public partial class MainWindowViewModel : ObservableObject
     private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByKey;
     private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByTitle;
     private readonly Dictionary<string, string> commentsByObjectKey = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, HashSet<string>> deletedItemNamesByNodeKey = new(StringComparer.OrdinalIgnoreCase);
     private readonly List<string> statusTransitions = [];
     private readonly List<int> progressTransitions = [];
     private const string DefaultStatusText = "Done.";
@@ -256,8 +257,18 @@ public partial class MainWindowViewModel : ObservableObject
             return;
         }
 
+        var nodeKey = SelectedTreeNode?.Key ?? "library";
+        if (!deletedItemNamesByNodeKey.TryGetValue(nodeKey, out var deletedNames))
+        {
+            deletedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            deletedItemNamesByNodeKey[nodeKey] = deletedNames;
+        }
+
+        deletedNames.Add(SelectedBrowserItem.Name);
+        var deletedName = SelectedBrowserItem.Name;
+        RefreshBrowserItemsForSelection();
         IsDirtyDocument = true;
-        StatusText = $"Deleted {SelectedBrowserItem.Name}.";
+        StatusText = $"Deleted {deletedName}.";
     }
 
     [RelayCommand]
@@ -585,6 +596,13 @@ public partial class MainWindowViewModel : ObservableObject
         var previouslySelectedName = SelectedBrowserItem?.Name;
         var nodeKey = SelectedTreeNode?.Key ?? "library";
         var items = browserDataStore.GetBrowserItems(nodeKey);
+        if (deletedItemNamesByNodeKey.TryGetValue(nodeKey, out var deletedNames) && deletedNames.Count > 0)
+        {
+            items = items
+                .Where(item => !deletedNames.Contains(item.Name))
+                .ToArray();
+        }
+
         if (items.Count == 0)
         {
             BrowserItems = [];

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -246,9 +246,23 @@ public class MainWindowViewModelTests
         Assert.True(vm.IsDeleteEnabled);
         Assert.True(vm.DeleteItemCommand.CanExecute(null));
 
+        var deletedName = vm.BrowserItems[0].Name;
         vm.DeleteItemCommand.Execute(null);
 
-        Assert.Equal($"Deleted {vm.BrowserItems[0].Name}.", vm.StatusText);
+        Assert.Equal($"Deleted {deletedName}.", vm.StatusText);
+    }
+
+    [Fact]
+    public void DeleteCommand_RemovesItemFromVisibleList()
+    {
+        var vm = new MainWindowViewModel();
+        var originalCount = vm.BrowserItems.Count;
+        var deletedName = vm.SelectedBrowserItem?.Name;
+
+        vm.DeleteItemCommand.Execute(null);
+
+        Assert.Equal(originalCount - 1, vm.BrowserItems.Count);
+        Assert.DoesNotContain(vm.BrowserItems, item => item.Name == deletedName);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- make DeleteItemCommand remove selected items from visible node data instead of only setting status
- persist per-node deleted item tracking for list refresh lifecycle
- keep selection and dirty-state behavior aligned after deletion
- add tests for both status message correctness and visible removal

## Testing
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj
- dotnet build src/SkyCD.App/SkyCD.App.csproj

Closes #183