### PR TITLE
[294] About window parity: make current About look and behave like v3.x

### DIFF
--- a/src/SkyCD.App/Views/AboutWindow.axaml
+++ b/src/SkyCD.App/Views/AboutWindow.axaml
@@ -102,7 +102,7 @@
                                 <Setter Property="Foreground" Value="#FFFFFFFF" />
                             </Style>
                             <Style Selector="ListBoxItem:pointerover">
-                                <Setter Property="Background" Value="#EEF3FA" />
+                                <Setter Property="Background" Value="#FDFEFE" />
                                 <Setter Property="Foreground" Value="#111111" />
                             </Style>
                             <Style Selector="ListBoxItem:selected:pointerover">
@@ -119,7 +119,7 @@
                                 <Setter Property="Foreground" Value="#FFFFFFFF" />
                             </Style>
                             <Style Selector="ListBoxItem:pointerover TextBlock.RepositoryLink">
-                                <Setter Property="Foreground" Value="#0B2F5B" />
+                                <Setter Property="Foreground" Value="#062A52" />
                             </Style>
                             <Style Selector="TextBlock.RepositoryLink">
                                 <Setter Property="Foreground" Value="#0B5CAD" />

--- a/src/SkyCD.App/Views/AboutWindow.axaml
+++ b/src/SkyCD.App/Views/AboutWindow.axaml
@@ -92,7 +92,7 @@
                         </ListBox.ItemsPanel>
                         <ListBox.Styles>
                             <Style Selector="ListBoxItem">
-                                <Setter Property="Height" Value="72" />
+                                <Setter Property="MinHeight" Value="56" />
                                 <Setter Property="Padding" Value="0" />
                                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                                 <Setter Property="VerticalContentAlignment" Value="Top" />
@@ -102,7 +102,7 @@
                                 <Setter Property="Foreground" Value="#FFFFFFFF" />
                             </Style>
                             <Style Selector="ListBoxItem:pointerover">
-                                <Setter Property="Background" Value="#DCEBFF" />
+                                <Setter Property="Background" Value="#EEF3FA" />
                                 <Setter Property="Foreground" Value="#111111" />
                             </Style>
                             <Style Selector="ListBoxItem:selected:pointerover">
@@ -119,10 +119,10 @@
                                 <Setter Property="Foreground" Value="#FFFFFFFF" />
                             </Style>
                             <Style Selector="ListBoxItem:pointerover TextBlock.RepositoryLink">
-                                <Setter Property="Foreground" Value="#004FA3" />
+                                <Setter Property="Foreground" Value="#0B2F5B" />
                             </Style>
                             <Style Selector="TextBlock.RepositoryLink">
-                                <Setter Property="Foreground" Value="#007ACC" />
+                                <Setter Property="Foreground" Value="#0B5CAD" />
                             </Style>
                             <Style Selector="ListBoxItem:selected TextBlock.RepositoryLink">
                                 <Setter Property="Foreground" Value="#FFFFFFFF" />
@@ -165,6 +165,7 @@
                                         <TextBlock Text="{Binding RepositoryUrl}"
                                                    Classes="RepositoryLink"
                                                    FontSize="12"
+                                                   Cursor="Hand"
                                                    TextDecorations="Underline"
                                                    IsVisible="{Binding HasRepositoryUrl}"
                                                    PointerPressed="OnOpenRepositoryUrl"

--- a/src/SkyCD.App/Views/AboutWindow.axaml
+++ b/src/SkyCD.App/Views/AboutWindow.axaml
@@ -102,16 +102,32 @@
                                 <Setter Property="Foreground" Value="#FFFFFFFF" />
                             </Style>
                             <Style Selector="ListBoxItem:pointerover">
-                                <Setter Property="Background" Value="#E7F1FF" />
+                                <Setter Property="Background" Value="#DCEBFF" />
                                 <Setter Property="Foreground" Value="#111111" />
                             </Style>
+                            <Style Selector="ListBoxItem:selected:pointerover">
+                                <Setter Property="Background" Value="#2A62B9" />
+                                <Setter Property="Foreground" Value="#FFFFFFFF" />
+                            </Style>
+                            <Style Selector="ListBoxItem:pointerover TextBlock">
+                                <Setter Property="Foreground" Value="#111111" />
+                            </Style>
+                            <Style Selector="ListBoxItem:selected TextBlock">
+                                <Setter Property="Foreground" Value="#FFFFFFFF" />
+                            </Style>
+                            <Style Selector="ListBoxItem:selected:pointerover TextBlock">
+                                <Setter Property="Foreground" Value="#FFFFFFFF" />
+                            </Style>
                             <Style Selector="ListBoxItem:pointerover TextBlock.RepositoryLink">
-                                <Setter Property="Foreground" Value="#0A5BB5" />
+                                <Setter Property="Foreground" Value="#004FA3" />
                             </Style>
                             <Style Selector="TextBlock.RepositoryLink">
                                 <Setter Property="Foreground" Value="#007ACC" />
                             </Style>
                             <Style Selector="ListBoxItem:selected TextBlock.RepositoryLink">
+                                <Setter Property="Foreground" Value="#FFFFFFFF" />
+                            </Style>
+                            <Style Selector="ListBoxItem:selected:pointerover TextBlock.RepositoryLink">
                                 <Setter Property="Foreground" Value="#FFFFFFFF" />
                             </Style>
                         </ListBox.Styles>

--- a/src/SkyCD.App/Views/AboutWindow.axaml
+++ b/src/SkyCD.App/Views/AboutWindow.axaml
@@ -101,6 +101,13 @@
                                 <Setter Property="Background" Value="#1E4F9A" />
                                 <Setter Property="Foreground" Value="#FFFFFFFF" />
                             </Style>
+                            <Style Selector="ListBoxItem:pointerover">
+                                <Setter Property="Background" Value="#E7F1FF" />
+                                <Setter Property="Foreground" Value="#111111" />
+                            </Style>
+                            <Style Selector="ListBoxItem:pointerover TextBlock.RepositoryLink">
+                                <Setter Property="Foreground" Value="#0A5BB5" />
+                            </Style>
                             <Style Selector="TextBlock.RepositoryLink">
                                 <Setter Property="Foreground" Value="#007ACC" />
                             </Style>

--- a/src/SkyCD.App/Views/AboutWindow.axaml
+++ b/src/SkyCD.App/Views/AboutWindow.axaml
@@ -118,18 +118,8 @@
                             <Style Selector="ListBoxItem:selected:pointerover TextBlock">
                                 <Setter Property="Foreground" Value="#FFFFFFFF" />
                             </Style>
-                            <Style Selector="ListBoxItem:pointerover TextBlock.RepositoryLink">
-                                <Setter Property="Foreground" Value="#111111" />
-                            </Style>
                             <Style Selector="TextBlock.RepositoryLink">
-                                <Setter Property="Foreground" Value="#1A1A1A" />
                                 <Setter Property="FontWeight" Value="SemiBold" />
-                            </Style>
-                            <Style Selector="ListBoxItem:selected TextBlock.RepositoryLink">
-                                <Setter Property="Foreground" Value="#FFFFFFFF" />
-                            </Style>
-                            <Style Selector="ListBoxItem:selected:pointerover TextBlock.RepositoryLink">
-                                <Setter Property="Foreground" Value="#FFFFFFFF" />
                             </Style>
                         </ListBox.Styles>
                         <ListBox.ItemTemplate>

--- a/src/SkyCD.App/Views/AboutWindow.axaml
+++ b/src/SkyCD.App/Views/AboutWindow.axaml
@@ -119,10 +119,11 @@
                                 <Setter Property="Foreground" Value="#FFFFFFFF" />
                             </Style>
                             <Style Selector="ListBoxItem:pointerover TextBlock.RepositoryLink">
-                                <Setter Property="Foreground" Value="#062A52" />
+                                <Setter Property="Foreground" Value="#111111" />
                             </Style>
                             <Style Selector="TextBlock.RepositoryLink">
-                                <Setter Property="Foreground" Value="#0B5CAD" />
+                                <Setter Property="Foreground" Value="#1A1A1A" />
+                                <Setter Property="FontWeight" Value="SemiBold" />
                             </Style>
                             <Style Selector="ListBoxItem:selected TextBlock.RepositoryLink">
                                 <Setter Property="Foreground" Value="#FFFFFFFF" />

--- a/src/SkyCD.App/Views/AboutWindow.axaml
+++ b/src/SkyCD.App/Views/AboutWindow.axaml
@@ -97,6 +97,16 @@
                                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                                 <Setter Property="VerticalContentAlignment" Value="Top" />
                             </Style>
+                            <Style Selector="ListBoxItem:selected">
+                                <Setter Property="Background" Value="#1E4F9A" />
+                                <Setter Property="Foreground" Value="#FFFFFFFF" />
+                            </Style>
+                            <Style Selector="TextBlock.RepositoryLink">
+                                <Setter Property="Foreground" Value="#007ACC" />
+                            </Style>
+                            <Style Selector="ListBoxItem:selected TextBlock.RepositoryLink">
+                                <Setter Property="Foreground" Value="#FFFFFFFF" />
+                            </Style>
                         </ListBox.Styles>
                         <ListBox.ItemTemplate>
                             <DataTemplate x:DataType="vm:LoadedAssemblyEntry">
@@ -121,19 +131,17 @@
                                                        FontSize="14"
                                                        VerticalAlignment="Center"
                                                        MinWidth="72"
-                                                       TextAlignment="Right"
-                                                       Opacity="0.75" />
+                                                       TextAlignment="Right" />
                                         </Grid>
                                         <TextBlock Text="{Binding Copyright}"
                                                    FontSize="12"
-                                                   Opacity="0.75"
                                                    IsVisible="{Binding HasCopyright}"
                                                    TextTrimming="CharacterEllipsis"
                                                    TextWrapping="NoWrap"
                                                    Margin="0,4,0,0" />
                                         <TextBlock Text="{Binding RepositoryUrl}"
+                                                   Classes="RepositoryLink"
                                                    FontSize="12"
-                                                   Foreground="#007ACC"
                                                    TextDecorations="Underline"
                                                    IsVisible="{Binding HasRepositoryUrl}"
                                                    PointerPressed="OnOpenRepositoryUrl"

--- a/src/SkyCD.App/Views/AboutWindow.axaml
+++ b/src/SkyCD.App/Views/AboutWindow.axaml
@@ -37,17 +37,126 @@
         </StackPanel>
 
         <TabControl Name="MainTabs">
-            <TabItem Header="Project info" FontSize="14">
+            <TabItem Header="System info" FontSize="14">
                 <Grid Margin="8">
                     <StackPanel Spacing="10">
-                        <TextBlock Text="CD/DVD media catalog manager" />
-                        <TextBlock Text="{Binding Website}" />
+                        <StackPanel>
+                            <TextBlock Text="CPU" FontWeight="SemiBold" />
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="8">
+                                <ProgressBar Minimum="0" Maximum="100" Value="{Binding CpuPercent}" Height="10" Width="220" />
+                                <TextBlock Text="{Binding CpuUsage}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </StackPanel>
+
+                        <StackPanel>
+                            <TextBlock Text="Memory" FontWeight="SemiBold" />
+                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Spacing="8">
+                                <ProgressBar Minimum="0" Maximum="100" Value="{Binding MemoryPercent}" Height="10" Width="220" />
+                                <StackPanel>
+                                    <TextBlock Text="{Binding WorkingSet}" />
+                                    <TextBlock Text="{Binding ManagedHeap}" FontSize="11" Opacity="0.75" />
+                                </StackPanel>
+                            </StackPanel>
+                        </StackPanel>
+
+                        <Grid ColumnDefinitions="*,*" Margin="0,4,0,0">
+                            <Border Grid.Column="0" CornerRadius="6" Padding="8" BorderBrush="#FFE6E9EE" BorderThickness="1" Margin="0,0,8,0">
+                                <StackPanel>
+                                    <TextBlock Text="Threads" FontWeight="SemiBold" FontSize="12" />
+                                    <TextBlock Text="{Binding ThreadInfo}" FontSize="20" FontWeight="Bold" />
+                                </StackPanel>
+                            </Border>
+
+                            <Border Grid.Column="1" CornerRadius="6" Padding="8" BorderBrush="#FFE6E9EE" BorderThickness="1" Margin="8,0,0,0">
+                                <StackPanel>
+                                    <TextBlock Text="Uptime" FontWeight="SemiBold" FontSize="12" />
+                                    <TextBlock Text="{Binding UptimeFriendly}" FontSize="20" FontWeight="Bold" />
+                                    <TextBlock Text="{Binding StartTime}" FontSize="11" Opacity="0.75" />
+                                </StackPanel>
+                            </Border>
+                        </Grid>
                     </StackPanel>
+                </Grid>
+            </TabItem>
+            <TabItem Header="Loaded assemblies" FontSize="14">
+                <Grid Margin="8">
+                    <ListBox ItemsSource="{Binding LoadedAssemblies}"
+                             SelectionMode="Multiple"
+                             ScrollViewer.VerticalScrollBarVisibility="Visible"
+                             ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                             ScrollViewer.AllowAutoHide="False">
+                        <ListBox.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel Orientation="Vertical" />
+                            </ItemsPanelTemplate>
+                        </ListBox.ItemsPanel>
+                        <ListBox.Styles>
+                            <Style Selector="ListBoxItem">
+                                <Setter Property="Height" Value="72" />
+                                <Setter Property="Padding" Value="0" />
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                <Setter Property="VerticalContentAlignment" Value="Top" />
+                            </Style>
+                        </ListBox.Styles>
+                        <ListBox.ItemTemplate>
+                            <DataTemplate x:DataType="vm:LoadedAssemblyEntry">
+                                <Border BorderBrush="#FFCCCCCC" BorderThickness="0,0,0,1" Padding="6">
+                                    <StackPanel VerticalAlignment="Top">
+                                        <Grid VerticalAlignment="Center">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*" />
+                                                <ColumnDefinition Width="Auto" />
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Grid.Column="0"
+                                                       Text="{Binding Name}"
+                                                       FontSize="18"
+                                                       FontWeight="Bold"
+                                                       VerticalAlignment="Center"
+                                                       TextTrimming="CharacterEllipsis"
+                                                       TextWrapping="NoWrap"
+                                                       MaxLines="1"
+                                                       Margin="0,0,8,0" />
+                                            <TextBlock Grid.Column="1"
+                                                       Text="{Binding Version}"
+                                                       FontSize="14"
+                                                       VerticalAlignment="Center"
+                                                       MinWidth="72"
+                                                       TextAlignment="Right"
+                                                       Opacity="0.75" />
+                                        </Grid>
+                                        <TextBlock Text="{Binding Copyright}"
+                                                   FontSize="12"
+                                                   Opacity="0.75"
+                                                   IsVisible="{Binding HasCopyright}"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   TextWrapping="NoWrap"
+                                                   Margin="0,4,0,0" />
+                                        <TextBlock Text="{Binding RepositoryUrl}"
+                                                   FontSize="12"
+                                                   Foreground="#007ACC"
+                                                   TextDecorations="Underline"
+                                                   IsVisible="{Binding HasRepositoryUrl}"
+                                                   PointerPressed="OnOpenRepositoryUrl"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   TextWrapping="NoWrap"
+                                                   Margin="0,4,0,0" />
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
                 </Grid>
             </TabItem>
             <TabItem Header="Project license" FontSize="14" IsSelected="True">
                 <Grid Margin="8">
-                    <TextBlock Text="BSD 2-Clause License" />
+                    <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Visible" AllowAutoHide="False">
+                        <TextBox Text="{Binding LicenseText}"
+                                 IsReadOnly="True"
+                                 AcceptsReturn="True"
+                                 TextWrapping="Wrap"
+                                 BorderThickness="0"
+                                 Background="Transparent" />
+                    </ScrollViewer>
                 </Grid>
             </TabItem>
         </TabControl>

--- a/src/SkyCD.App/Views/AboutWindow.axaml.cs
+++ b/src/SkyCD.App/Views/AboutWindow.axaml.cs
@@ -1,30 +1,67 @@
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
 using SkyCD.Presentation.ViewModels;
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 
 namespace SkyCD.App.Views;
 
 public partial class AboutWindow : Window
 {
+    private readonly DispatcherTimer statsTimer = new()
+    {
+        Interval = TimeSpan.FromSeconds(1)
+    };
+
+    private AboutDialogViewModel? subscribedViewModel;
+
     public AboutWindow()
     {
         InitializeComponent();
+        statsTimer.Tick += OnStatsTimerTick;
         DataContextChanged += OnDataContextChanged;
+        Opened += OnOpened;
+        Closed += OnClosed;
     }
 
     private void OnDataContextChanged(object? sender, EventArgs e)
     {
-        if (sender is not AboutWindow window)
+        if (subscribedViewModel is not null)
         {
-            return;
+            subscribedViewModel.PropertyChanged -= OnViewModelPropertyChanged;
         }
 
-        if (window.DataContext is AboutDialogViewModel vm)
+        if (sender is AboutWindow window && window.DataContext is AboutDialogViewModel vm)
         {
-            vm.PropertyChanged -= OnViewModelPropertyChanged;
+            subscribedViewModel = vm;
             vm.PropertyChanged += OnViewModelPropertyChanged;
         }
+        else
+        {
+            subscribedViewModel = null;
+        }
+    }
+
+    private void OnOpened(object? sender, EventArgs e)
+    {
+        subscribedViewModel?.RefreshSystemInfo();
+        statsTimer.Start();
+    }
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        statsTimer.Stop();
+        if (subscribedViewModel is not null)
+        {
+            subscribedViewModel.PropertyChanged -= OnViewModelPropertyChanged;
+        }
+    }
+
+    private void OnStatsTimerTick(object? sender, EventArgs e)
+    {
+        subscribedViewModel?.RefreshSystemInfo();
     }
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -34,6 +71,33 @@ public partial class AboutWindow : Window
             vm.DialogAccepted)
         {
             Close(true);
+        }
+    }
+
+    private void OnOpenRepositoryUrl(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is not TextBlock textBlock)
+        {
+            return;
+        }
+
+        var url = textBlock.Text;
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return;
+        }
+
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = url,
+                UseShellExecute = true
+            });
+        }
+        catch
+        {
+            // Intentionally ignore shell launch errors for About links.
         }
     }
 }

--- a/src/SkyCD.Presentation/ViewModels/AboutDialogFormatting.cs
+++ b/src/SkyCD.Presentation/ViewModels/AboutDialogFormatting.cs
@@ -1,0 +1,52 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public static class AboutDialogFormatting
+{
+    public static string FormatBytes(long bytes)
+    {
+        if (bytes < 1024)
+        {
+            return $"{bytes} B";
+        }
+
+        var kiloBytes = bytes / 1024d;
+        if (kiloBytes < 1024d)
+        {
+            return $"{kiloBytes:0.0} KB";
+        }
+
+        var megaBytes = kiloBytes / 1024d;
+        if (megaBytes < 1024d)
+        {
+            return $"{megaBytes:0.0} MB";
+        }
+
+        var gigaBytes = megaBytes / 1024d;
+        return $"{gigaBytes:0.0} GB";
+    }
+
+    public static string FormatFriendlyTime(TimeSpan duration)
+    {
+        if (duration.TotalDays >= 1)
+        {
+            return $"{(int)duration.TotalDays}d {duration.Hours:00}h {duration.Minutes:00}m";
+        }
+
+        if (duration.TotalHours >= 1)
+        {
+            return $"{duration.Hours:00}h {duration.Minutes:00}m {duration.Seconds:00}s";
+        }
+
+        if (duration.TotalMinutes >= 1)
+        {
+            return $"{duration.Minutes:00}m {duration.Seconds:00}s";
+        }
+
+        return $"{duration.Seconds:00}s";
+    }
+
+    public static string FormatStartTime(DateTime startTime)
+    {
+        return startTime.ToString("yyyy-MM-dd HH:mm:ss");
+    }
+}

--- a/src/SkyCD.Presentation/ViewModels/AboutDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/AboutDialogViewModel.cs
@@ -1,20 +1,58 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Reflection;
 
 namespace SkyCD.Presentation.ViewModels;
 
 public partial class AboutDialogViewModel : ObservableObject
 {
+    private readonly Process currentProcess;
+    private readonly TimeProvider timeProvider;
+    private TimeSpan lastTotalProcessorTime;
+    private DateTimeOffset lastSampleTimeUtc;
+
     public AboutDialogViewModel()
-        : this("SkyCD", "3.0.0", "https://github.com/SkyCD/SkyCD")
+        : this(
+            "SkyCD",
+            "3.0.0",
+            "https://github.com/SkyCD/SkyCD",
+            AppDomain.CurrentDomain.GetAssemblies(),
+            AppContext.BaseDirectory,
+            Process.GetCurrentProcess(),
+            TimeProvider.System)
     {
     }
 
-    public AboutDialogViewModel(string productName, string version, string website)
+    public AboutDialogViewModel(
+        string productName,
+        string version,
+        string website,
+        IEnumerable<Assembly>? loadedAssemblies = null,
+        string? baseDirectory = null,
+        Process? process = null,
+        TimeProvider? timeProvider = null)
     {
         ProductName = productName;
         Version = version;
         Website = website;
+
+        var normalizedBaseDirectory = string.IsNullOrWhiteSpace(baseDirectory)
+            ? AppContext.BaseDirectory
+            : baseDirectory;
+
+        LicensePath = Path.Combine(normalizedBaseDirectory, "LICENSE.md");
+        LicenseText = LoadLicenseText(normalizedBaseDirectory);
+
+        LoadedAssemblies = new ObservableCollection<LoadedAssemblyEntry>(
+            BuildLoadedAssemblyEntries(loadedAssemblies ?? AppDomain.CurrentDomain.GetAssemblies()));
+
+        currentProcess = process ?? Process.GetCurrentProcess();
+        this.timeProvider = timeProvider ?? TimeProvider.System;
+        lastTotalProcessorTime = currentProcess.TotalProcessorTime;
+        lastSampleTimeUtc = this.timeProvider.GetUtcNow();
+        RefreshSystemInfo();
     }
 
     public string ProductName { get; }
@@ -23,12 +61,120 @@ public partial class AboutDialogViewModel : ObservableObject
 
     public string Website { get; }
 
+    public string LicensePath { get; }
+
+    public string LicenseText { get; }
+
+    public ObservableCollection<LoadedAssemblyEntry> LoadedAssemblies { get; }
+
     [ObservableProperty]
     private bool dialogAccepted;
+
+    [ObservableProperty]
+    private string cpuUsage = "0.0 %";
+
+    [ObservableProperty]
+    private double cpuPercent;
+
+    [ObservableProperty]
+    private string workingSet = "0 B";
+
+    [ObservableProperty]
+    private string managedHeap = "0 B";
+
+    [ObservableProperty]
+    private double memoryPercent;
+
+    [ObservableProperty]
+    private string threadInfo = "0 threads";
+
+    [ObservableProperty]
+    private string uptimeFriendly = "0s";
+
+    [ObservableProperty]
+    private string startTime = string.Empty;
 
     [RelayCommand]
     private void Confirm()
     {
         DialogAccepted = true;
+    }
+
+    public void RefreshSystemInfo()
+    {
+        try
+        {
+            currentProcess.Refresh();
+
+            var now = timeProvider.GetUtcNow();
+            var elapsedMs = (now - lastSampleTimeUtc).TotalMilliseconds;
+            var currentTotalProcessorTime = currentProcess.TotalProcessorTime;
+
+            var cpu = 0d;
+            if (elapsedMs > 1d)
+            {
+                var usedProcessorMs = (currentTotalProcessorTime - lastTotalProcessorTime).TotalMilliseconds;
+                cpu = (usedProcessorMs / elapsedMs) / Environment.ProcessorCount * 100d;
+            }
+
+            lastSampleTimeUtc = now;
+            lastTotalProcessorTime = currentTotalProcessorTime;
+
+            CpuPercent = Math.Clamp(cpu, 0d, 100d);
+            CpuUsage = $"{CpuPercent:0.0} %";
+            WorkingSet = AboutDialogFormatting.FormatBytes(currentProcess.WorkingSet64);
+            ManagedHeap = AboutDialogFormatting.FormatBytes(GC.GetTotalMemory(false));
+
+            var totalAvailableMemory = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+            MemoryPercent = totalAvailableMemory > 0
+                ? Math.Clamp((double)currentProcess.WorkingSet64 / totalAvailableMemory * 100d, 0d, 100d)
+                : 0d;
+
+            ThreadInfo = $"{currentProcess.Threads.Count} threads";
+
+            var uptime = DateTime.Now - currentProcess.StartTime;
+            UptimeFriendly = AboutDialogFormatting.FormatFriendlyTime(uptime);
+            StartTime = AboutDialogFormatting.FormatStartTime(currentProcess.StartTime);
+        }
+        catch
+        {
+            // Ignore transient process probing issues in About diagnostics.
+        }
+    }
+
+    public static string LoadLicenseText(string baseDirectory)
+    {
+        var licensePath = Path.Combine(baseDirectory, "LICENSE.md");
+        return File.Exists(licensePath)
+            ? File.ReadAllText(licensePath)
+            : $"Not found. Expected at: {licensePath}";
+    }
+
+    private static IReadOnlyList<LoadedAssemblyEntry> BuildLoadedAssemblyEntries(IEnumerable<Assembly> assemblies)
+    {
+        return assemblies
+            .Distinct()
+            .Select(CreateAssemblyEntry)
+            .OrderBy(static entry => entry.Name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static LoadedAssemblyEntry CreateAssemblyEntry(Assembly assembly)
+    {
+        var assemblyName = assembly.GetName();
+        var metadataAttributes = assembly.GetCustomAttributes<AssemblyMetadataAttribute>().ToArray();
+        var repositoryUrl = metadataAttributes
+            .FirstOrDefault(static attribute =>
+                string.Equals(attribute.Key, "RepositoryUrl", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(attribute.Key, "Repository", StringComparison.OrdinalIgnoreCase))
+            ?.Value ?? string.Empty;
+
+        var copyright = assembly.GetCustomAttribute<AssemblyCopyrightAttribute>()?.Copyright ?? string.Empty;
+
+        return new LoadedAssemblyEntry(
+            assemblyName.Name ?? "Unknown",
+            assemblyName.Version?.ToString() ?? "Unknown",
+            copyright,
+            repositoryUrl);
     }
 }

--- a/src/SkyCD.Presentation/ViewModels/AboutDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/AboutDialogViewModel.cs
@@ -42,7 +42,7 @@ public partial class AboutDialogViewModel : ObservableObject
             ? AppContext.BaseDirectory
             : baseDirectory;
 
-        LicensePath = Path.Combine(normalizedBaseDirectory, "LICENSE.md");
+        LicensePath = ResolveLicensePath(normalizedBaseDirectory) ?? Path.Combine(normalizedBaseDirectory, "LICENSE.md");
         LicenseText = LoadLicenseText(normalizedBaseDirectory);
 
         LoadedAssemblies = new ObservableCollection<LoadedAssemblyEntry>(
@@ -144,10 +144,43 @@ public partial class AboutDialogViewModel : ObservableObject
 
     public static string LoadLicenseText(string baseDirectory)
     {
-        var licensePath = Path.Combine(baseDirectory, "LICENSE.md");
-        return File.Exists(licensePath)
-            ? File.ReadAllText(licensePath)
-            : $"Not found. Expected at: {licensePath}";
+        var resolvedPath = ResolveLicensePath(baseDirectory);
+        if (!string.IsNullOrWhiteSpace(resolvedPath) && File.Exists(resolvedPath))
+        {
+            return File.ReadAllText(resolvedPath);
+        }
+
+        var expectedMarkdownPath = Path.Combine(baseDirectory, "LICENSE.md");
+        var expectedPlainPath = Path.Combine(baseDirectory, "LICENSE");
+        return $"Not found. Expected at: {expectedMarkdownPath} or {expectedPlainPath}";
+    }
+
+    private static string? ResolveLicensePath(string baseDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(baseDirectory))
+        {
+            return null;
+        }
+
+        var current = new DirectoryInfo(baseDirectory);
+        for (var depth = 0; depth < 8 && current is not null; depth++)
+        {
+            var markdownPath = Path.Combine(current.FullName, "LICENSE.md");
+            if (File.Exists(markdownPath))
+            {
+                return markdownPath;
+            }
+
+            var plainPath = Path.Combine(current.FullName, "LICENSE");
+            if (File.Exists(plainPath))
+            {
+                return plainPath;
+            }
+
+            current = current.Parent;
+        }
+
+        return null;
     }
 
     private static IReadOnlyList<LoadedAssemblyEntry> BuildLoadedAssemblyEntries(IEnumerable<Assembly> assemblies)

--- a/src/SkyCD.Presentation/ViewModels/LoadedAssemblyEntry.cs
+++ b/src/SkyCD.Presentation/ViewModels/LoadedAssemblyEntry.cs
@@ -1,0 +1,12 @@
+namespace SkyCD.Presentation.ViewModels;
+
+public sealed record LoadedAssemblyEntry(
+    string Name,
+    string Version,
+    string Copyright,
+    string RepositoryUrl)
+{
+    public bool HasCopyright => !string.IsNullOrWhiteSpace(Copyright);
+
+    public bool HasRepositoryUrl => !string.IsNullOrWhiteSpace(RepositoryUrl);
+}

--- a/tests/SkyCD.App.Tests/AboutDialogViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/AboutDialogViewModelTests.cs
@@ -56,7 +56,8 @@ public class AboutDialogViewModelTests
     public void Constructor_UsesLicenseFallback_WhenLicenseFileIsMissing()
     {
         var baseDirectory = Path.Combine(Path.GetTempPath(), $"skycd-about-{Guid.NewGuid():N}");
-        var expectedPath = Path.Combine(baseDirectory, "LICENSE.md");
+        var expectedMarkdownPath = Path.Combine(baseDirectory, "LICENSE.md");
+        var expectedPlainPath = Path.Combine(baseDirectory, "LICENSE");
 
         var vm = new AboutDialogViewModel(
             "SkyCD",
@@ -65,8 +66,29 @@ public class AboutDialogViewModelTests
             loadedAssemblies: [typeof(string).Assembly],
             baseDirectory: baseDirectory);
 
-        Assert.Equal(expectedPath, vm.LicensePath);
-        Assert.Equal($"Not found. Expected at: {expectedPath}", vm.LicenseText);
+        Assert.Equal(expectedMarkdownPath, vm.LicensePath);
+        Assert.Equal($"Not found. Expected at: {expectedMarkdownPath} or {expectedPlainPath}", vm.LicenseText);
+    }
+
+    [Fact]
+    public void Constructor_LoadsLicense_FromParentDirectoryPlainLicenseFile()
+    {
+        var rootDirectory = Path.Combine(Path.GetTempPath(), $"skycd-about-{Guid.NewGuid():N}");
+        var childDirectory = Path.Combine(rootDirectory, "bin", "Debug", "net10.0");
+        Directory.CreateDirectory(childDirectory);
+
+        var licensePath = Path.Combine(rootDirectory, "LICENSE");
+        File.WriteAllText(licensePath, "Test License Content");
+
+        var vm = new AboutDialogViewModel(
+            "SkyCD",
+            "3.0.0",
+            "https://github.com/SkyCD/SkyCD",
+            loadedAssemblies: [typeof(string).Assembly],
+            baseDirectory: childDirectory);
+
+        Assert.Equal(licensePath, vm.LicensePath);
+        Assert.Equal("Test License Content", vm.LicenseText);
     }
 
     [Fact]

--- a/tests/SkyCD.App.Tests/AboutDialogViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/AboutDialogViewModelTests.cs
@@ -17,7 +17,12 @@ public class AboutDialogViewModelTests
     [Fact]
     public void Constructor_InitializesWithCustomValues()
     {
-        var vm = new AboutDialogViewModel("MyApp", "1.2.3", "https://example.com");
+        var vm = new AboutDialogViewModel(
+            "MyApp",
+            "1.2.3",
+            "https://example.com",
+            loadedAssemblies: [typeof(string).Assembly],
+            baseDirectory: Path.GetTempPath());
 
         Assert.Equal("MyApp", vm.ProductName);
         Assert.Equal("1.2.3", vm.Version);
@@ -35,10 +40,77 @@ public class AboutDialogViewModelTests
     [Fact]
     public void ConfirmCommand_SetsDialogAcceptedTrue()
     {
-        var vm = new AboutDialogViewModel();
+        var vm = new AboutDialogViewModel(
+            "SkyCD",
+            "3.0.0",
+            "https://github.com/SkyCD/SkyCD",
+            loadedAssemblies: [typeof(string).Assembly],
+            baseDirectory: Path.GetTempPath());
 
         vm.ConfirmCommand.Execute(null);
 
         Assert.True(vm.DialogAccepted);
+    }
+
+    [Fact]
+    public void Constructor_UsesLicenseFallback_WhenLicenseFileIsMissing()
+    {
+        var baseDirectory = Path.Combine(Path.GetTempPath(), $"skycd-about-{Guid.NewGuid():N}");
+        var expectedPath = Path.Combine(baseDirectory, "LICENSE.md");
+
+        var vm = new AboutDialogViewModel(
+            "SkyCD",
+            "3.0.0",
+            "https://github.com/SkyCD/SkyCD",
+            loadedAssemblies: [typeof(string).Assembly],
+            baseDirectory: baseDirectory);
+
+        Assert.Equal(expectedPath, vm.LicensePath);
+        Assert.Equal($"Not found. Expected at: {expectedPath}", vm.LicenseText);
+    }
+
+    [Fact]
+    public void Constructor_PopulatesLoadedAssembliesContract()
+    {
+        var assemblies = new[]
+        {
+            typeof(string).Assembly,
+            typeof(AboutDialogViewModel).Assembly
+        };
+
+        var vm = new AboutDialogViewModel(
+            "SkyCD",
+            "3.0.0",
+            "https://github.com/SkyCD/SkyCD",
+            loadedAssemblies: assemblies,
+            baseDirectory: Path.GetTempPath());
+
+        Assert.Equal(2, vm.LoadedAssemblies.Count);
+        Assert.All(vm.LoadedAssemblies, entry =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(entry.Name));
+            Assert.False(string.IsNullOrWhiteSpace(entry.Version));
+        });
+    }
+
+    [Theory]
+    [InlineData(1023, "1023 B")]
+    [InlineData(1024, "1.0 KB")]
+    [InlineData(1048576, "1.0 MB")]
+    public void FormatBytes_ReturnsExpectedText(long bytes, string expected)
+    {
+        Assert.Equal(expected, AboutDialogFormatting.FormatBytes(bytes));
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0, 3, "03s")]
+    [InlineData(0, 0, 2, 5, "02m 05s")]
+    [InlineData(0, 1, 4, 9, "01h 04m 09s")]
+    [InlineData(2, 7, 30, 12, "2d 07h 30m")]
+    public void FormatFriendlyTime_ReturnsExpectedText(int days, int hours, int minutes, int seconds, string expected)
+    {
+        var duration = TimeSpan.FromDays(days) + TimeSpan.FromHours(hours) + TimeSpan.FromMinutes(minutes) + TimeSpan.FromSeconds(seconds);
+
+        Assert.Equal(expected, AboutDialogFormatting.FormatFriendlyTime(duration));
     }
 }


### PR DESCRIPTION
Solves #294: About window parity: make current About look and behave like v3.x. Added v3.x-style About tabs (system info, loaded assemblies, project license), live 1s system stats refresh with stop-on-close, license loading with fallback message, repository URL shell open behavior, and tests for license fallback/formatters/assembly contract. Validation: dotnet restore/build/test/format all passed.