### PR TITLE
ci: preserve per-project TRX test results in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         run: dotnet build SkyCD.slnx --configuration Release --no-restore -warnaserror
 
       - name: Test solution
-        run: dotnet test SkyCD.slnx --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=test-results-${{ matrix.os }}.trx" --results-directory artifacts/test-results/${{ matrix.os }}
+        run: dotnet test SkyCD.slnx --configuration Release --no-build --verbosity normal --logger "trx;LogFilePrefix=test-results-${{ matrix.os }}" --results-directory artifacts/test-results/${{ matrix.os }}
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
## Summary
- switch CI test logger from `LogFileName` to `LogFilePrefix`
- prevent TRX overwrites when multiple test projects run in one matrix job
- ensure artifacts keep all project-level test result files

Closes #244

## Validation
- `dotnet test SkyCD.slnx --configuration Release --no-build --verbosity normal --logger "trx;LogFilePrefix=test-results-ubuntu-latest" --results-directory artifacts/test-results/ubuntu-latest`
- verified no `Overwriting results file` warnings
