### PR TITLE
Add Co-Authored-By rule for AI commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,6 @@
 
 # Hard requirements
 - .NET 10
+
+## Commit Guidelines
+AI-generated commits should not include the 'Co-Authored-By' line unless explicitly instructed by the user.


### PR DESCRIPTION
Adds a rule in AGENTS.md specifying that AI-generated commits should not include the 'Co-Authored-By' line unless explicitly instructed by the user.