### PR TITLE
Fix #262: add kilo custom agent with free-model-only policy

### DIFF
--- a/.github/agents/kilo.agent.md
+++ b/.github/agents/kilo.agent.md
@@ -1,0 +1,19 @@
+---
+name: kilo
+description: Cost-controlled SkyCD custom agent restricted to free-tier model usage.
+target: github-copilot
+model: claude-sonnet-4.5
+tools: ["*"]
+---
+
+You are the `kilo` custom agent for SkyCD.
+
+Policy:
+- Use only the configured free-tier model for this profile.
+- Do not switch to paid or premium models.
+- Keep changes focused, test-backed, and ready for PR review.
+
+Execution guidelines:
+- Follow repository rules in `README.md`, `CONTRIBUTING.md`, and `AGENTS.md`.
+- Prefer main stack development (`src/`, `tests/`, `tools/`, `Plugins/samples/`).
+- Avoid introducing new feature work in `legacy/`.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Primary entrypoints:
 - solution: `SkyCD.slnx`
 - CI workflow: `.github/workflows/ci.yml`
 - architecture docs: `docs/architecture/`
+- custom agent config: `.github/agents/kilo.agent.md` (`docs/ci/github-custom-agent-kilo.md`)
 
 Useful local commands:
 ```powershell

--- a/docs/ci/github-custom-agent-kilo.md
+++ b/docs/ci/github-custom-agent-kilo.md
@@ -1,0 +1,30 @@
+# GitHub Custom Agent: kilo (Free-Model-Only)
+
+This repository configures a repository-level custom agent profile for cost-controlled usage:
+
+- Agent profile file: `.github/agents/kilo.agent.md`
+- Agent display name: `kilo`
+- Configured model: `claude-sonnet-4.5` (intended non-premium/free-tier usage)
+
+## Verify Configuration
+
+1. Open `https://github.com/copilot/agents`.
+2. Select repository `SkyCD/SkyCD` and default branch.
+3. Confirm `kilo` appears in the custom agents list.
+4. Open `kilo` details and verify model is `claude-sonnet-4.5`.
+
+## Free-Only Policy Guardrails
+
+- Repository profile guardrail: the agent profile pins `model` to `claude-sonnet-4.5`.
+- Organization policy guardrail: in GitHub organization Copilot/Models settings, keep only allowed free models enabled and block premium models.
+
+Together these guardrails keep premium/paid models unavailable for `kilo`.
+
+## Maintainer Updates
+
+To update allowed free models for `kilo`:
+
+1. Edit `.github/agents/kilo.agent.md` and change `model` to another approved free model.
+2. Update this document's "Configured model" line.
+3. Open a PR with rationale and verification notes.
+4. After merge, refresh Agents UI and re-check model/policy behavior.

--- a/src/SkyCD.UI/Controls/Lists/DetailsListView.axaml.cs
+++ b/src/SkyCD.UI/Controls/Lists/DetailsListView.axaml.cs
@@ -28,7 +28,7 @@ public partial class DetailsListView : UserControl
     public static readonly StyledProperty<double> ListMinWidthProperty =
         AvaloniaProperty.Register<DetailsListView, double>(nameof(ListMinWidth));
 
-    public event EventHandler<TappedEventArgs>? DoubleTapped;
+    public new event EventHandler<TappedEventArgs>? DoubleTapped;
 
     public DetailsListView()
     {


### PR DESCRIPTION
## Summary\n- add repository custom agent profile at .github/agents/kilo.agent.md\n- configure kilo to use claude-sonnet-4.5 and document free-model-only usage policy\n- add maintainer documentation with verification steps and model update flow in docs/ci/github-custom-agent-kilo.md\n- add README pointer to the new custom agent config/docs\n\n## Validation\n- verified the profile and docs files are present on this branch\n- pushed branch from updated main\n\nCloses #262