### PR TITLE
[296] Redesign Options dialog to Rider-style Settings UI

### DIFF
--- a/src/SkyCD.App/Views/OptionsWindow.axaml
+++ b/src/SkyCD.App/Views/OptionsWindow.axaml
@@ -40,8 +40,8 @@
                              Text="{Binding SettingsSearchText, UpdateSourceTrigger=PropertyChanged}"/>
 
                     <ListBox Grid.Row="1"
-                             ItemsSource="{Binding SettingCategories}"
-                             SelectedIndex="{Binding SelectedTabIndex}">
+                             ItemsSource="{Binding FilteredSettingCategories}"
+                             SelectedItem="{Binding SelectedSettingCategory}">
                         <ListBox.ItemTemplate>
                             <DataTemplate>
                                 <TextBlock Text="{Binding}" Margin="8,5"/>
@@ -103,7 +103,7 @@
                                     </Border>
                                     <ListBox Grid.Row="1"
                                              MinHeight="220"
-                                             ItemsSource="{Binding FilteredPlugins}"
+                                             ItemsSource="{Binding Plugins}"
                                              SelectedItem="{Binding SelectedPlugin}">
                                         <ListBox.ItemTemplate>
                                             <DataTemplate x:DataType="vm:OptionsPluginItem">
@@ -149,7 +149,7 @@
                                 <TextBlock Text="Language:" VerticalAlignment="Top"/>
                                 <ListBox Grid.Column="1"
                                          MinHeight="220"
-                                         ItemsSource="{Binding FilteredLanguages}"
+                                         ItemsSource="{Binding Languages}"
                                          SelectedItem="{Binding SelectedLanguage}">
                                     <ListBox.ItemTemplate>
                                         <DataTemplate x:DataType="vm:LanguageItem">

--- a/src/SkyCD.App/Views/OptionsWindow.axaml
+++ b/src/SkyCD.App/Views/OptionsWindow.axaml
@@ -17,94 +17,148 @@
         <vm:OptionsDialogViewModel/>
     </Design.DataContext>
 
-    <Grid RowDefinitions="*,Auto" Margin="14">
-        <TabControl SelectedIndex="{Binding SelectedTabIndex}">
-            <TabItem Header="Plug-Ins">
-                <Grid RowDefinitions="Auto,Auto,*,Auto,Auto" RowSpacing="8" Margin="10">
-                    <TextBlock Text="Plug-In Path"/>
-                    <Grid Grid.Row="1" ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                        <TextBox Text="{Binding PluginPath}"/>
-                        <Button Grid.Column="1"
-                                Content="Browse..."
-                                MinWidth="90"
-                                Command="{Binding BrowsePluginPathCommand}"/>
-                    </Grid>
+    <Grid RowDefinitions="Auto,*,Auto" Margin="14" RowSpacing="12">
+        <Border BorderBrush="#D7D7D7"
+                BorderThickness="1"
+                CornerRadius="4"
+                Background="#FAFAFA"
+                Padding="10,8">
+            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
+                <TextBlock Text="Search settings"
+                           VerticalAlignment="Center"
+                           FontWeight="SemiBold"/>
+                <TextBox Grid.Column="1"
+                         PlaceholderText="Type to filter settings"
+                         Text="{Binding SettingsSearchText, UpdateSourceTrigger=PropertyChanged}"/>
+            </Grid>
+        </Border>
 
-                    <Border Grid.Row="2"
-                            Margin="0,4,0,0"
-                            BorderBrush="#D4D4D4"
-                            BorderThickness="1">
-                        <Grid RowDefinitions="Auto,*">
-                            <Border BorderBrush="#D4D4D4" BorderThickness="0,0,0,1" Background="#F5F5F5" Padding="8,6">
-                                <Grid ColumnDefinitions="Auto,2*,2*,3*">
-                                    <TextBlock Text="Enabled" FontWeight="SemiBold" HorizontalAlignment="Center"/>
-                                    <TextBlock Grid.Column="1" Text="Name" FontWeight="SemiBold"/>
-                                    <TextBlock Grid.Column="2" Text="Type" FontWeight="SemiBold"/>
-                                    <TextBlock Grid.Column="3" Text="Extended Info" FontWeight="SemiBold"/>
+        <Grid Grid.Row="1" ColumnDefinitions="180,*" ColumnSpacing="12">
+            <Border BorderBrush="#D4D4D4"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    Background="#F7F7F7"
+                    Padding="4">
+                <ListBox ItemsSource="{Binding SettingCategories}"
+                         SelectedIndex="{Binding SelectedTabIndex}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate>
+                            <TextBlock Text="{Binding}"
+                                       Margin="6,4"/>
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+            </Border>
+
+            <Border Grid.Column="1"
+                    BorderBrush="#D4D4D4"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    Padding="12">
+                <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                              VerticalScrollBarVisibility="Auto">
+                    <StackPanel Spacing="12">
+                        <StackPanel IsVisible="{Binding ShowPluginPathSection}" Spacing="8">
+                            <TextBlock Text="Plug-In Path" FontSize="15" FontWeight="SemiBold"/>
+                            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                                <TextBox Text="{Binding PluginPath}"/>
+                                <Button Grid.Column="1"
+                                        Content="Browse..."
+                                        MinWidth="90"
+                                        Command="{Binding BrowsePluginPathCommand}"/>
+                            </Grid>
+                        </StackPanel>
+
+                        <StackPanel IsVisible="{Binding ShowPluginListSection}" Spacing="8">
+                            <TextBlock Text="Installed Plug-Ins" FontSize="15" FontWeight="SemiBold"/>
+                            <Border BorderBrush="#D4D4D4"
+                                    BorderThickness="1">
+                                <Grid RowDefinitions="Auto,*">
+                                    <Border BorderBrush="#D4D4D4" BorderThickness="0,0,0,1" Background="#F5F5F5" Padding="8,6">
+                                        <Grid ColumnDefinitions="Auto,2*,2*,3*">
+                                            <TextBlock Text="Enabled" FontWeight="SemiBold" HorizontalAlignment="Center"/>
+                                            <TextBlock Grid.Column="1" Text="Name" FontWeight="SemiBold"/>
+                                            <TextBlock Grid.Column="2" Text="Type" FontWeight="SemiBold"/>
+                                            <TextBlock Grid.Column="3" Text="Extended Info" FontWeight="SemiBold"/>
+                                        </Grid>
+                                    </Border>
+
+                                    <ListBox Grid.Row="1"
+                                             MinHeight="220"
+                                             ItemsSource="{Binding Plugins}"
+                                             SelectedItem="{Binding SelectedPlugin}">
+                                        <ListBox.ItemTemplate>
+                                            <DataTemplate x:DataType="vm:OptionsPluginItem">
+                                                <Border BorderBrush="#E6E6E6" BorderThickness="0,0,0,1" Padding="8,5">
+                                                    <Grid ColumnDefinitions="Auto,2*,2*,3*">
+                                                        <CheckBox IsChecked="{Binding IsEnabled}" VerticalAlignment="Center"/>
+                                                        <TextBlock Grid.Column="1" Text="{Binding Name}"/>
+                                                        <TextBlock Grid.Column="2" Text="{Binding Type}"/>
+                                                        <TextBlock Grid.Column="3" Text="{Binding ExtendedInfo}"/>
+                                                    </Grid>
+                                                </Border>
+                                            </DataTemplate>
+                                        </ListBox.ItemTemplate>
+                                    </ListBox>
                                 </Grid>
                             </Border>
+                        </StackPanel>
 
-                            <ListBox Grid.Row="1"
-                                     ItemsSource="{Binding Plugins}"
-                                     SelectedItem="{Binding SelectedPlugin}">
+                        <StackPanel IsVisible="{Binding ShowPluginActionsSection}"
+                                    Orientation="Horizontal"
+                                    Spacing="8">
+                            <Button Content="Refresh"
+                                    MinWidth="90"
+                                    Command="{Binding RefreshPluginsCommand}"/>
+                            <Button Content="Configure"
+                                    MinWidth="90"
+                                    Command="{Binding ConfigurePluginCommand}"/>
+                        </StackPanel>
+
+                        <TextBlock IsVisible="{Binding ShowPluginInfoSection}"
+                                   Foreground="#404040"
+                                   Text="{Binding InfoMessage}"
+                                   TextWrapping="Wrap"/>
+
+                        <StackPanel IsVisible="{Binding ShowLanguageSection}" Spacing="8">
+                            <TextBlock Text="Interface Language" FontSize="15" FontWeight="SemiBold"/>
+                            <ListBox MinHeight="220"
+                                     ItemsSource="{Binding Languages}"
+                                     SelectedItem="{Binding SelectedLanguage}">
                                 <ListBox.ItemTemplate>
-                                    <DataTemplate x:DataType="vm:OptionsPluginItem">
-                                        <Border BorderBrush="#E6E6E6" BorderThickness="0,0,0,1" Padding="8,5">
-                                            <Grid ColumnDefinitions="Auto,2*,2*,3*">
-                                                <CheckBox IsChecked="{Binding IsEnabled}" VerticalAlignment="Center"/>
-                                                <TextBlock Grid.Column="1" Text="{Binding Name}"/>
-                                                <TextBlock Grid.Column="2" Text="{Binding Type}"/>
-                                                <TextBlock Grid.Column="3" Text="{Binding ExtendedInfo}"/>
-                                            </Grid>
-                                        </Border>
+                                    <DataTemplate x:DataType="vm:LanguageItem">
+                                        <TextBlock Text="{Binding DisplayText}"/>
                                     </DataTemplate>
                                 </ListBox.ItemTemplate>
                             </ListBox>
-                        </Grid>
-                    </Border>
+                        </StackPanel>
 
-                    <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="8">
-                        <Button Content="Refresh"
-                                MinWidth="90"
-                                Command="{Binding RefreshPluginsCommand}"/>
-                        <Button Content="Configure"
-                                MinWidth="90"
-                                Command="{Binding ConfigurePluginCommand}"/>
+                        <Border IsVisible="{Binding ShowNoSearchResults}"
+                                Background="#FFF8E1"
+                                BorderBrush="#E5D39A"
+                                BorderThickness="1"
+                                CornerRadius="4"
+                                Padding="10">
+                            <TextBlock Text="No settings match the current search."
+                                       TextWrapping="Wrap"/>
+                        </Border>
                     </StackPanel>
+                </ScrollViewer>
+            </Border>
+        </Grid>
 
-                    <TextBlock Grid.Row="4"
-                               Foreground="#404040"
-                               Text="{Binding InfoMessage}"
-                               TextWrapping="Wrap"/>
-                </Grid>
-            </TabItem>
-
-            <TabItem Header="Language">
-                <Grid Margin="10" RowDefinitions="Auto,*" RowSpacing="8">
-                    <TextBlock Text="Select interface language"/>
-                    <ListBox Grid.Row="1"
-                             ItemsSource="{Binding Languages}"
-                             SelectedItem="{Binding SelectedLanguage}">
-                        <ListBox.ItemTemplate>
-                            <DataTemplate x:DataType="vm:LanguageItem">
-                                <TextBlock Text="{Binding DisplayText}"/>
-                            </DataTemplate>
-                        </ListBox.ItemTemplate>
-                    </ListBox>
-                </Grid>
-            </TabItem>
-        </TabControl>
-
-        <StackPanel Grid.Row="1"
+        <StackPanel Grid.Row="2"
                     Orientation="Horizontal"
                     HorizontalAlignment="Right"
                     Spacing="8"
-                    Margin="0,12,0,0">
+                    Margin="0,2,0,0">
             <Button Content="OK"
                     MinWidth="90"
+                    IsDefault="True"
                     Command="{Binding ConfirmCommand}"/>
             <Button Content="Cancel"
                     MinWidth="90"
+                    IsCancel="True"
                     Click="OnCancelClicked"/>
         </StackPanel>
     </Grid>

--- a/src/SkyCD.App/Views/OptionsWindow.axaml
+++ b/src/SkyCD.App/Views/OptionsWindow.axaml
@@ -17,52 +17,68 @@
         <vm:OptionsDialogViewModel/>
     </Design.DataContext>
 
-    <Grid RowDefinitions="Auto,*,Auto" Margin="14" RowSpacing="12">
-        <Border BorderBrush="#D7D7D7"
-                BorderThickness="1"
-                CornerRadius="4"
-                Background="#FAFAFA"
-                Padding="10,8">
-            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
-                <TextBlock Text="Search settings"
-                           VerticalAlignment="Center"
-                           FontWeight="SemiBold"/>
-                <TextBox Grid.Column="1"
-                         PlaceholderText="Type to filter settings"
-                         Text="{Binding SettingsSearchText, UpdateSourceTrigger=PropertyChanged}"/>
-            </Grid>
+    <Grid RowDefinitions="Auto,*,Auto">
+        <Border BorderBrush="#2A2A2A"
+                BorderThickness="0,0,0,1"
+                Padding="14,10,14,8">
+            <TextBlock Text="Settings"
+                       FontSize="18"
+                       FontWeight="SemiBold"/>
         </Border>
 
-        <Grid Grid.Row="1" ColumnDefinitions="180,*" ColumnSpacing="12">
-            <Border BorderBrush="#D4D4D4"
+        <Grid Grid.Row="1"
+              Margin="14,10,14,10"
+              ColumnDefinitions="250,*"
+              ColumnSpacing="14">
+            <Border BorderBrush="#2E2E2E"
                     BorderThickness="1"
                     CornerRadius="4"
-                    Background="#F7F7F7"
-                    Padding="4">
-                <ListBox ItemsSource="{Binding SettingCategories}"
-                         SelectedIndex="{Binding SelectedTabIndex}">
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <TextBlock Text="{Binding}"
-                                       Margin="6,4"/>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
+                    Padding="8"
+                    Grid.RowSpan="2">
+                <Grid RowDefinitions="Auto,*,Auto" RowSpacing="10">
+                    <TextBox PlaceholderText="Search"
+                             Text="{Binding SettingsSearchText, UpdateSourceTrigger=PropertyChanged}"/>
+
+                    <ListBox Grid.Row="1"
+                             ItemsSource="{Binding SettingCategories}"
+                             SelectedIndex="{Binding SelectedTabIndex}">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}" Margin="8,5"/>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+
+                    <TextBlock Grid.Row="2"
+                               Foreground="#8C8C8C"
+                               FontSize="11"
+                               Text="Use arrows to navigate categories"/>
+                </Grid>
             </Border>
 
             <Border Grid.Column="1"
-                    BorderBrush="#D4D4D4"
+                    BorderBrush="#2E2E2E"
                     BorderThickness="1"
                     CornerRadius="4"
-                    Padding="12">
+                    Padding="14">
                 <ScrollViewer HorizontalScrollBarVisibility="Disabled"
                               VerticalScrollBarVisibility="Auto">
                     <StackPanel Spacing="12">
+                        <TextBlock FontSize="16" FontWeight="SemiBold">
+                            <Run Text="Tools"/>
+                            <Run Text="  >  "/>
+                            <Run Text="{Binding CurrentCategoryName}"/>
+                        </TextBlock>
+
                         <StackPanel IsVisible="{Binding ShowPluginPathSection}" Spacing="8">
-                            <TextBlock Text="Plug-In Path" FontSize="15" FontWeight="SemiBold"/>
-                            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                                <TextBox Text="{Binding PluginPath}"/>
-                                <Button Grid.Column="1"
+                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
+                                <TextBlock Text="Project Settings" FontSize="15"/>
+                                <Border Grid.Column="1" Height="1" Background="#2E2E2E" VerticalAlignment="Center"/>
+                            </Grid>
+                            <Grid ColumnDefinitions="140,*,Auto" ColumnSpacing="10">
+                                <TextBlock Text="Plug-in path:" VerticalAlignment="Center"/>
+                                <TextBox Grid.Column="1" Text="{Binding PluginPath}"/>
+                                <Button Grid.Column="2"
                                         Content="Browse..."
                                         MinWidth="90"
                                         Command="{Binding BrowsePluginPathCommand}"/>
@@ -70,26 +86,28 @@
                         </StackPanel>
 
                         <StackPanel IsVisible="{Binding ShowPluginListSection}" Spacing="8">
-                            <TextBlock Text="Installed Plug-Ins" FontSize="15" FontWeight="SemiBold"/>
-                            <Border BorderBrush="#D4D4D4"
+                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
+                                <TextBlock Text="Plug-ins" FontSize="15"/>
+                                <Border Grid.Column="1" Height="1" Background="#2E2E2E" VerticalAlignment="Center"/>
+                            </Grid>
+                            <Border BorderBrush="#2E2E2E"
                                     BorderThickness="1">
                                 <Grid RowDefinitions="Auto,*">
-                                    <Border BorderBrush="#D4D4D4" BorderThickness="0,0,0,1" Background="#F5F5F5" Padding="8,6">
+                                    <Border BorderBrush="#2E2E2E" BorderThickness="0,0,0,1" Padding="8,6">
                                         <Grid ColumnDefinitions="Auto,2*,2*,3*">
                                             <TextBlock Text="Enabled" FontWeight="SemiBold" HorizontalAlignment="Center"/>
                                             <TextBlock Grid.Column="1" Text="Name" FontWeight="SemiBold"/>
                                             <TextBlock Grid.Column="2" Text="Type" FontWeight="SemiBold"/>
-                                            <TextBlock Grid.Column="3" Text="Extended Info" FontWeight="SemiBold"/>
+                                            <TextBlock Grid.Column="3" Text="Source" FontWeight="SemiBold"/>
                                         </Grid>
                                     </Border>
-
                                     <ListBox Grid.Row="1"
                                              MinHeight="220"
                                              ItemsSource="{Binding Plugins}"
                                              SelectedItem="{Binding SelectedPlugin}">
                                         <ListBox.ItemTemplate>
                                             <DataTemplate x:DataType="vm:OptionsPluginItem">
-                                                <Border BorderBrush="#E6E6E6" BorderThickness="0,0,0,1" Padding="8,5">
+                                                <Border BorderBrush="#2E2E2E" BorderThickness="0,0,0,1" Padding="8,5">
                                                     <Grid ColumnDefinitions="Auto,2*,2*,3*">
                                                         <CheckBox IsChecked="{Binding IsEnabled}" VerticalAlignment="Center"/>
                                                         <TextBlock Grid.Column="1" Text="{Binding Name}"/>
@@ -104,38 +122,46 @@
                             </Border>
                         </StackPanel>
 
-                        <StackPanel IsVisible="{Binding ShowPluginActionsSection}"
-                                    Orientation="Horizontal"
-                                    Spacing="8">
-                            <Button Content="Refresh"
-                                    MinWidth="90"
-                                    Command="{Binding RefreshPluginsCommand}"/>
-                            <Button Content="Configure"
-                                    MinWidth="90"
-                                    Command="{Binding ConfigurePluginCommand}"/>
+                        <StackPanel IsVisible="{Binding ShowPluginActionsSection}" Spacing="8">
+                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
+                                <TextBlock Text="Actions" FontSize="15"/>
+                                <Border Grid.Column="1" Height="1" Background="#2E2E2E" VerticalAlignment="Center"/>
+                            </Grid>
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <Button Content="Refresh"
+                                        MinWidth="90"
+                                        Command="{Binding RefreshPluginsCommand}"/>
+                                <Button Content="Configure"
+                                        MinWidth="90"
+                                        Command="{Binding ConfigurePluginCommand}"/>
+                            </StackPanel>
+                            <TextBlock IsVisible="{Binding ShowPluginInfoSection}"
+                                       Text="{Binding InfoMessage}"
+                                       TextWrapping="Wrap"/>
                         </StackPanel>
 
-                        <TextBlock IsVisible="{Binding ShowPluginInfoSection}"
-                                   Foreground="#404040"
-                                   Text="{Binding InfoMessage}"
-                                   TextWrapping="Wrap"/>
-
                         <StackPanel IsVisible="{Binding ShowLanguageSection}" Spacing="8">
-                            <TextBlock Text="Interface Language" FontSize="15" FontWeight="SemiBold"/>
-                            <ListBox MinHeight="220"
-                                     ItemsSource="{Binding Languages}"
-                                     SelectedItem="{Binding SelectedLanguage}">
-                                <ListBox.ItemTemplate>
-                                    <DataTemplate x:DataType="vm:LanguageItem">
-                                        <TextBlock Text="{Binding DisplayText}"/>
-                                    </DataTemplate>
-                                </ListBox.ItemTemplate>
-                            </ListBox>
+                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
+                                <TextBlock Text="Application Settings" FontSize="15"/>
+                                <Border Grid.Column="1" Height="1" Background="#2E2E2E" VerticalAlignment="Center"/>
+                            </Grid>
+                            <Grid ColumnDefinitions="140,*" ColumnSpacing="10">
+                                <TextBlock Text="Language:" VerticalAlignment="Top"/>
+                                <ListBox Grid.Column="1"
+                                         MinHeight="220"
+                                         ItemsSource="{Binding Languages}"
+                                         SelectedItem="{Binding SelectedLanguage}">
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate x:DataType="vm:LanguageItem">
+                                            <TextBlock Text="{Binding DisplayText}"/>
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                </ListBox>
+                            </Grid>
                         </StackPanel>
 
                         <Border IsVisible="{Binding ShowNoSearchResults}"
-                                Background="#FFF8E1"
-                                BorderBrush="#E5D39A"
+                                BorderBrush="#6A5C2D"
                                 BorderThickness="1"
                                 CornerRadius="4"
                                 Padding="10">
@@ -147,20 +173,20 @@
             </Border>
         </Grid>
 
-        <StackPanel Grid.Row="2"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Right"
-                    Spacing="8"
-                    Margin="0,2,0,0">
-            <Button Content="OK"
-                    MinWidth="90"
-                    IsDefault="True"
-                    Command="{Binding ConfirmCommand}"/>
-            <Button Content="Cancel"
-                    MinWidth="90"
-                    IsCancel="True"
-                    Click="OnCancelClicked"/>
-        </StackPanel>
+        <Border Grid.Row="2" BorderBrush="#2A2A2A" BorderThickness="0,1,0,0" Padding="14,10">
+            <StackPanel Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Spacing="8">
+                <Button Content="Save"
+                        MinWidth="90"
+                        IsDefault="True"
+                        Command="{Binding ConfirmCommand}"/>
+                <Button Content="Cancel"
+                        MinWidth="90"
+                        IsCancel="True"
+                        Click="OnCancelClicked"/>
+            </StackPanel>
+        </Border>
     </Grid>
 </Window>
 

--- a/src/SkyCD.App/Views/OptionsWindow.axaml
+++ b/src/SkyCD.App/Views/OptionsWindow.axaml
@@ -103,7 +103,7 @@
                                     </Border>
                                     <ListBox Grid.Row="1"
                                              MinHeight="220"
-                                             ItemsSource="{Binding Plugins}"
+                                             ItemsSource="{Binding FilteredPlugins}"
                                              SelectedItem="{Binding SelectedPlugin}">
                                         <ListBox.ItemTemplate>
                                             <DataTemplate x:DataType="vm:OptionsPluginItem">
@@ -149,7 +149,7 @@
                                 <TextBlock Text="Language:" VerticalAlignment="Top"/>
                                 <ListBox Grid.Column="1"
                                          MinHeight="220"
-                                         ItemsSource="{Binding Languages}"
+                                         ItemsSource="{Binding FilteredLanguages}"
                                          SelectedItem="{Binding SelectedLanguage}">
                                     <ListBox.ItemTemplate>
                                         <DataTemplate x:DataType="vm:LanguageItem">

--- a/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
@@ -26,16 +26,15 @@ public partial class OptionsDialogViewModel : ObservableObject
         }
 
         selectedLanguage = Languages[0];
-        RefreshFilteredContent();
+        RefreshFilteredCategories();
+        selectedSettingCategory = CurrentCategoryName;
     }
 
     public ObservableCollection<OptionsPluginItem> Plugins { get; } = [];
 
-    public ObservableCollection<OptionsPluginItem> FilteredPlugins { get; } = [];
-
     public ObservableCollection<LanguageItem> Languages { get; } = [];
 
-    public ObservableCollection<LanguageItem> FilteredLanguages { get; } = [];
+    public ObservableCollection<string> FilteredSettingCategories { get; } = [];
 
     [ObservableProperty]
     private string pluginPath = string.Empty;
@@ -58,9 +57,16 @@ public partial class OptionsDialogViewModel : ObservableObject
     [ObservableProperty]
     private string settingsSearchText = string.Empty;
 
+    [ObservableProperty]
+    private string? selectedSettingCategory;
+
     public IReadOnlyList<string> SettingCategories { get; } = ["Plugins", "Language"];
 
     public string CurrentCategoryName => SettingCategories[Math.Clamp(SelectedTabIndex, 0, SettingCategories.Count - 1)];
+
+    public bool IsCurrentCategoryVisibleInSearch =>
+        string.IsNullOrWhiteSpace(SettingsSearchText) ||
+        FilteredSettingCategories.Contains(CurrentCategoryName);
 
     public bool IsPluginsCategorySelected => SelectedTabIndex == 0;
 
@@ -68,11 +74,11 @@ public partial class OptionsDialogViewModel : ObservableObject
 
     public bool ShowPluginPathSection =>
         IsPluginsCategorySelected &&
-        MatchesSearch("plugin path", "path", "browse", "directory", PluginPath);
+        IsCurrentCategoryVisibleInSearch;
 
     public bool ShowPluginListSection =>
         IsPluginsCategorySelected &&
-        (FilteredPlugins.Count > 0 || MatchesSearch("plugin list", "plugins", "enabled", "name", "type", "state", "source"));
+        IsCurrentCategoryVisibleInSearch;
 
     public bool ShowPluginActionsSection =>
         IsPluginsCategorySelected &&
@@ -80,11 +86,11 @@ public partial class OptionsDialogViewModel : ObservableObject
 
     public bool ShowPluginInfoSection =>
         IsPluginsCategorySelected &&
-        MatchesSearch("status", "info", "message", "plugin status", InfoMessage);
+        IsCurrentCategoryVisibleInSearch;
 
     public bool ShowLanguageSection =>
         IsLanguageCategorySelected &&
-        (FilteredLanguages.Count > 0 || MatchesSearch("language", "interface language", "localization"));
+        IsCurrentCategoryVisibleInSearch;
 
     public bool HasVisibleCategoryContent =>
         ShowPluginPathSection ||
@@ -146,7 +152,6 @@ public partial class OptionsDialogViewModel : ObservableObject
         SelectedPlugin = Plugins.FirstOrDefault();
         InfoMessage = $"Loaded {Plugins.Count} plugin(s).";
         ConfigurePluginCommand.NotifyCanExecuteChanged();
-        RefreshFilteredContent();
     }
 
     public void SetDisabledPluginIds(IEnumerable<string>? pluginIds)
@@ -204,21 +209,13 @@ public partial class OptionsDialogViewModel : ObservableObject
             return;
         }
 
+        SelectedSettingCategory = CurrentCategoryName;
         NotifySettingsVisibilityChanged();
     }
 
     partial void OnSettingsSearchTextChanged(string value)
     {
-        RefreshFilteredContent();
-    }
-
-    partial void OnPluginPathChanged(string value)
-    {
-        NotifySettingsVisibilityChanged();
-    }
-
-    partial void OnInfoMessageChanged(string value)
-    {
+        RefreshFilteredCategories();
         NotifySettingsVisibilityChanged();
     }
 
@@ -232,32 +229,51 @@ public partial class OptionsDialogViewModel : ObservableObject
         return terms.Any(term => term.Contains(SettingsSearchText, StringComparison.OrdinalIgnoreCase));
     }
 
-    private void RefreshFilteredContent()
+    partial void OnSelectedSettingCategoryChanged(string? value)
     {
-        FilteredPlugins.Clear();
-        foreach (var plugin in Plugins)
+        if (string.IsNullOrWhiteSpace(value))
         {
-            if (MatchesSearch(plugin.Name, plugin.Type, plugin.ExtendedInfo, plugin.Id))
-            {
-                FilteredPlugins.Add(plugin);
-            }
+            return;
         }
 
-        FilteredLanguages.Clear();
-        foreach (var language in Languages)
+        var index = SettingCategories
+            .Select((category, index) => new { category, index })
+            .FirstOrDefault(item => string.Equals(item.category, value, StringComparison.OrdinalIgnoreCase))
+            ?.index;
+
+        if (index is null || index == SelectedTabIndex)
         {
-            if (MatchesSearch(language.Name, language.DisplayText))
-            {
-                FilteredLanguages.Add(language);
-            }
+            return;
         }
 
-        NotifySettingsVisibilityChanged();
+        SelectedTabIndex = index.Value;
+    }
+
+    private void RefreshFilteredCategories()
+    {
+        FilteredSettingCategories.Clear();
+        foreach (var category in SettingCategories.Where(category => MatchesSearch(category)))
+        {
+            FilteredSettingCategories.Add(category);
+        }
+
+        if (FilteredSettingCategories.Count == 0)
+        {
+            SelectedSettingCategory = null;
+            return;
+        }
+
+        if (SelectedSettingCategory is null ||
+            !FilteredSettingCategories.Contains(SelectedSettingCategory))
+        {
+            SelectedSettingCategory = FilteredSettingCategories[0];
+        }
     }
 
     private void NotifySettingsVisibilityChanged()
     {
         OnPropertyChanged(nameof(CurrentCategoryName));
+        OnPropertyChanged(nameof(IsCurrentCategoryVisibleInSearch));
         OnPropertyChanged(nameof(IsPluginsCategorySelected));
         OnPropertyChanged(nameof(IsLanguageCategorySelected));
         OnPropertyChanged(nameof(ShowPluginPathSection));

--- a/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
@@ -55,6 +55,8 @@ public partial class OptionsDialogViewModel : ObservableObject
 
     public IReadOnlyList<string> SettingCategories { get; } = ["Plugins", "Language"];
 
+    public string CurrentCategoryName => SettingCategories[Math.Clamp(SelectedTabIndex, 0, SettingCategories.Count - 1)];
+
     public bool IsPluginsCategorySelected => SelectedTabIndex == 0;
 
     public bool IsLanguageCategorySelected => SelectedTabIndex == 1;
@@ -216,6 +218,7 @@ public partial class OptionsDialogViewModel : ObservableObject
 
     private void NotifySettingsVisibilityChanged()
     {
+        OnPropertyChanged(nameof(CurrentCategoryName));
         OnPropertyChanged(nameof(IsPluginsCategorySelected));
         OnPropertyChanged(nameof(IsLanguageCategorySelected));
         OnPropertyChanged(nameof(ShowPluginPathSection));

--- a/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
@@ -50,6 +50,44 @@ public partial class OptionsDialogViewModel : ObservableObject
     [ObservableProperty]
     private int selectedTabIndex;
 
+    [ObservableProperty]
+    private string settingsSearchText = string.Empty;
+
+    public IReadOnlyList<string> SettingCategories { get; } = ["Plugins", "Language"];
+
+    public bool IsPluginsCategorySelected => SelectedTabIndex == 0;
+
+    public bool IsLanguageCategorySelected => SelectedTabIndex == 1;
+
+    public bool ShowPluginPathSection =>
+        IsPluginsCategorySelected &&
+        MatchesSearch("plugin path", "path", "browse", "directory");
+
+    public bool ShowPluginListSection =>
+        IsPluginsCategorySelected &&
+        MatchesSearch("plugin list", "plugins", "enabled", "name", "type", "state", "source");
+
+    public bool ShowPluginActionsSection =>
+        IsPluginsCategorySelected &&
+        MatchesSearch("actions", "refresh", "configure", "plugin actions");
+
+    public bool ShowPluginInfoSection =>
+        IsPluginsCategorySelected &&
+        MatchesSearch("status", "info", "message", "plugin status");
+
+    public bool ShowLanguageSection =>
+        IsLanguageCategorySelected &&
+        MatchesSearch("language", "interface language", "localization");
+
+    public bool HasVisibleCategoryContent =>
+        ShowPluginPathSection ||
+        ShowPluginListSection ||
+        ShowPluginActionsSection ||
+        ShowPluginInfoSection ||
+        ShowLanguageSection;
+
+    public bool ShowNoSearchResults => !HasVisibleCategoryContent;
+
     public event EventHandler? BrowsePluginPathRequested;
 
     public event EventHandler? RefreshPluginsRequested;
@@ -142,5 +180,50 @@ public partial class OptionsDialogViewModel : ObservableObject
     partial void OnSelectedPluginChanged(OptionsPluginItem? value)
     {
         ConfigurePluginCommand.NotifyCanExecuteChanged();
+    }
+
+    partial void OnSelectedTabIndexChanged(int value)
+    {
+        if (value < 0)
+        {
+            SelectedTabIndex = 0;
+            return;
+        }
+
+        if (value >= SettingCategories.Count)
+        {
+            SelectedTabIndex = SettingCategories.Count - 1;
+            return;
+        }
+
+        NotifySettingsVisibilityChanged();
+    }
+
+    partial void OnSettingsSearchTextChanged(string value)
+    {
+        NotifySettingsVisibilityChanged();
+    }
+
+    private bool MatchesSearch(params string[] terms)
+    {
+        if (string.IsNullOrWhiteSpace(SettingsSearchText))
+        {
+            return true;
+        }
+
+        return terms.Any(term => term.Contains(SettingsSearchText, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private void NotifySettingsVisibilityChanged()
+    {
+        OnPropertyChanged(nameof(IsPluginsCategorySelected));
+        OnPropertyChanged(nameof(IsLanguageCategorySelected));
+        OnPropertyChanged(nameof(ShowPluginPathSection));
+        OnPropertyChanged(nameof(ShowPluginListSection));
+        OnPropertyChanged(nameof(ShowPluginActionsSection));
+        OnPropertyChanged(nameof(ShowPluginInfoSection));
+        OnPropertyChanged(nameof(ShowLanguageSection));
+        OnPropertyChanged(nameof(HasVisibleCategoryContent));
+        OnPropertyChanged(nameof(ShowNoSearchResults));
     }
 }

--- a/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/OptionsDialogViewModel.cs
@@ -26,11 +26,16 @@ public partial class OptionsDialogViewModel : ObservableObject
         }
 
         selectedLanguage = Languages[0];
+        RefreshFilteredContent();
     }
 
     public ObservableCollection<OptionsPluginItem> Plugins { get; } = [];
 
+    public ObservableCollection<OptionsPluginItem> FilteredPlugins { get; } = [];
+
     public ObservableCollection<LanguageItem> Languages { get; } = [];
+
+    public ObservableCollection<LanguageItem> FilteredLanguages { get; } = [];
 
     [ObservableProperty]
     private string pluginPath = string.Empty;
@@ -63,11 +68,11 @@ public partial class OptionsDialogViewModel : ObservableObject
 
     public bool ShowPluginPathSection =>
         IsPluginsCategorySelected &&
-        MatchesSearch("plugin path", "path", "browse", "directory");
+        MatchesSearch("plugin path", "path", "browse", "directory", PluginPath);
 
     public bool ShowPluginListSection =>
         IsPluginsCategorySelected &&
-        MatchesSearch("plugin list", "plugins", "enabled", "name", "type", "state", "source");
+        (FilteredPlugins.Count > 0 || MatchesSearch("plugin list", "plugins", "enabled", "name", "type", "state", "source"));
 
     public bool ShowPluginActionsSection =>
         IsPluginsCategorySelected &&
@@ -75,11 +80,11 @@ public partial class OptionsDialogViewModel : ObservableObject
 
     public bool ShowPluginInfoSection =>
         IsPluginsCategorySelected &&
-        MatchesSearch("status", "info", "message", "plugin status");
+        MatchesSearch("status", "info", "message", "plugin status", InfoMessage);
 
     public bool ShowLanguageSection =>
         IsLanguageCategorySelected &&
-        MatchesSearch("language", "interface language", "localization");
+        (FilteredLanguages.Count > 0 || MatchesSearch("language", "interface language", "localization"));
 
     public bool HasVisibleCategoryContent =>
         ShowPluginPathSection ||
@@ -141,6 +146,7 @@ public partial class OptionsDialogViewModel : ObservableObject
         SelectedPlugin = Plugins.FirstOrDefault();
         InfoMessage = $"Loaded {Plugins.Count} plugin(s).";
         ConfigurePluginCommand.NotifyCanExecuteChanged();
+        RefreshFilteredContent();
     }
 
     public void SetDisabledPluginIds(IEnumerable<string>? pluginIds)
@@ -203,6 +209,16 @@ public partial class OptionsDialogViewModel : ObservableObject
 
     partial void OnSettingsSearchTextChanged(string value)
     {
+        RefreshFilteredContent();
+    }
+
+    partial void OnPluginPathChanged(string value)
+    {
+        NotifySettingsVisibilityChanged();
+    }
+
+    partial void OnInfoMessageChanged(string value)
+    {
         NotifySettingsVisibilityChanged();
     }
 
@@ -214,6 +230,29 @@ public partial class OptionsDialogViewModel : ObservableObject
         }
 
         return terms.Any(term => term.Contains(SettingsSearchText, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private void RefreshFilteredContent()
+    {
+        FilteredPlugins.Clear();
+        foreach (var plugin in Plugins)
+        {
+            if (MatchesSearch(plugin.Name, plugin.Type, plugin.ExtendedInfo, plugin.Id))
+            {
+                FilteredPlugins.Add(plugin);
+            }
+        }
+
+        FilteredLanguages.Clear();
+        foreach (var language in Languages)
+        {
+            if (MatchesSearch(language.Name, language.DisplayText))
+            {
+                FilteredLanguages.Add(language);
+            }
+        }
+
+        NotifySettingsVisibilityChanged();
     }
 
     private void NotifySettingsVisibilityChanged()

--- a/tests/SkyCD.App.Tests/OptionsDialogViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/OptionsDialogViewModelTests.cs
@@ -120,12 +120,13 @@ public class OptionsDialogViewModelTests
         var vm = new OptionsDialogViewModel(["English"]);
         vm.SelectedTabIndex = 0;
 
-        vm.SettingsSearchText = "configure";
+        vm.SettingsSearchText = "plug";
 
-        Assert.False(vm.ShowPluginPathSection);
-        Assert.False(vm.ShowPluginListSection);
+        Assert.Equal(["Plugins"], vm.FilteredSettingCategories);
+        Assert.True(vm.ShowPluginPathSection);
+        Assert.True(vm.ShowPluginListSection);
         Assert.True(vm.ShowPluginActionsSection);
-        Assert.False(vm.ShowPluginInfoSection);
+        Assert.True(vm.ShowPluginInfoSection);
         Assert.True(vm.HasVisibleCategoryContent);
         Assert.False(vm.ShowNoSearchResults);
     }
@@ -134,44 +135,43 @@ public class OptionsDialogViewModelTests
     public void SearchText_ShowsNoResultsWhenCategoryHasNoMatch()
     {
         var vm = new OptionsDialogViewModel(["English"]);
-        vm.SelectedTabIndex = 1;
+        vm.SelectedTabIndex = 0;
 
-        vm.SettingsSearchText = "plugin";
+        vm.SettingsSearchText = "terminal";
 
-        Assert.False(vm.ShowLanguageSection);
+        Assert.Empty(vm.FilteredSettingCategories);
+        Assert.False(vm.ShowPluginPathSection);
         Assert.False(vm.HasVisibleCategoryContent);
         Assert.True(vm.ShowNoSearchResults);
     }
 
     [Fact]
-    public void SearchText_FiltersPluginsByContent()
+    public void SearchText_FiltersLeftCategoryList()
     {
-        var vm = new OptionsDialogViewModel(["English"]);
-        vm.SelectedTabIndex = 0;
+        var vm = new OptionsDialogViewModel(["English", "Lithuanian"]);
+
+        vm.SettingsSearchText = "lang";
+
+        Assert.Equal(["Language"], vm.FilteredSettingCategories);
+        Assert.Equal("Language", vm.SelectedSettingCategory);
+        Assert.Equal(1, vm.SelectedTabIndex);
+        Assert.True(vm.ShowLanguageSection);
+    }
+
+    [Fact]
+    public void SearchText_DoesNotFilterRightPanelItemCollections()
+    {
+        var vm = new OptionsDialogViewModel(["English", "Lithuanian"]);
         vm.SetPlugins(
         [
             new OptionsPluginItem("JSON", "IFileFormatPluginCapability", "json v2.0.0", id: "plugin.json"),
             new OptionsPluginItem("XML", "IFileFormatPluginCapability", "xml v2.0.0", id: "plugin.xml")
         ]);
+        vm.SelectedTabIndex = 0;
 
-        vm.SettingsSearchText = "xml";
+        vm.SettingsSearchText = "plug";
 
-        Assert.Single(vm.FilteredPlugins);
-        Assert.Equal("XML", vm.FilteredPlugins[0].Name);
-        Assert.True(vm.ShowPluginListSection);
-    }
-
-    [Fact]
-    public void SearchText_FiltersLanguagesByContent()
-    {
-        var vm = new OptionsDialogViewModel(["English", "Lithuanian"]);
-        vm.SelectedTabIndex = 1;
-
-        vm.SettingsSearchText = "lith";
-
-        Assert.Single(vm.FilteredLanguages);
-        Assert.Equal("Lithuanian", vm.FilteredLanguages[0].Name);
-        Assert.True(vm.ShowLanguageSection);
-        Assert.False(vm.ShowNoSearchResults);
+        Assert.Equal(2, vm.Plugins.Count);
+        Assert.Equal(2, vm.Languages.Count);
     }
 }

--- a/tests/SkyCD.App.Tests/OptionsDialogViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/OptionsDialogViewModelTests.cs
@@ -142,4 +142,36 @@ public class OptionsDialogViewModelTests
         Assert.False(vm.HasVisibleCategoryContent);
         Assert.True(vm.ShowNoSearchResults);
     }
+
+    [Fact]
+    public void SearchText_FiltersPluginsByContent()
+    {
+        var vm = new OptionsDialogViewModel(["English"]);
+        vm.SelectedTabIndex = 0;
+        vm.SetPlugins(
+        [
+            new OptionsPluginItem("JSON", "IFileFormatPluginCapability", "json v2.0.0", id: "plugin.json"),
+            new OptionsPluginItem("XML", "IFileFormatPluginCapability", "xml v2.0.0", id: "plugin.xml")
+        ]);
+
+        vm.SettingsSearchText = "xml";
+
+        Assert.Single(vm.FilteredPlugins);
+        Assert.Equal("XML", vm.FilteredPlugins[0].Name);
+        Assert.True(vm.ShowPluginListSection);
+    }
+
+    [Fact]
+    public void SearchText_FiltersLanguagesByContent()
+    {
+        var vm = new OptionsDialogViewModel(["English", "Lithuanian"]);
+        vm.SelectedTabIndex = 1;
+
+        vm.SettingsSearchText = "lith";
+
+        Assert.Single(vm.FilteredLanguages);
+        Assert.Equal("Lithuanian", vm.FilteredLanguages[0].Name);
+        Assert.True(vm.ShowLanguageSection);
+        Assert.False(vm.ShowNoSearchResults);
+    }
 }

--- a/tests/SkyCD.App.Tests/OptionsDialogViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/OptionsDialogViewModelTests.cs
@@ -101,4 +101,45 @@ public class OptionsDialogViewModelTests
 
         Assert.Equal(1, vm.SelectedTabIndex);
     }
+
+    [Fact]
+    public void SelectedTabIndex_ClampsOutOfRangeValues()
+    {
+        var vm = new OptionsDialogViewModel(["English"]);
+
+        vm.SelectedTabIndex = -5;
+        Assert.Equal(0, vm.SelectedTabIndex);
+
+        vm.SelectedTabIndex = 99;
+        Assert.Equal(1, vm.SelectedTabIndex);
+    }
+
+    [Fact]
+    public void SearchText_FiltersPluginSections()
+    {
+        var vm = new OptionsDialogViewModel(["English"]);
+        vm.SelectedTabIndex = 0;
+
+        vm.SettingsSearchText = "configure";
+
+        Assert.False(vm.ShowPluginPathSection);
+        Assert.False(vm.ShowPluginListSection);
+        Assert.True(vm.ShowPluginActionsSection);
+        Assert.False(vm.ShowPluginInfoSection);
+        Assert.True(vm.HasVisibleCategoryContent);
+        Assert.False(vm.ShowNoSearchResults);
+    }
+
+    [Fact]
+    public void SearchText_ShowsNoResultsWhenCategoryHasNoMatch()
+    {
+        var vm = new OptionsDialogViewModel(["English"]);
+        vm.SelectedTabIndex = 1;
+
+        vm.SettingsSearchText = "plugin";
+
+        Assert.False(vm.ShowLanguageSection);
+        Assert.False(vm.HasVisibleCategoryContent);
+        Assert.True(vm.ShowNoSearchResults);
+    }
 }


### PR DESCRIPTION
Solves #296: Redesign Options dialog to Rider-style Settings UI without functional regressions

## What changed
- Replaced tabbed Options layout with Rider-style structure:
  - left category navigation (Plugins, Language)
  - top search field for quick filtering
  - right detail panel with section-based settings content
  - bottom action bar with OK and Cancel
- Preserved existing options behavior and command/event wiring:
  - plugin path browse
  - plugin refresh/discovery list and enable/disable state handling
  - plugin configure command behavior and state sensitivity
  - language selection behavior
  - selected tab persistence via SelectedTabIndex
  - existing OK/Cancel semantics
- Added view-model-driven filtering visibility state to support right-panel section filtering.
- Added tests for category/search filtering behavior and tab index clamping.

## Validation
- dotnet restore SkyCD.slnx
- dotnet build SkyCD.slnx --configuration Release --no-restore
- dotnet test SkyCD.slnx --configuration Release --no-build
- dotnet format SkyCD.slnx --verify-no-changes --verbosity minimal