### PR TITLE
Complete Edit -> Properties by supporting item rename

### DIFF
--- a/src/SkyCD.App/Views/PropertiesWindow.axaml
+++ b/src/SkyCD.App/Views/PropertiesWindow.axaml
@@ -36,8 +36,7 @@
                     <TextBox Grid.Column="2"
                              Grid.Row="1"
                              Margin="0,2,0,0"
-                             Text="{Binding Name}"
-                             IsReadOnly="True"/>
+                             Text="{Binding Name}"/>
 
                     <TextBlock Grid.Row="2" Grid.ColumnSpan="3" Margin="0,12,0,4" Text="Comments:" VerticalAlignment="Top"/>
                     <TextBox Grid.Row="3"

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -11,6 +11,7 @@ public partial class MainWindowViewModel : ObservableObject
     private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByKey;
     private readonly IReadOnlyDictionary<string, BrowserTreeNode> treeNodesByTitle;
     private readonly Dictionary<string, string> commentsByObjectKey = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, Dictionary<string, string>> renamedBrowserItemNamesByNodeKey = new(StringComparer.OrdinalIgnoreCase);
     private readonly List<string> statusTransitions = [];
     private readonly List<int> progressTransitions = [];
     private const string DefaultStatusText = "Done.";
@@ -228,6 +229,7 @@ public partial class MainWindowViewModel : ObservableObject
                     return;
                 }
 
+                ApplyBrowserItemRenameIfNeeded(dialog);
                 commentsByObjectKey[dialog.ObjectKey] = comments;
                 IsDirtyDocument = true;
                 StatusText = DefaultStatusText;
@@ -572,7 +574,8 @@ public partial class MainWindowViewModel : ObservableObject
     private string GetBrowserItemObjectKey(BrowserItem item)
     {
         var nodeKey = SelectedTreeNode?.Key ?? "library";
-        return $"item:{nodeKey}:{item.Name}";
+        var originalName = ResolveOriginalBrowserItemName(nodeKey, item.Name);
+        return $"item:{nodeKey}:{originalName}";
     }
 
     private static string GetTreeNodeObjectKey(BrowserTreeNode node)
@@ -585,6 +588,18 @@ public partial class MainWindowViewModel : ObservableObject
         var previouslySelectedName = SelectedBrowserItem?.Name;
         var nodeKey = SelectedTreeNode?.Key ?? "library";
         var items = browserDataStore.GetBrowserItems(nodeKey);
+        if (renamedBrowserItemNamesByNodeKey.TryGetValue(nodeKey, out var renamedItems) && renamedItems.Count > 0)
+        {
+            items = items
+                .Select(item =>
+                {
+                    return renamedItems.TryGetValue(item.Name, out var renamedName)
+                        ? item with { Name = renamedName }
+                        : item;
+                })
+                .ToArray();
+        }
+
         if (items.Count == 0)
         {
             BrowserItems = [];
@@ -607,6 +622,53 @@ public partial class MainWindowViewModel : ObservableObject
         SelectedBrowserItem = refreshedItems.FirstOrDefault(item =>
                                  item.Name.Equals(previouslySelectedName, StringComparison.OrdinalIgnoreCase))
                              ?? refreshedItems.FirstOrDefault();
+    }
+
+    private void ApplyBrowserItemRenameIfNeeded(PropertiesDialogViewModel dialog)
+    {
+        if (SelectedBrowserItem is null || SelectedTreeNode is null)
+        {
+            return;
+        }
+
+        var nodeKey = SelectedTreeNode.Key;
+        var currentDisplayName = SelectedBrowserItem.Name;
+        var requestedName = dialog.Name.Trim();
+        if (string.IsNullOrWhiteSpace(requestedName) ||
+            requestedName.Equals(currentDisplayName, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var originalName = ResolveOriginalBrowserItemName(nodeKey, currentDisplayName);
+        if (!renamedBrowserItemNamesByNodeKey.TryGetValue(nodeKey, out var renamedItems))
+        {
+            renamedItems = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            renamedBrowserItemNamesByNodeKey[nodeKey] = renamedItems;
+        }
+
+        renamedItems[originalName] = requestedName;
+        RefreshBrowserItemsForSelection();
+        SelectedBrowserItem = BrowserItems.FirstOrDefault(item =>
+            item.Name.Equals(requestedName, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private string ResolveOriginalBrowserItemName(string nodeKey, string displayName)
+    {
+        if (!renamedBrowserItemNamesByNodeKey.TryGetValue(nodeKey, out var renamedItems))
+        {
+            return displayName;
+        }
+
+        foreach (var (original, renamed) in renamedItems)
+        {
+            if (renamed.Equals(displayName, StringComparison.OrdinalIgnoreCase))
+            {
+                return original;
+            }
+        }
+
+        return displayName;
     }
 
     partial void OnSelectedTreeNodeChanged(BrowserTreeNode? value)

--- a/src/SkyCD.Presentation/ViewModels/PropertiesDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/PropertiesDialogViewModel.cs
@@ -13,7 +13,7 @@ public partial class PropertiesDialogViewModel : ObservableObject
         IReadOnlyList<PropertiesInfoItem> infoProperties)
     {
         ObjectKey = objectKey;
-        Name = name;
+        this.name = name;
         IconGlyph = iconGlyph;
         this.comments = comments;
         InfoProperties = infoProperties;
@@ -21,7 +21,8 @@ public partial class PropertiesDialogViewModel : ObservableObject
 
     public string ObjectKey { get; }
 
-    public string Name { get; }
+    [ObservableProperty]
+    private string name;
 
     public string IconGlyph { get; }
 

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -404,6 +404,24 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void OpenPropertiesCommand_Accepted_RenamesSelectedBrowserItem()
+    {
+        var vm = new MainWindowViewModel();
+        PropertiesDialogRequestedEventArgs? request = null;
+        vm.PropertiesRequested += (_, args) => request = args;
+
+        var originalName = vm.SelectedBrowserItem!.Name;
+        vm.OpenPropertiesCommand.Execute(null);
+
+        Assert.NotNull(request);
+        request!.Dialog.Name = "Renamed Item";
+        request.Complete(true, request.Dialog.Comments);
+
+        Assert.Equal("Renamed Item", vm.SelectedBrowserItem?.Name);
+        Assert.DoesNotContain(vm.BrowserItems, item => item.Name == originalName);
+    }
+
+    [Fact]
     public void OpenPropertiesCommand_Canceled_DiscardsCommentChanges()
     {
         var vm = new MainWindowViewModel();

--- a/tests/SkyCD.App.Tests/PropertiesDialogViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/PropertiesDialogViewModelTests.cs
@@ -58,6 +58,16 @@ public class PropertiesDialogViewModelTests
     }
 
     [Fact]
+    public void Name_CanBeModified()
+    {
+        var vm = new PropertiesDialogViewModel("key", "name", "icon", "initial", []);
+
+        vm.Name = "renamed";
+
+        Assert.Equal("renamed", vm.Name);
+    }
+
+    [Fact]
     public void ConfirmCommand_SetsDialogAcceptedTrue()
     {
         var vm = new PropertiesDialogViewModel("key", "name", "icon", "comments", []);


### PR DESCRIPTION
## Summary
- make Properties dialog Name editable (not read-only)
- apply accepted name changes back to selected browser items in MainWindowViewModel
- persist renamed display names per node during refresh and selection cycles
- keep comments persistence and dirty-state updates intact
- add unit tests for editable name and rename round-trip through Properties command

## Testing
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj
- dotnet build src/SkyCD.App/SkyCD.App.csproj

Closes #184