### PR TITLE
Complete Tools -> Options wiring and persistence

### DIFF
--- a/src/SkyCD.App/Models/AppOptions.cs
+++ b/src/SkyCD.App/Models/AppOptions.cs
@@ -27,4 +27,6 @@ public sealed class AppOptions
     public string Language { get; set; } = "English";
 
     public List<string> DisabledPluginIds { get; set; } = [];
+
+    public int OptionsTabIndex { get; set; }
 }

--- a/src/SkyCD.App/Views/MainWindow.axaml
+++ b/src/SkyCD.App/Views/MainWindow.axaml
@@ -140,7 +140,7 @@
                 <MenuItem Header="_Refresh" HotKey="F5" Command="{Binding RefreshCommand}"/>
             </MenuItem>
             <MenuItem Header="_Tools">
-                <MenuItem Header="_Options..." Command="{Binding OpenOptionsCommand}"/>
+                <MenuItem Header="_Options..." HotKey="Ctrl+Alt+O" Command="{Binding OpenOptionsCommand}"/>
             </MenuItem>
             <MenuItem Header="_Help">
                 <MenuItem Header="Project website in _SourceForge.NET" Command="{Binding OpenProjectWebsiteCommand}"/>

--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -254,6 +254,7 @@ public partial class MainWindow : Window
         }
 
         e.Dialog.SetDisabledPluginIds(options.DisabledPluginIds);
+        e.Dialog.SelectedTabIndex = Math.Max(0, options.OptionsTabIndex);
         e.Dialog.BrowsePluginPathRequested += OnBrowsePluginPathRequested;
         e.Dialog.RefreshPluginsRequested += OnRefreshPluginsRequested;
         RefreshPlugins(e.Dialog);
@@ -269,6 +270,7 @@ public partial class MainWindow : Window
             options.PluginPath = e.Dialog.PluginPath;
             options.Language = e.Dialog.SelectedLanguage.Name;
             options.DisabledPluginIds = e.Dialog.GetDisabledPluginIds().ToList();
+            options.OptionsTabIndex = Math.Max(0, e.Dialog.SelectedTabIndex);
             appOptionsStore.Save(options);
             ApplyLanguage(options.Language);
         }

--- a/src/SkyCD.App/Views/OptionsWindow.axaml
+++ b/src/SkyCD.App/Views/OptionsWindow.axaml
@@ -18,7 +18,7 @@
     </Design.DataContext>
 
     <Grid RowDefinitions="*,Auto" Margin="14">
-        <TabControl>
+        <TabControl SelectedIndex="{Binding SelectedTabIndex}">
             <TabItem Header="Plug-Ins">
                 <Grid RowDefinitions="Auto,Auto,*,Auto,Auto" RowSpacing="8" Margin="10">
                     <TextBlock Text="Plug-In Path"/>

--- a/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
@@ -47,6 +47,9 @@ public partial class OptionsDialogViewModel : ObservableObject
     [ObservableProperty]
     private bool dialogAccepted;
 
+    [ObservableProperty]
+    private int selectedTabIndex;
+
     public event EventHandler? BrowsePluginPathRequested;
 
     public event EventHandler? RefreshPluginsRequested;

--- a/tests/SkyCD.App.Tests/OptionsDialogViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/OptionsDialogViewModelTests.cs
@@ -91,4 +91,14 @@ public class OptionsDialogViewModelTests
 
         Assert.Equal(["plugin.xml"], disabled);
     }
+
+    [Fact]
+    public void SelectedTabIndex_CanBeUpdated()
+    {
+        var vm = new OptionsDialogViewModel(["English"]);
+
+        vm.SelectedTabIndex = 1;
+
+        Assert.Equal(1, vm.SelectedTabIndex);
+    }
 }


### PR DESCRIPTION
## Summary
- persist and restore selected tab index for Options dialog
- bind OptionsWindow tab selection to view-model state
- save selected options tab in app options on dialog accept
- add Ctrl+Alt+O hotkey for Tools -> Options menu action
- add unit test coverage for tab index state behavior

## Testing
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj
- dotnet build src/SkyCD.App/SkyCD.App.csproj

Closes #186