### PR TITLE
Fix #260: configure repository custom Cascade agent

### DIFF
--- a/.github/agents/cascade.agent.md
+++ b/.github/agents/cascade.agent.md
@@ -1,0 +1,25 @@
+---
+name: Cascade
+description: Default SkyCD repository agent for implementation tasks, quality checks, and PR-ready changes.
+target: github-copilot
+model: swe-1.6
+tools: ["*"]
+---
+
+You are the default custom agent for the SkyCD repository.
+
+Primary responsibilities:
+- Implement issue-driven changes in the main stack (`src/`, `tests/`, `tools/`, and `Plugins/samples/`).
+- Keep changes aligned with repository constraints in `README.md`, `CONTRIBUTING.md`, and `AGENTS.md`.
+- Add or update tests when behavior changes.
+- Keep pull requests focused and CI-ready.
+
+Working rules:
+- Prefer modern `.NET` code paths and avoid introducing new feature work in `legacy/`.
+- Use small, reviewable commits and clear PR descriptions.
+- Highlight risks, tradeoffs, and any assumptions explicitly.
+
+Definition of done:
+- Build and test commands relevant to the change pass locally when feasible.
+- Documentation and migration notes are updated when needed.
+- PR includes issue linkage and a concise validation summary.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Primary entrypoints:
 - solution: `SkyCD.slnx`
 - CI workflow: `.github/workflows/ci.yml`
 - architecture docs: `docs/architecture/`
+- custom agent config: `.github/agents/cascade.agent.md` (`docs/ci/github-custom-agent-cascade.md`)
 
 Useful local commands:
 ```powershell

--- a/docs/ci/github-custom-agent-cascade.md
+++ b/docs/ci/github-custom-agent-cascade.md
@@ -1,0 +1,27 @@
+# GitHub Custom Agent: Cascade
+
+This repository configures a repository-level custom agent for GitHub Copilot cloud agent:
+
+- Agent profile file: `.github/agents/cascade.agent.md`
+- Agent display name: `Cascade`
+- Default model configured in profile: `swe-1.6`
+
+## Verify Configuration
+
+1. Open `https://github.com/copilot/agents`.
+2. Select the `SkyCD/SkyCD` repository and the default branch.
+3. Open the agents dropdown and confirm `Cascade` is listed.
+4. Open `Cascade` details and verify the model is `swe-1.6`.
+
+## Set As Default Agent In UI
+
+If GitHub exposes a default-agent selector for your plan/UI version, set `Cascade` as the repository default there.  
+The repository-managed source of truth for this agent remains `.github/agents/cascade.agent.md`.
+
+## Maintainer Changes
+
+To change the default model or behavior:
+
+1. Edit `.github/agents/cascade.agent.md` frontmatter (`model`, `tools`, `target`) and prompt body.
+2. Open a PR with the reason for the change and validation notes.
+3. After merge to the default branch, refresh the Agents page to confirm the updated profile is loaded.


### PR DESCRIPTION
## Summary\n- add repository custom agent profile at .github/agents/cascade.agent.md\n- configure agent name Cascade and model swe-1.6 in frontmatter\n- document storage location, verification flow, and maintainer update steps in docs/ci/github-custom-agent-cascade.md\n- add README pointer to the custom agent config/docs\n\n## Validation\n- verified the profile file and docs are present on this branch\n- pushed branch and confirmed PR branch is based on updated main\n\nCloses #260