### PR TITLE
Add command-line switch support with plugin-extensible CLI commands

### DIFF
--- a/SkyCD.slnx
+++ b/SkyCD.slnx
@@ -22,6 +22,7 @@
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/SkyCD.App/SkyCD.App.csproj" />
+    <Project Path="src/SkyCD.Cli/SkyCD.Cli.csproj" />
     <Project Path="src/SkyCD.UI/SkyCD.UI.csproj" />
     <Project Path="src/SkyCD.Application/SkyCD.Application.csproj" />
     <Project Path="src/SkyCD.Domain/SkyCD.Domain.csproj" />
@@ -33,6 +34,7 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj" />
+    <Project Path="tests/SkyCD.Cli.Tests/SkyCD.Cli.Tests.csproj" />
     <Project Path="tests/SkyCD.UI.Tests/SkyCD.UI.Tests.csproj" />
     <Project Path="tests/SkyCD.Domain.Tests/SkyCD.Domain.Tests.csproj" />
     <Project Path="tests/SkyCD.Infrastructure.Tests/SkyCD.Infrastructure.Tests.csproj" />

--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -1,0 +1,47 @@
+# SkyCD CLI Usage
+
+SkyCD can run in headless CLI mode when command-line switches are provided.
+Running with no CLI arguments keeps desktop startup unchanged.
+
+## Commands
+
+```text
+skycd open <file> [--format <id>] [--json]
+skycd convert --in <file> --out <file> [--in-format <id>] [--format <id>] [--json]
+skycd list-formats [--json]
+skycd plugins list [--json]
+skycd --help
+skycd --version
+```
+
+## Output Conventions
+
+- Human-readable output is written to stdout by default.
+- Machine-readable output can be requested with `--json`.
+- Errors are written to stderr and return non-zero exit codes.
+
+## Exit Codes
+
+- `0`: success
+- `2`: invalid arguments
+- `3`: command execution failure
+- `4`: plugin/CLI configuration error (e.g., command collision)
+- `130`: cancelled (Ctrl+C)
+
+## Plugin CLI Contributions
+
+Plugins can implement `ICliPluginCapability` to:
+
+- add new commands (`CliContributionType.Command`)
+- extend host command pipelines (`CliContributionType.Extension`)
+
+Current extension points:
+
+- `open`
+- `convert`
+
+Collision rules:
+
+- Built-in command names are reserved.
+- Duplicate plugin command paths are rejected deterministically with a clear error message.
+- Extension contributions must target an existing extension point.

--- a/docs/plugins/sdk-contracts.md
+++ b/docs/plugins/sdk-contracts.md
@@ -18,6 +18,10 @@
 - `IModalPluginCapability`
   - Declares modal descriptors with size hints, permission requirements, and typed input/output contracts
   - Uses `ModalPayload` (`TypeId` + value) for input/output envelopes
+- `ICliPluginCapability`
+  - Declares CLI command contributions (`CliCommandContribution`)
+  - Supports new command registration and extension-point contributions for built-in host commands
+  - Executes contributed command handlers through `ExecuteCliCommandAsync` and `CliCommandContext`
 
 ## Runtime Discovery
 - Runtime scans assemblies for classes implementing `IPlugin`.
@@ -28,6 +32,7 @@
 - Host executes menu commands through `MenuExtensionService` with timeout and exception isolation.
 - Plugin exceptions are converted to result failures and should not crash the host UI thread.
 - Host executes modals through `ModalExtensionService` with permission checks, typed payload validation, timeout/cancellation propagation, and reentrancy guards.
+- Host executes CLI plugin handlers with timeout and exception isolation, including deterministic command collision checks.
 
 ## Sample Plugin
 - `Plugins/SkyCD.Plugin.Json`

--- a/src/SkyCD.App/Program.cs
+++ b/src/SkyCD.App/Program.cs
@@ -1,6 +1,10 @@
 using Avalonia;
 using SkyCD.Cli;
+using Microsoft.Win32.SafeHandles;
 using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace SkyCD.App;
 
@@ -9,7 +13,10 @@ sealed class Program
     [STAThread]
     public static void Main(string[] args)
     {
-        var cliResult = CliEntryPoint.TryRun(args);
+        var cliResult = CliEntryPoint.TryRun(
+            args,
+            stdout: CliStdIo.CreateOutputWriter(),
+            stderr: CliStdIo.CreateErrorWriter());
         if (cliResult.Handled)
         {
             Environment.ExitCode = cliResult.ExitCode;
@@ -27,4 +34,48 @@ sealed class Program
 #endif
             .WithInterFont()
             .LogToTrace();
+}
+
+internal static class CliStdIo
+{
+    private static readonly TextWriter fallbackOut = Console.Out;
+    private static readonly TextWriter fallbackError = Console.Error;
+
+    public static TextWriter CreateOutputWriter() => CreateWriter(StandardHandle.Output, fallbackOut);
+
+    public static TextWriter CreateErrorWriter() => CreateWriter(StandardHandle.Error, fallbackError);
+
+    private static TextWriter CreateWriter(StandardHandle handle, TextWriter fallback)
+    {
+        var stdHandle = GetStdHandle((int)handle);
+        if (stdHandle == IntPtr.Zero || stdHandle == InvalidHandleValue)
+        {
+            return fallback;
+        }
+
+        try
+        {
+            var safeHandle = new SafeFileHandle(stdHandle, ownsHandle: false);
+            var stream = new FileStream(safeHandle, FileAccess.Write);
+            return TextWriter.Synchronized(new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false))
+            {
+                AutoFlush = true
+            });
+        }
+        catch
+        {
+            return fallback;
+        }
+    }
+
+    private static readonly IntPtr InvalidHandleValue = new(-1);
+
+    private enum StandardHandle
+    {
+        Output = -11,
+        Error = -12
+    }
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern IntPtr GetStdHandle(int nStdHandle);
 }

--- a/src/SkyCD.App/Program.cs
+++ b/src/SkyCD.App/Program.cs
@@ -49,6 +49,11 @@ internal static class CliStdIo
 
     public static void EnsureConsoleAttached()
     {
+        if (HasUsableStdHandle(StandardHandle.Output) || HasUsableStdHandle(StandardHandle.Error))
+        {
+            return;
+        }
+
         AttachConsole(AttachParentProcess);
     }
 
@@ -77,6 +82,12 @@ internal static class CliStdIo
         {
             return fallback;
         }
+    }
+
+    private static bool HasUsableStdHandle(StandardHandle handle)
+    {
+        var stdHandle = GetStdHandle((int)handle);
+        return stdHandle != IntPtr.Zero && stdHandle != InvalidHandleValue;
     }
 
     private static readonly IntPtr InvalidHandleValue = new(-1);

--- a/src/SkyCD.App/Program.cs
+++ b/src/SkyCD.App/Program.cs
@@ -1,18 +1,24 @@
-﻿using Avalonia;
+using Avalonia;
+using SkyCD.Cli;
 using System;
 
 namespace SkyCD.App;
 
 sealed class Program
 {
-    // Initialization code. Don't use any Avalonia, third-party APIs or any
-    // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
-    // yet and stuff might break.
     [STAThread]
-    public static void Main(string[] args) => BuildAvaloniaApp()
-        .StartWithClassicDesktopLifetime(args);
+    public static void Main(string[] args)
+    {
+        var cliResult = CliEntryPoint.TryRun(args);
+        if (cliResult.Handled)
+        {
+            Environment.ExitCode = cliResult.ExitCode;
+            return;
+        }
 
-    // Avalonia configuration, don't remove; also used by visual designer.
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
+
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()

--- a/src/SkyCD.App/Program.cs
+++ b/src/SkyCD.App/Program.cs
@@ -13,6 +13,11 @@ sealed class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        if (args.Length > 0)
+        {
+            CliStdIo.EnsureConsoleAttached();
+        }
+
         var cliResult = CliEntryPoint.TryRun(
             args,
             stdout: CliStdIo.CreateOutputWriter(),
@@ -38,8 +43,14 @@ sealed class Program
 
 internal static class CliStdIo
 {
-    private static readonly TextWriter fallbackOut = Console.Out;
-    private static readonly TextWriter fallbackError = Console.Error;
+    private const uint AttachParentProcess = 0xFFFFFFFF;
+    private static readonly TextWriter fallbackOut = TextWriter.Null;
+    private static readonly TextWriter fallbackError = TextWriter.Null;
+
+    public static void EnsureConsoleAttached()
+    {
+        AttachConsole(AttachParentProcess);
+    }
 
     public static TextWriter CreateOutputWriter() => CreateWriter(StandardHandle.Output, fallbackOut);
 
@@ -78,4 +89,7 @@ internal static class CliStdIo
 
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern IntPtr GetStdHandle(int nStdHandle);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool AttachConsole(uint dwProcessId);
 }

--- a/src/SkyCD.App/Services/RuntimePluginDiscoveryService.cs
+++ b/src/SkyCD.App/Services/RuntimePluginDiscoveryService.cs
@@ -1,16 +1,15 @@
 using SkyCD.Presentation.ViewModels;
-using SkyCD.Plugin.Runtime.Discovery;
+using SkyCD.Plugin.Runtime.Loading;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 
 namespace SkyCD.App.Services;
 
 public sealed class RuntimePluginDiscoveryService
 {
-    private readonly PluginDiscoveryService discoveryService = new();
+    private readonly PluginDirectoryDiscoveryService discoveryService = new();
     private readonly Version hostVersion = new(3, 0, 0);
 
     public IReadOnlyList<OptionsPluginItem> Discover(string pluginPath)
@@ -23,10 +22,15 @@ public sealed class RuntimePluginDiscoveryService
         var discovered = new List<OptionsPluginItem>();
         var seenPluginIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-        var dllPaths = Directory.GetFiles(pluginPath, "*.dll", SearchOption.AllDirectories);
-        foreach (var dllPath in dllPaths)
+        var loadResult = discoveryService.Discover([pluginPath], new PluginLoadOptions
         {
-            TryDiscoverFromAssembly(dllPath, seenPluginIds, discovered);
+            HostVersion = hostVersion,
+            EnableAssemblyIsolation = false
+        }, fallbackToAssemblyScan: true);
+
+        foreach (var plugin in loadResult.Plugins)
+        {
+            TryAdd(plugin, seenPluginIds, discovered);
         }
 
         return discovered
@@ -34,51 +38,28 @@ public sealed class RuntimePluginDiscoveryService
             .ToArray();
     }
 
-    private void TryDiscoverFromAssembly(
-        string dllPath,
+    private static void TryAdd(
+        SkyCD.Plugin.Runtime.Discovery.DiscoveredPlugin plugin,
         ISet<string> seenPluginIds,
         ICollection<OptionsPluginItem> output)
     {
-        Assembly assembly;
-        try
-        {
-            assembly = Assembly.LoadFrom(dllPath);
-        }
-        catch
+        var descriptor = plugin.Plugin.Descriptor;
+        if (!seenPluginIds.Add(descriptor.Id))
         {
             return;
         }
 
-        IReadOnlyList<DiscoveredPlugin> plugins;
-        try
-        {
-            plugins = discoveryService.DiscoverFromAssembly(assembly, hostVersion);
-        }
-        catch
-        {
-            return;
-        }
+        var capabilitySummary = plugin.Capabilities.Count == 0
+            ? "Generic"
+            : string.Join(", ", plugin.Capabilities
+                .Select(static capability => capability.GetType().Name)
+                .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase));
 
-        foreach (var plugin in plugins)
-        {
-            var descriptor = plugin.Plugin.Descriptor;
-            if (!seenPluginIds.Add(descriptor.Id))
-            {
-                continue;
-            }
-
-            var capabilitySummary = plugin.Capabilities.Count == 0
-                ? "Generic"
-                : string.Join(", ", plugin.Capabilities
-                    .Select(static capability => capability.GetType().Name)
-                    .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase));
-
-            var extendedInfo = $"{descriptor.Id} v{descriptor.Version}";
-            output.Add(new OptionsPluginItem(
-                descriptor.DisplayName,
-                capabilitySummary,
-                extendedInfo,
-                id: descriptor.Id));
-        }
+        var extendedInfo = $"{descriptor.Id} v{descriptor.Version}";
+        output.Add(new OptionsPluginItem(
+            descriptor.DisplayName,
+            capabilitySummary,
+            extendedInfo,
+            id: descriptor.Id));
     }
 }

--- a/src/SkyCD.App/SkyCD.App.csproj
+++ b/src/SkyCD.App/SkyCD.App.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/SkyCD.App/SkyCD.App.csproj
+++ b/src/SkyCD.App/SkyCD.App.csproj
@@ -43,6 +43,7 @@
     <ProjectReference Include="..\SkyCD.Presentation\SkyCD.Presentation.csproj" />
     <ProjectReference Include="..\SkyCD.UI\SkyCD.UI.csproj" />
     <ProjectReference Include="..\SkyCD.Application\SkyCD.Application.csproj" />
+    <ProjectReference Include="..\SkyCD.Cli\SkyCD.Cli.csproj" />
     <ProjectReference Include="..\SkyCD.Plugin.Host\SkyCD.Plugin.Host.csproj" />
   </ItemGroup>
 </Project>

--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -8,13 +8,12 @@ using SkyCD.App.Services;
 using SkyCD.Presentation.ViewModels;
 using SkyCD.Plugin.Host;
 using SkyCD.Plugin.Host.FileFormats;
-using SkyCD.Plugin.Runtime.Discovery;
+using SkyCD.Plugin.Runtime.Loading;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -712,26 +711,14 @@ public partial class MainWindow : Window
             return;
         }
 
-        var hostVersion = new Version(3, 0, 0);
-        var discoveryService = new SkyCD.Plugin.Runtime.Discovery.PluginDiscoveryService();
-        var discoveredPlugins = new List<SkyCD.Plugin.Runtime.Discovery.DiscoveredPlugin>();
-
-        var dllPaths = Directory.GetFiles(pluginPath, "*.dll", SearchOption.AllDirectories);
-        foreach (var dllPath in dllPaths)
+        var discoveryService = new PluginDirectoryDiscoveryService();
+        var loadResult = discoveryService.Discover([pluginPath], new PluginLoadOptions
         {
-            try
-            {
-                var assembly = Assembly.LoadFrom(dllPath);
-                var plugins = discoveryService.DiscoverFromAssembly(assembly, hostVersion);
-                discoveredPlugins.AddRange(plugins);
-            }
-            catch
-            {
-                // Skip assemblies that can't be loaded
-            }
-        }
+            HostVersion = new Version(3, 0, 0),
+            EnableAssemblyIsolation = false
+        }, fallbackToAssemblyScan: true);
 
-        pluginCatalog.SetPlugins(discoveredPlugins);
+        pluginCatalog.SetPlugins(loadResult.Plugins);
     }
 
     private static string ResolveDefaultPluginPath()

--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -296,7 +296,43 @@ public partial class MainWindow : Window
             }
         }
 
-        vm.CompleteOpenCatalog();
+        var openFormats = GetDistinctRoutes(fileFormatRoutingService.GetOpenFormats());
+        var fileTypeChoices = BuildFileTypeChoices(openFormats);
+        fileTypeChoices.Add(new FilePickerFileType("All files")
+        {
+            Patterns = ["*.*"]
+        });
+
+        var files = await StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Open catalog",
+            AllowMultiple = false,
+            FileTypeFilter = fileTypeChoices
+        });
+
+        var localPath = files.FirstOrDefault()?.TryGetLocalPath();
+        if (string.IsNullOrWhiteSpace(localPath))
+        {
+            return;
+        }
+
+        try
+        {
+            var format = ResolveRouteByFileName(localPath, openFormats);
+            await using var source = File.OpenRead(localPath);
+            await fileFormatRoutingService.ReadAsync(new SkyCD.Plugin.Abstractions.Capabilities.FileFormats.FileFormatReadRequest
+            {
+                FormatId = format.FormatId,
+                Source = source,
+                FileName = Path.GetFileName(localPath)
+            });
+
+            vm.CompleteOpenCatalog();
+        }
+        catch (Exception ex)
+        {
+            vm.StatusText = $"Failed to open catalog: {ex.Message}";
+        }
     }
 
     private async void OnSaveCatalogRequested(object? sender, EventArgs e)
@@ -309,17 +345,8 @@ public partial class MainWindow : Window
         var targetPath = vm.CurrentCatalogPath;
         if (string.IsNullOrWhiteSpace(targetPath))
         {
-            var saveFormats = fileFormatRoutingService.GetSaveFormats();
-            var fileTypeChoices = new List<FilePickerFileType>();
-
-            foreach (var format in saveFormats)
-            {
-                var patterns = format.Extensions.Select(ext => $"*{ext}").ToArray();
-                fileTypeChoices.Add(new FilePickerFileType(format.DisplayName)
-                {
-                    Patterns = patterns
-                });
-            }
+            var saveFormats = GetDistinctRoutes(fileFormatRoutingService.GetSaveFormats());
+            var fileTypeChoices = BuildFileTypeChoices(saveFormats);
 
             fileTypeChoices.Add(new FilePickerFileType("All files")
             {
@@ -367,17 +394,8 @@ public partial class MainWindow : Window
             return;
         }
 
-        var saveFormats = fileFormatRoutingService.GetSaveFormats();
-        var fileTypeChoices = new List<FilePickerFileType>();
-
-        foreach (var format in saveFormats)
-        {
-            var patterns = format.Extensions.Select(ext => $"*{ext}").ToArray();
-            fileTypeChoices.Add(new FilePickerFileType(format.DisplayName)
-            {
-                Patterns = patterns
-            });
-        }
+        var saveFormats = GetDistinctRoutes(fileFormatRoutingService.GetSaveFormats());
+        var fileTypeChoices = BuildFileTypeChoices(saveFormats);
 
         fileTypeChoices.Add(new FilePickerFileType("All files")
         {
@@ -780,5 +798,54 @@ public partial class MainWindow : Window
         CultureInfo.DefaultThreadCurrentUICulture = culture;
         Thread.CurrentThread.CurrentCulture = culture;
         Thread.CurrentThread.CurrentUICulture = culture;
+    }
+
+    private static IReadOnlyList<FileFormatRoute> GetDistinctRoutes(IEnumerable<FileFormatRoute> routes)
+    {
+        return routes
+            .GroupBy(static route => route.FormatId, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.First())
+            .OrderBy(static route => route.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static List<FilePickerFileType> BuildFileTypeChoices(IEnumerable<FileFormatRoute> routes)
+    {
+        var choices = new List<FilePickerFileType>();
+        foreach (var route in routes)
+        {
+            var patterns = route.Extensions
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Select(static extension => $"*{extension}")
+                .ToArray();
+
+            choices.Add(new FilePickerFileType(route.DisplayName)
+            {
+                Patterns = patterns
+            });
+        }
+
+        return choices;
+    }
+
+    private static FileFormatRoute ResolveRouteByFileName(string path, IReadOnlyList<FileFormatRoute> routes)
+    {
+        var extension = Path.GetExtension(path);
+        if (!string.IsNullOrWhiteSpace(extension))
+        {
+            var byExtension = routes.FirstOrDefault(route =>
+                route.Extensions.Any(candidate => candidate.Equals(extension, StringComparison.OrdinalIgnoreCase)));
+            if (byExtension is not null)
+            {
+                return byExtension;
+            }
+        }
+
+        if (routes.Count > 0)
+        {
+            return routes[0];
+        }
+
+        throw new InvalidOperationException("No readable file format plugins are available.");
     }
 }

--- a/src/SkyCD.Cli/CliContributionRegistry.cs
+++ b/src/SkyCD.Cli/CliContributionRegistry.cs
@@ -1,0 +1,146 @@
+using SkyCD.Plugin.Abstractions.Capabilities.Cli;
+using SkyCD.Plugin.Runtime.Discovery;
+
+namespace SkyCD.Cli;
+
+internal sealed class CliContributionRegistry
+{
+    private static readonly StringComparer CommandComparer = StringComparer.OrdinalIgnoreCase;
+    private readonly Dictionary<string, RegisteredCliContribution> commands = new(CommandComparer);
+    private readonly Dictionary<string, List<RegisteredCliContribution>> extensions = new(CommandComparer);
+    private readonly HashSet<string> builtInCommands;
+    private readonly HashSet<string> extensionPoints;
+
+    public CliContributionRegistry(IEnumerable<string> builtInCommands, IEnumerable<string> extensionPoints)
+    {
+        this.builtInCommands = new HashSet<string>(builtInCommands.Select(NormalizePath), CommandComparer);
+        this.extensionPoints = new HashSet<string>(extensionPoints.Select(NormalizePath), CommandComparer);
+    }
+
+    public IReadOnlyList<string> Errors { get; private set; } = [];
+
+    public void Register(IEnumerable<DiscoveredPlugin> plugins)
+    {
+        var errors = new List<string>();
+
+        foreach (var plugin in plugins)
+        {
+            foreach (var capability in plugin.Capabilities.OfType<ICliPluginCapability>())
+            {
+                foreach (var contribution in capability.GetCliContributions())
+                {
+                    RegisterContribution(plugin, capability, contribution, errors);
+                }
+            }
+        }
+
+        foreach (var extension in extensions.Values)
+        {
+            extension.Sort(static (left, right) =>
+            {
+                var byPriority = right.Contribution.Priority.CompareTo(left.Contribution.Priority);
+                if (byPriority != 0)
+                {
+                    return byPriority;
+                }
+
+                return StringComparer.OrdinalIgnoreCase.Compare(left.Plugin.Plugin.Descriptor.Id, right.Plugin.Plugin.Descriptor.Id);
+            });
+        }
+
+        Errors = errors;
+    }
+
+    public IReadOnlyCollection<string> CommandPaths => commands.Keys.ToArray();
+
+    public RegisteredCliContribution? ResolveCommand(IReadOnlyList<string> args, out int consumedTokens)
+    {
+        consumedTokens = 0;
+        for (var index = args.Count; index >= 1; index--)
+        {
+            var path = NormalizePath(args.Take(index));
+            if (!commands.TryGetValue(path, out var contribution))
+            {
+                continue;
+            }
+
+            consumedTokens = index;
+            return contribution;
+        }
+
+        return null;
+    }
+
+    public IReadOnlyList<RegisteredCliContribution> ResolveExtensions(string extensionPoint)
+    {
+        return extensions.TryGetValue(NormalizePath(extensionPoint), out var contributions)
+            ? contributions
+            : [];
+    }
+
+    private void RegisterContribution(
+        DiscoveredPlugin plugin,
+        ICliPluginCapability capability,
+        CliCommandContribution contribution,
+        ICollection<string> errors)
+    {
+        if (string.IsNullOrWhiteSpace(contribution.CommandPath) || string.IsNullOrWhiteSpace(contribution.CommandId))
+        {
+            errors.Add($"Plugin '{plugin.Plugin.Descriptor.Id}' has CLI contribution with missing command path or command id.");
+            return;
+        }
+
+        var normalizedPath = NormalizePath(contribution.CommandPath);
+        var registration = new RegisteredCliContribution(plugin, capability, contribution);
+
+        if (contribution.ContributionType == CliContributionType.Extension)
+        {
+            if (!extensionPoints.Contains(normalizedPath))
+            {
+                errors.Add(
+                    $"Plugin '{plugin.Plugin.Descriptor.Id}' contributes extension '{contribution.CommandPath}' but no such extension point exists.");
+                return;
+            }
+
+            if (!extensions.TryGetValue(normalizedPath, out var list))
+            {
+                list = [];
+                extensions[normalizedPath] = list;
+            }
+
+            list.Add(registration);
+            return;
+        }
+
+        if (builtInCommands.Contains(normalizedPath))
+        {
+            errors.Add(
+                $"Plugin '{plugin.Plugin.Descriptor.Id}' cannot register command '{contribution.CommandPath}' because it is reserved by the host.");
+            return;
+        }
+
+        if (commands.TryGetValue(normalizedPath, out var existing))
+        {
+            errors.Add(
+                $"CLI command collision on '{contribution.CommandPath}' between '{existing.Plugin.Plugin.Descriptor.Id}' and '{plugin.Plugin.Descriptor.Id}'.");
+            return;
+        }
+
+        commands[normalizedPath] = registration;
+    }
+
+    private static string NormalizePath(string path)
+    {
+        return NormalizePath(path.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+    }
+
+    private static string NormalizePath(IEnumerable<string> tokens)
+    {
+        return string.Join(' ', tokens).Trim();
+    }
+}
+
+internal sealed record RegisteredCliContribution(
+    DiscoveredPlugin Plugin,
+    ICliPluginCapability Capability,
+    CliCommandContribution Contribution);

--- a/src/SkyCD.Cli/CliEntryPoint.cs
+++ b/src/SkyCD.Cli/CliEntryPoint.cs
@@ -1,0 +1,26 @@
+namespace SkyCD.Cli;
+
+public static class CliEntryPoint
+{
+    public static CliRunResult TryRun(string[] args, TextWriter? stdout = null, TextWriter? stderr = null)
+    {
+        using var cts = new CancellationTokenSource();
+        ConsoleCancelEventHandler? handler = null;
+        handler = (_, eventArgs) =>
+        {
+            eventArgs.Cancel = true;
+            cts.Cancel();
+        };
+
+        Console.CancelKeyPress += handler;
+        try
+        {
+            var host = new CliHost(stdout ?? Console.Out, stderr ?? Console.Error);
+            return host.TryRunAsync(args, cts.Token).GetAwaiter().GetResult();
+        }
+        finally
+        {
+            Console.CancelKeyPress -= handler;
+        }
+    }
+}

--- a/src/SkyCD.Cli/CliExitCodes.cs
+++ b/src/SkyCD.Cli/CliExitCodes.cs
@@ -1,0 +1,10 @@
+namespace SkyCD.Cli;
+
+public static class CliExitCodes
+{
+    public const int Success = 0;
+    public const int InvalidArguments = 2;
+    public const int CommandFailed = 3;
+    public const int ConfigurationError = 4;
+    public const int Cancelled = 130;
+}

--- a/src/SkyCD.Cli/CliHost.cs
+++ b/src/SkyCD.Cli/CliHost.cs
@@ -10,7 +10,8 @@ namespace SkyCD.Cli;
 public sealed class CliHost(
     TextWriter stdout,
     TextWriter stderr,
-    Func<Version, CancellationToken, Task<CliPluginRuntime>>? runtimeLoader = null)
+    Func<Version, CancellationToken, Task<CliPluginRuntime>>? runtimeLoader = null,
+    Func<string>? executableNameProvider = null)
 {
     private static readonly string[] BuiltInCommands =
     [
@@ -30,6 +31,7 @@ public sealed class CliHost(
     {
         WriteIndented = true
     };
+    private readonly Func<string> executableNameProvider = executableNameProvider ?? ResolveExecutableName;
     private readonly Func<Version, CancellationToken, Task<CliPluginRuntime>> runtimeLoaderFactory =
         runtimeLoader ?? CliPluginRuntime.LoadAsync;
 
@@ -497,12 +499,13 @@ public sealed class CliHost(
 
     private async Task WriteHelpAsync(IEnumerable<string> pluginCommands, bool jsonOutput)
     {
+        var executableName = executableNameProvider();
         var builtIn = new[]
         {
-            "open",
-            "convert",
-            "list-formats",
-            "plugins list"
+            new { Name = "open", Description = "Open and validate a catalog file." },
+            new { Name = "convert", Description = "Convert a catalog between supported formats." },
+            new { Name = "list-formats", Description = "List available read/write format handlers." },
+            new { Name = "plugins list", Description = "List loaded plugins, capabilities, and commands." }
         };
 
         if (jsonOutput)
@@ -510,15 +513,15 @@ public sealed class CliHost(
             await stdout.WriteLineAsync(JsonSerializer.Serialize(new
             {
                 description = "SkyCD command line interface",
-                usage = "skycd [options] [command]",
+                usage = $"{executableName} [options] [command]",
                 options = new[]
                 {
                     "--help     Display this help",
                     "--version  Display application version",
                     "--json     Use JSON output where supported"
                 },
-                builtInCommands = builtIn,
-                commandHelpHint = "Use `skycd <command> --help` for command-specific options.",
+                builtInCommands = builtIn.Select(static command => new { command.Name, command.Description }).ToArray(),
+                commandHelpHint = $"Use `{executableName} <command> --help` for command-specific options.",
                 pluginCommands = pluginCommands.OrderBy(static command => command, StringComparer.OrdinalIgnoreCase).ToArray()
             }, jsonOptions));
             return;
@@ -528,7 +531,7 @@ public sealed class CliHost(
         await stdout.WriteLineAsync("  SkyCD command line interface");
         await stdout.WriteLineAsync("");
         await stdout.WriteLineAsync("Usage:");
-        await stdout.WriteLineAsync("  skycd [options] [command]");
+        await stdout.WriteLineAsync($"  {executableName} [options] [command]");
         await stdout.WriteLineAsync("");
         await stdout.WriteLineAsync("Options:");
         await stdout.WriteLineAsync("  --help       Display this help");
@@ -538,12 +541,12 @@ public sealed class CliHost(
         await stdout.WriteLineAsync("Commands:");
         foreach (var command in builtIn)
         {
-            await stdout.WriteLineAsync($"  {command}");
+            await stdout.WriteLineAsync($"  {command.Name,-12} {command.Description}");
         }
 
         await stdout.WriteLineAsync("");
         await stdout.WriteLineAsync("Notes:");
-        await stdout.WriteLineAsync("  Use `skycd <command> --help` for command-specific options.");
+        await stdout.WriteLineAsync($"  Use `{executableName} <command> --help` for command-specific options.");
 
         var contributedCommands = pluginCommands.OrderBy(static command => command, StringComparer.OrdinalIgnoreCase).ToArray();
         if (contributedCommands.Length > 0)
@@ -560,10 +563,11 @@ public sealed class CliHost(
 
     private async Task WriteCommandHelpAsync(string command, bool jsonOutput)
     {
+        var executableName = executableNameProvider();
         var (usage, options, notes) = command switch
         {
             "open" => (
-                "skycd open <file> [--format <id>] [--json]",
+                $"{executableName} open <file> [--format <id>] [--json]",
                 new[]
                 {
                     "--format <id>  Override inferred format id",
@@ -575,7 +579,7 @@ public sealed class CliHost(
                     "open infers format from file extension by default."
                 }),
             "convert" => (
-                "skycd convert --in <file> --out <file> [--in-format <id>] [--format <id>] [--json]",
+                $"{executableName} convert --in <file> --out <file> [--in-format <id>] [--format <id>] [--json]",
                 new[]
                 {
                     "--in <file>        Input file path (required)",
@@ -590,7 +594,7 @@ public sealed class CliHost(
                     "Format ids are listed by `skycd list-formats`."
                 }),
             "list-formats" => (
-                "skycd list-formats [--json]",
+                $"{executableName} list-formats [--json]",
                 new[]
                 {
                     "--json   Use JSON output where supported",
@@ -598,7 +602,7 @@ public sealed class CliHost(
                 },
                 Array.Empty<string>()),
             "plugins list" => (
-                "skycd plugins list [--json]",
+                $"{executableName} plugins list [--json]",
                 new[]
                 {
                     "--json   Use JSON output where supported",
@@ -790,6 +794,18 @@ public sealed class CliHost(
         }
 
         return sawAny;
+    }
+
+    private static string ResolveExecutableName()
+    {
+        var arg0 = Environment.GetCommandLineArgs().FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(arg0))
+        {
+            return "skycd";
+        }
+
+        var executableName = Path.GetFileName(arg0);
+        return string.IsNullOrWhiteSpace(executableName) ? "skycd" : executableName;
     }
 
     private static string ResolveFormatId(

--- a/src/SkyCD.Cli/CliHost.cs
+++ b/src/SkyCD.Cli/CliHost.cs
@@ -57,6 +57,12 @@ public sealed class CliHost(
             return new CliRunResult { Handled = true, ExitCode = CliExitCodes.Success };
         }
 
+        if (TryGetImplicitBuiltInHelpCommand(normalized, out var implicitHelpCommand))
+        {
+            await WriteCommandHelpAsync(implicitHelpCommand, jsonOutput);
+            return new CliRunResult { Handled = true, ExitCode = CliExitCodes.Success };
+        }
+
         if (normalized.Count == 1 && IsVersionToken(normalized[0]))
         {
             await stdout.WriteLineAsync(GetVersionText());
@@ -130,7 +136,9 @@ public sealed class CliHost(
             {
                 "open" => await ExecuteOpenAsync(args, jsonOutput, routing, hostApi, registry, cancellationToken),
                 "convert" => await ExecuteConvertAsync(args, jsonOutput, routing, hostApi, registry, cancellationToken),
+                "fileformats" => await WriteBuiltInHelpAsync("fileformats", jsonOutput),
                 "fileformats list" => await ExecuteListFormatsAsync(jsonOutput, routing, pluginDirectories),
+                "plugins" => await WriteBuiltInHelpAsync("plugins", jsonOutput),
                 "plugins list" => await ExecutePluginsListAsync(jsonOutput, registry, routing, discoveredPlugins, pluginDirectories),
                 _ => CliExitCodes.InvalidArguments
             };
@@ -383,6 +391,12 @@ public sealed class CliHost(
 
         await stdout.WriteLineAsync($"Plugin directories checked: {string.Join(", ", pluginDirectories)}");
 
+        return CliExitCodes.Success;
+    }
+
+    private async Task<int> WriteBuiltInHelpAsync(string command, bool jsonOutput)
+    {
+        await WriteCommandHelpAsync(command, jsonOutput);
         return CliExitCodes.Success;
     }
 
@@ -797,6 +811,29 @@ public sealed class CliHost(
             ContainsOnlyHelpTokens(args.Skip(1)))
         {
             command = "fileformats list";
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryGetImplicitBuiltInHelpCommand(IReadOnlyList<string> args, out string command)
+    {
+        command = string.Empty;
+        if (args.Count != 1)
+        {
+            return false;
+        }
+
+        if (args[0].Equals("plugins", StringComparison.OrdinalIgnoreCase))
+        {
+            command = "plugins";
+            return true;
+        }
+
+        if (args[0].Equals("fileformats", StringComparison.OrdinalIgnoreCase))
+        {
+            command = "fileformats";
             return true;
         }
 

--- a/src/SkyCD.Cli/CliHost.cs
+++ b/src/SkyCD.Cli/CliHost.cs
@@ -49,6 +49,12 @@ public sealed class CliHost(
             return new CliRunResult { Handled = true, ExitCode = CliExitCodes.Success };
         }
 
+        if (TryGetBuiltInHelpCommand(normalized, out var helpCommand))
+        {
+            await WriteCommandHelpAsync(helpCommand, jsonOutput);
+            return new CliRunResult { Handled = true, ExitCode = CliExitCodes.Success };
+        }
+
         if (normalized.Count == 1 && IsVersionToken(normalized[0]))
         {
             await stdout.WriteLineAsync(GetVersionText());
@@ -493,10 +499,10 @@ public sealed class CliHost(
     {
         var builtIn = new[]
         {
-            "open <file> [--json]",
-            "convert --in <file> --out <file> [--in-format <id>] [--format <id>] [--json]",
-            "list-formats [--json]",
-            "plugins list [--json]"
+            "open",
+            "convert",
+            "list-formats",
+            "plugins list"
         };
 
         if (jsonOutput)
@@ -512,6 +518,7 @@ public sealed class CliHost(
                     "--json     Use JSON output where supported"
                 },
                 builtInCommands = builtIn,
+                commandHelpHint = "Use `skycd <command> --help` for command-specific options.",
                 pluginCommands = pluginCommands.OrderBy(static command => command, StringComparer.OrdinalIgnoreCase).ToArray()
             }, jsonOptions));
             return;
@@ -536,8 +543,7 @@ public sealed class CliHost(
 
         await stdout.WriteLineAsync("");
         await stdout.WriteLineAsync("Notes:");
-        await stdout.WriteLineAsync("  open infers format from file extension by default.");
-        await stdout.WriteLineAsync("  Use --format <id> to override inferred format for open/convert.");
+        await stdout.WriteLineAsync("  Use `skycd <command> --help` for command-specific options.");
 
         var contributedCommands = pluginCommands.OrderBy(static command => command, StringComparer.OrdinalIgnoreCase).ToArray();
         if (contributedCommands.Length > 0)
@@ -549,6 +555,93 @@ public sealed class CliHost(
         foreach (var pluginCommand in contributedCommands)
         {
             await stdout.WriteLineAsync($"  {pluginCommand}");
+        }
+    }
+
+    private async Task WriteCommandHelpAsync(string command, bool jsonOutput)
+    {
+        var (usage, options, notes) = command switch
+        {
+            "open" => (
+                "skycd open <file> [--format <id>] [--json]",
+                new[]
+                {
+                    "--format <id>  Override inferred format id",
+                    "--json         Use JSON output where supported",
+                    "--help         Display this help"
+                },
+                new[]
+                {
+                    "open infers format from file extension by default."
+                }),
+            "convert" => (
+                "skycd convert --in <file> --out <file> [--in-format <id>] [--format <id>] [--json]",
+                new[]
+                {
+                    "--in <file>        Input file path (required)",
+                    "--out <file>       Output file path (required)",
+                    "--in-format <id>   Override inferred input format id",
+                    "--format <id>      Override inferred output format id",
+                    "--json             Use JSON output where supported",
+                    "--help             Display this help"
+                },
+                new[]
+                {
+                    "Format ids are listed by `skycd list-formats`."
+                }),
+            "list-formats" => (
+                "skycd list-formats [--json]",
+                new[]
+                {
+                    "--json   Use JSON output where supported",
+                    "--help   Display this help"
+                },
+                Array.Empty<string>()),
+            "plugins list" => (
+                "skycd plugins list [--json]",
+                new[]
+                {
+                    "--json   Use JSON output where supported",
+                    "--help   Display this help"
+                },
+                Array.Empty<string>()),
+            _ => throw new InvalidOperationException($"Unsupported help command: {command}")
+        };
+
+        if (jsonOutput)
+        {
+            await stdout.WriteLineAsync(JsonSerializer.Serialize(new
+            {
+                command,
+                usage,
+                options,
+                notes
+            }, jsonOptions));
+            return;
+        }
+
+        await stdout.WriteLineAsync("Description:");
+        await stdout.WriteLineAsync($"  {command} command");
+        await stdout.WriteLineAsync("");
+        await stdout.WriteLineAsync("Usage:");
+        await stdout.WriteLineAsync($"  {usage}");
+        await stdout.WriteLineAsync("");
+        await stdout.WriteLineAsync("Options:");
+        foreach (var option in options)
+        {
+            await stdout.WriteLineAsync($"  {option}");
+        }
+
+        if (notes.Length == 0)
+        {
+            return;
+        }
+
+        await stdout.WriteLineAsync("");
+        await stdout.WriteLineAsync("Notes:");
+        foreach (var note in notes)
+        {
+            await stdout.WriteLineAsync($"  {note}");
         }
     }
 
@@ -604,6 +697,46 @@ public sealed class CliHost(
         return false;
     }
 
+    private static bool TryGetBuiltInHelpCommand(IReadOnlyList<string> args, out string command)
+    {
+        command = string.Empty;
+
+        if (args.Count >= 2 &&
+            args[0].Equals("open", StringComparison.OrdinalIgnoreCase) &&
+            ContainsOnlyHelpTokens(args.Skip(1)))
+        {
+            command = "open";
+            return true;
+        }
+
+        if (args.Count >= 2 &&
+            args[0].Equals("convert", StringComparison.OrdinalIgnoreCase) &&
+            ContainsOnlyHelpTokens(args.Skip(1)))
+        {
+            command = "convert";
+            return true;
+        }
+
+        if (args.Count >= 2 &&
+            args[0].Equals("list-formats", StringComparison.OrdinalIgnoreCase) &&
+            ContainsOnlyHelpTokens(args.Skip(1)))
+        {
+            command = "list-formats";
+            return true;
+        }
+
+        if (args.Count >= 3 &&
+            args[0].Equals("plugins", StringComparison.OrdinalIgnoreCase) &&
+            args[1].Equals("list", StringComparison.OrdinalIgnoreCase) &&
+            ContainsOnlyHelpTokens(args.Skip(2)))
+        {
+            command = "plugins list";
+            return true;
+        }
+
+        return false;
+    }
+
     private static (bool JsonOutput, IReadOnlyList<string> Tokens) ExtractJsonFlag(IReadOnlyList<string> args)
     {
         var json = false;
@@ -641,6 +774,22 @@ public sealed class CliHost(
     {
         return token.Equals("--version", StringComparison.OrdinalIgnoreCase)
                || token.Equals("-v", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool ContainsOnlyHelpTokens(IEnumerable<string> args)
+    {
+        var sawAny = false;
+        foreach (var token in args)
+        {
+            if (!IsHelpToken(token))
+            {
+                return false;
+            }
+
+            sawAny = true;
+        }
+
+        return sawAny;
     }
 
     private static string ResolveFormatId(

--- a/src/SkyCD.Cli/CliHost.cs
+++ b/src/SkyCD.Cli/CliHost.cs
@@ -81,7 +81,16 @@ public sealed class CliHost(
 
         if (TrySplitBuiltIn(normalized, out var builtInCommand, out var builtInArguments))
         {
-            var exitCode = await ExecuteBuiltInAsync(builtInCommand, builtInArguments, jsonOutput, routing, pluginApi, registry, cancellationToken);
+            var exitCode = await ExecuteBuiltInAsync(
+                builtInCommand,
+                builtInArguments,
+                jsonOutput,
+                routing,
+                pluginApi,
+                registry,
+                runtime.DiscoveredPlugins,
+                runtime.PluginDirectories,
+                cancellationToken);
             return new CliRunResult { Handled = true, ExitCode = exitCode };
         }
 
@@ -103,6 +112,8 @@ public sealed class CliHost(
         FileFormatRoutingService routing,
         IHostCliApi hostApi,
         CliContributionRegistry registry,
+        IReadOnlyList<SkyCD.Plugin.Runtime.Discovery.DiscoveredPlugin> discoveredPlugins,
+        IReadOnlyList<string> pluginDirectories,
         CancellationToken cancellationToken)
     {
         try
@@ -111,8 +122,8 @@ public sealed class CliHost(
             {
                 "open" => await ExecuteOpenAsync(args, jsonOutput, routing, hostApi, registry, cancellationToken),
                 "convert" => await ExecuteConvertAsync(args, jsonOutput, routing, hostApi, registry, cancellationToken),
-                "list-formats" => await ExecuteListFormatsAsync(jsonOutput, routing),
-                "plugins list" => await ExecutePluginsListAsync(jsonOutput, registry, routing),
+                "list-formats" => await ExecuteListFormatsAsync(jsonOutput, routing, pluginDirectories),
+                "plugins list" => await ExecutePluginsListAsync(jsonOutput, registry, routing, discoveredPlugins, pluginDirectories),
                 _ => CliExitCodes.InvalidArguments
             };
         }
@@ -265,7 +276,10 @@ public sealed class CliHost(
         return CliExitCodes.Success;
     }
 
-    private async Task<int> ExecuteListFormatsAsync(bool jsonOutput, FileFormatRoutingService routing)
+    private async Task<int> ExecuteListFormatsAsync(
+        bool jsonOutput,
+        FileFormatRoutingService routing,
+        IReadOnlyList<string> pluginDirectories)
     {
         var routes = routing.GetOpenFormats()
             .Concat(routing.GetSaveFormats())
@@ -283,6 +297,7 @@ public sealed class CliHost(
         if (routes.Count == 0)
         {
             await stdout.WriteLineAsync("No file format plugins were found.");
+            await stdout.WriteLineAsync($"Plugin directories checked: {string.Join(", ", pluginDirectories)}");
             return CliExitCodes.Success;
         }
 
@@ -297,15 +312,27 @@ public sealed class CliHost(
     private async Task<int> ExecutePluginsListAsync(
         bool jsonOutput,
         CliContributionRegistry registry,
-        FileFormatRoutingService routing)
+        FileFormatRoutingService routing,
+        IReadOnlyList<SkyCD.Plugin.Runtime.Discovery.DiscoveredPlugin> discoveredPlugins,
+        IReadOnlyList<string> pluginDirectories)
     {
-        var pluginInfo = routing.GetOpenFormats()
+        var formatsByPlugin = routing.GetOpenFormats()
             .Concat(routing.GetSaveFormats())
             .GroupBy(static route => route.PluginId, StringComparer.OrdinalIgnoreCase)
-            .Select(group => new
+            .ToDictionary(
+                static group => group.Key,
+                static group => group.Select(route => route.FormatId).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(static id => id).ToArray(),
+                StringComparer.OrdinalIgnoreCase);
+
+        var pluginInfo = discoveredPlugins
+            .Select(plugin => new
             {
-                PluginId = group.Key,
-                Formats = group.Select(route => route.FormatId).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(static id => id).ToArray()
+                PluginId = plugin.Plugin.Descriptor.Id,
+                DisplayName = plugin.Plugin.Descriptor.DisplayName,
+                Capabilities = plugin.Capabilities.Select(static capability => capability.GetType().Name).OrderBy(static name => name).ToArray(),
+                Formats = formatsByPlugin.TryGetValue(plugin.Plugin.Descriptor.Id, out var formats)
+                    ? formats
+                    : Array.Empty<string>()
             })
             .OrderBy(static plugin => plugin.PluginId, StringComparer.OrdinalIgnoreCase)
             .ToList();
@@ -315,7 +342,8 @@ public sealed class CliHost(
             await stdout.WriteLineAsync(JsonSerializer.Serialize(new
             {
                 plugins = pluginInfo,
-                cliCommands = registry.CommandPaths.OrderBy(static path => path, StringComparer.OrdinalIgnoreCase).ToArray()
+                cliCommands = registry.CommandPaths.OrderBy(static path => path, StringComparer.OrdinalIgnoreCase).ToArray(),
+                pluginDirectories = pluginDirectories
             }, jsonOptions));
             return CliExitCodes.Success;
         }
@@ -328,7 +356,10 @@ public sealed class CliHost(
         {
             foreach (var plugin in pluginInfo)
             {
-                await stdout.WriteLineAsync($"{plugin.PluginId}: {string.Join(", ", plugin.Formats)}");
+                var formats = plugin.Formats.Length == 0 ? "-" : string.Join(", ", plugin.Formats);
+                await stdout.WriteLineAsync($"{plugin.PluginId} ({plugin.DisplayName})");
+                await stdout.WriteLineAsync($"  capabilities: {string.Join(", ", plugin.Capabilities)}");
+                await stdout.WriteLineAsync($"  formats: {formats}");
             }
         }
 
@@ -341,6 +372,8 @@ public sealed class CliHost(
                 await stdout.WriteLineAsync($"  {path}");
             }
         }
+
+        await stdout.WriteLineAsync($"Plugin directories checked: {string.Join(", ", pluginDirectories)}");
 
         return CliExitCodes.Success;
     }
@@ -460,33 +493,62 @@ public sealed class CliHost(
     {
         var builtIn = new[]
         {
-            "skycd open <file> [--format <id>] [--json]",
-            "skycd convert --in <file> --out <file> [--in-format <id>] [--format <id>] [--json]",
-            "skycd list-formats [--json]",
-            "skycd plugins list [--json]",
-            "skycd --help",
-            "skycd --version"
+            "open <file> [--json]",
+            "convert --in <file> --out <file> [--in-format <id>] [--format <id>] [--json]",
+            "list-formats [--json]",
+            "plugins list [--json]"
         };
 
         if (jsonOutput)
         {
             await stdout.WriteLineAsync(JsonSerializer.Serialize(new
             {
+                description = "SkyCD command line interface",
+                usage = "skycd [options] [command]",
+                options = new[]
+                {
+                    "--help     Display this help",
+                    "--version  Display application version",
+                    "--json     Use JSON output where supported"
+                },
                 builtInCommands = builtIn,
                 pluginCommands = pluginCommands.OrderBy(static command => command, StringComparer.OrdinalIgnoreCase).ToArray()
             }, jsonOptions));
             return;
         }
 
-        await stdout.WriteLineAsync("SkyCD CLI commands:");
+        await stdout.WriteLineAsync("Description:");
+        await stdout.WriteLineAsync("  SkyCD command line interface");
+        await stdout.WriteLineAsync("");
+        await stdout.WriteLineAsync("Usage:");
+        await stdout.WriteLineAsync("  skycd [options] [command]");
+        await stdout.WriteLineAsync("");
+        await stdout.WriteLineAsync("Options:");
+        await stdout.WriteLineAsync("  --help       Display this help");
+        await stdout.WriteLineAsync("  --version    Display application version");
+        await stdout.WriteLineAsync("  --json       Use JSON output where supported");
+        await stdout.WriteLineAsync("");
+        await stdout.WriteLineAsync("Commands:");
         foreach (var command in builtIn)
         {
             await stdout.WriteLineAsync($"  {command}");
         }
 
-        foreach (var pluginCommand in pluginCommands.OrderBy(static command => command, StringComparer.OrdinalIgnoreCase))
+        await stdout.WriteLineAsync("");
+        await stdout.WriteLineAsync("Notes:");
+        await stdout.WriteLineAsync("  open infers format from file extension by default.");
+        await stdout.WriteLineAsync("  Use --format <id> to override inferred format for open/convert.");
+
+        var contributedCommands = pluginCommands.OrderBy(static command => command, StringComparer.OrdinalIgnoreCase).ToArray();
+        if (contributedCommands.Length > 0)
         {
-            await stdout.WriteLineAsync($"  skycd {pluginCommand}");
+            await stdout.WriteLineAsync("");
+            await stdout.WriteLineAsync("Plugin Commands:");
+        }
+
+        foreach (var pluginCommand in contributedCommands)
+        {
+            await stdout.WriteLineAsync($"  {pluginCommand}");
         }
     }
 

--- a/src/SkyCD.Cli/CliHost.cs
+++ b/src/SkyCD.Cli/CliHost.cs
@@ -1,0 +1,638 @@
+using System.Reflection;
+using System.Text.Json;
+using SkyCD.Plugin.Abstractions.Capabilities.Cli;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Host;
+using SkyCD.Plugin.Host.FileFormats;
+
+namespace SkyCD.Cli;
+
+public sealed class CliHost(
+    TextWriter stdout,
+    TextWriter stderr,
+    Func<Version, CancellationToken, Task<CliPluginRuntime>>? runtimeLoader = null)
+{
+    private static readonly string[] BuiltInCommands =
+    [
+        "open",
+        "convert",
+        "list-formats",
+        "plugins list"
+    ];
+
+    private static readonly string[] ExtensionPoints =
+    [
+        "open",
+        "convert"
+    ];
+
+    private readonly JsonSerializerOptions jsonOptions = new()
+    {
+        WriteIndented = true
+    };
+    private readonly Func<Version, CancellationToken, Task<CliPluginRuntime>> runtimeLoaderFactory =
+        runtimeLoader ?? CliPluginRuntime.LoadAsync;
+
+    public async Task<CliRunResult> TryRunAsync(string[] args, CancellationToken cancellationToken = default)
+    {
+        if (args.Length == 0)
+        {
+            return new CliRunResult { Handled = false, ExitCode = CliExitCodes.Success };
+        }
+
+        var (jsonOutput, commandTokens) = ExtractJsonFlag(args);
+        var normalized = Normalize(commandTokens);
+
+        if (normalized.Count == 1 && IsHelpToken(normalized[0]))
+        {
+            await WriteHelpAsync(Array.Empty<string>(), jsonOutput);
+            return new CliRunResult { Handled = true, ExitCode = CliExitCodes.Success };
+        }
+
+        if (normalized.Count == 1 && IsVersionToken(normalized[0]))
+        {
+            await stdout.WriteLineAsync(GetVersionText());
+            return new CliRunResult { Handled = true, ExitCode = CliExitCodes.Success };
+        }
+
+        await using var runtime = await runtimeLoaderFactory(new Version(3, 0, 0), cancellationToken);
+
+        foreach (var diagnostic in runtime.Diagnostics.Where(static entry => entry.StartsWith("info:", StringComparison.OrdinalIgnoreCase)))
+        {
+            await stderr.WriteLineAsync(diagnostic);
+        }
+
+        var catalog = new PluginCatalog();
+        catalog.SetPlugins(runtime.DiscoveredPlugins);
+        var routing = new FileFormatRoutingService(catalog);
+        var pluginApi = new CliHostPluginApi(routing);
+        var registry = new CliContributionRegistry(BuiltInCommands, ExtensionPoints);
+        registry.Register(runtime.DiscoveredPlugins);
+
+        if (registry.Errors.Count > 0)
+        {
+            foreach (var error in registry.Errors)
+            {
+                await stderr.WriteLineAsync(error);
+            }
+
+            return new CliRunResult { Handled = true, ExitCode = CliExitCodes.ConfigurationError };
+        }
+
+        if (TrySplitBuiltIn(normalized, out var builtInCommand, out var builtInArguments))
+        {
+            var exitCode = await ExecuteBuiltInAsync(builtInCommand, builtInArguments, jsonOutput, routing, pluginApi, registry, cancellationToken);
+            return new CliRunResult { Handled = true, ExitCode = exitCode };
+        }
+
+        var pluginCommand = registry.ResolveCommand(normalized, out var consumedTokens);
+        if (pluginCommand is not null)
+        {
+            var pluginArgs = normalized.Skip(consumedTokens).ToArray();
+            var exitCode = await ExecutePluginCommandAsync(pluginCommand, pluginArgs, jsonOutput, pluginApi, cancellationToken);
+            return new CliRunResult { Handled = true, ExitCode = exitCode };
+        }
+
+        return new CliRunResult { Handled = false, ExitCode = CliExitCodes.Success };
+    }
+
+    private async Task<int> ExecuteBuiltInAsync(
+        string command,
+        IReadOnlyList<string> args,
+        bool jsonOutput,
+        FileFormatRoutingService routing,
+        IHostCliApi hostApi,
+        CliContributionRegistry registry,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return command switch
+            {
+                "open" => await ExecuteOpenAsync(args, jsonOutput, routing, hostApi, registry, cancellationToken),
+                "convert" => await ExecuteConvertAsync(args, jsonOutput, routing, hostApi, registry, cancellationToken),
+                "list-formats" => await ExecuteListFormatsAsync(jsonOutput, routing),
+                "plugins list" => await ExecutePluginsListAsync(jsonOutput, registry, routing),
+                _ => CliExitCodes.InvalidArguments
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            await stderr.WriteLineAsync("Operation cancelled.");
+            return CliExitCodes.Cancelled;
+        }
+        catch (Exception exception)
+        {
+            await stderr.WriteLineAsync($"Command failed: {exception.Message}");
+            return CliExitCodes.CommandFailed;
+        }
+    }
+
+    private async Task<int> ExecuteOpenAsync(
+        IReadOnlyList<string> args,
+        bool jsonOutput,
+        FileFormatRoutingService routing,
+        IHostCliApi hostApi,
+        CliContributionRegistry registry,
+        CancellationToken cancellationToken)
+    {
+        var file = args.FirstOrDefault(static token => !token.StartsWith("--", StringComparison.Ordinal));
+        var formatId = ReadOption(args, "--format");
+
+        if (string.IsNullOrWhiteSpace(file))
+        {
+            await stderr.WriteLineAsync("Missing required argument: <file>");
+            return CliExitCodes.InvalidArguments;
+        }
+
+        var fullPath = Path.GetFullPath(file);
+        if (!File.Exists(fullPath))
+        {
+            await stderr.WriteLineAsync($"File not found: {fullPath}");
+            return CliExitCodes.InvalidArguments;
+        }
+
+        var resolvedFormat = ResolveFormatId(formatId, fullPath, routing.GetOpenFormats(), "read");
+        await using var source = File.OpenRead(fullPath);
+        var readResult = await routing.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = resolvedFormat,
+            Source = source,
+            FileName = Path.GetFileName(fullPath)
+        }, cancellationToken);
+
+        var extensionResult = await ExecuteExtensionsAsync("open", args, jsonOutput, readResult.Payload, hostApi, registry, cancellationToken);
+        if (!extensionResult.Success)
+        {
+            await stderr.WriteLineAsync(extensionResult.Error ?? "Plugin extension failed.");
+            return CliExitCodes.CommandFailed;
+        }
+
+        if (jsonOutput)
+        {
+            await stdout.WriteLineAsync(JsonSerializer.Serialize(new
+            {
+                success = true,
+                command = "open",
+                file = fullPath,
+                formatId = resolvedFormat
+            }, jsonOptions));
+        }
+        else
+        {
+            await stdout.WriteLineAsync($"Opened '{fullPath}' as {resolvedFormat}.");
+        }
+
+        return CliExitCodes.Success;
+    }
+
+    private async Task<int> ExecuteConvertAsync(
+        IReadOnlyList<string> args,
+        bool jsonOutput,
+        FileFormatRoutingService routing,
+        IHostCliApi hostApi,
+        CliContributionRegistry registry,
+        CancellationToken cancellationToken)
+    {
+        var inputPath = ReadOption(args, "--in");
+        var outputPath = ReadOption(args, "--out");
+        var inputFormat = ReadOption(args, "--in-format");
+        var outputFormat = ReadOption(args, "--format");
+
+        if (string.IsNullOrWhiteSpace(inputPath) || string.IsNullOrWhiteSpace(outputPath))
+        {
+            await stderr.WriteLineAsync("Missing required options: --in <file> --out <file>");
+            return CliExitCodes.InvalidArguments;
+        }
+
+        var fullInputPath = Path.GetFullPath(inputPath);
+        var fullOutputPath = Path.GetFullPath(outputPath);
+
+        if (!File.Exists(fullInputPath))
+        {
+            await stderr.WriteLineAsync($"Input file not found: {fullInputPath}");
+            return CliExitCodes.InvalidArguments;
+        }
+
+        var resolvedInputFormat = ResolveFormatId(inputFormat, fullInputPath, routing.GetOpenFormats(), "read");
+        var resolvedOutputFormat = ResolveFormatId(outputFormat, fullOutputPath, routing.GetSaveFormats(), "write");
+
+        await using var source = File.OpenRead(fullInputPath);
+        var readResult = await routing.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = resolvedInputFormat,
+            Source = source,
+            FileName = Path.GetFileName(fullInputPath)
+        }, cancellationToken);
+
+        var extensionResult = await ExecuteExtensionsAsync("convert", args, jsonOutput, readResult.Payload, hostApi, registry, cancellationToken);
+        if (!extensionResult.Success)
+        {
+            await stderr.WriteLineAsync(extensionResult.Error ?? "Plugin extension failed.");
+            return CliExitCodes.CommandFailed;
+        }
+
+        var payload = extensionResult.Payload ?? readResult.Payload
+            ?? throw new InvalidOperationException("Source format returned empty payload.");
+        Directory.CreateDirectory(Path.GetDirectoryName(fullOutputPath) ?? Directory.GetCurrentDirectory());
+
+        await using var target = File.Create(fullOutputPath);
+        await routing.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = resolvedOutputFormat,
+            Target = target,
+            FileName = Path.GetFileName(fullOutputPath),
+            Payload = payload
+        }, cancellationToken);
+
+        if (jsonOutput)
+        {
+            await stdout.WriteLineAsync(JsonSerializer.Serialize(new
+            {
+                success = true,
+                command = "convert",
+                inputPath = fullInputPath,
+                outputPath = fullOutputPath,
+                inputFormatId = resolvedInputFormat,
+                outputFormatId = resolvedOutputFormat
+            }, jsonOptions));
+        }
+        else
+        {
+            await stdout.WriteLineAsync($"Converted '{fullInputPath}' ({resolvedInputFormat}) -> '{fullOutputPath}' ({resolvedOutputFormat}).");
+        }
+
+        return CliExitCodes.Success;
+    }
+
+    private async Task<int> ExecuteListFormatsAsync(bool jsonOutput, FileFormatRoutingService routing)
+    {
+        var routes = routing.GetOpenFormats()
+            .Concat(routing.GetSaveFormats())
+            .GroupBy(static route => route.FormatId, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.First())
+            .OrderBy(static route => route.DisplayName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (jsonOutput)
+        {
+            await stdout.WriteLineAsync(JsonSerializer.Serialize(routes, jsonOptions));
+            return CliExitCodes.Success;
+        }
+
+        if (routes.Count == 0)
+        {
+            await stdout.WriteLineAsync("No file format plugins were found.");
+            return CliExitCodes.Success;
+        }
+
+        foreach (var route in routes)
+        {
+            await stdout.WriteLineAsync($"{route.FormatId,-16} {route.DisplayName} [{string.Join(", ", route.Extensions)}]");
+        }
+
+        return CliExitCodes.Success;
+    }
+
+    private async Task<int> ExecutePluginsListAsync(
+        bool jsonOutput,
+        CliContributionRegistry registry,
+        FileFormatRoutingService routing)
+    {
+        var pluginInfo = routing.GetOpenFormats()
+            .Concat(routing.GetSaveFormats())
+            .GroupBy(static route => route.PluginId, StringComparer.OrdinalIgnoreCase)
+            .Select(group => new
+            {
+                PluginId = group.Key,
+                Formats = group.Select(route => route.FormatId).Distinct(StringComparer.OrdinalIgnoreCase).OrderBy(static id => id).ToArray()
+            })
+            .OrderBy(static plugin => plugin.PluginId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (jsonOutput)
+        {
+            await stdout.WriteLineAsync(JsonSerializer.Serialize(new
+            {
+                plugins = pluginInfo,
+                cliCommands = registry.CommandPaths.OrderBy(static path => path, StringComparer.OrdinalIgnoreCase).ToArray()
+            }, jsonOptions));
+            return CliExitCodes.Success;
+        }
+
+        if (pluginInfo.Count == 0)
+        {
+            await stdout.WriteLineAsync("No plugins loaded.");
+        }
+        else
+        {
+            foreach (var plugin in pluginInfo)
+            {
+                await stdout.WriteLineAsync($"{plugin.PluginId}: {string.Join(", ", plugin.Formats)}");
+            }
+        }
+
+        var pluginCommands = registry.CommandPaths.OrderBy(static path => path, StringComparer.OrdinalIgnoreCase).ToArray();
+        if (pluginCommands.Length > 0)
+        {
+            await stdout.WriteLineAsync("Plugin CLI commands:");
+            foreach (var path in pluginCommands)
+            {
+                await stdout.WriteLineAsync($"  {path}");
+            }
+        }
+
+        return CliExitCodes.Success;
+    }
+
+    private async Task<int> ExecutePluginCommandAsync(
+        RegisteredCliContribution command,
+        IReadOnlyList<string> pluginArgs,
+        bool jsonOutput,
+        IHostCliApi hostApi,
+        CancellationToken cancellationToken)
+    {
+        var result = await ExecuteWithTimeoutAsync(
+            token => command.Capability.ExecuteCliCommandAsync(new CliCommandContext
+            {
+                CommandPath = command.Contribution.CommandPath,
+                CommandId = command.Contribution.CommandId,
+                Arguments = pluginArgs,
+                JsonOutput = jsonOutput,
+                HostApi = hostApi
+            }, token),
+            cancellationToken);
+
+        if (!result.Success)
+        {
+            await stderr.WriteLineAsync(result.Error ?? "Plugin command failed.");
+            return CliExitCodes.CommandFailed;
+        }
+
+        if (!string.IsNullOrWhiteSpace(result.Output))
+        {
+            await stdout.WriteLineAsync(result.Output);
+        }
+        else if (jsonOutput)
+        {
+            await stdout.WriteLineAsync(JsonSerializer.Serialize(new
+            {
+                success = true,
+                command = command.Contribution.CommandPath
+            }, jsonOptions));
+        }
+
+        return CliExitCodes.Success;
+    }
+
+    private async Task<CliCommandResult> ExecuteExtensionsAsync(
+        string extensionPoint,
+        IReadOnlyList<string> args,
+        bool jsonOutput,
+        object? payload,
+        IHostCliApi hostApi,
+        CliContributionRegistry registry,
+        CancellationToken cancellationToken)
+    {
+        var currentPayload = payload;
+        foreach (var extension in registry.ResolveExtensions(extensionPoint))
+        {
+            var result = await ExecuteWithTimeoutAsync(
+                token => extension.Capability.ExecuteCliCommandAsync(new CliCommandContext
+                {
+                    CommandPath = extension.Contribution.CommandPath,
+                    CommandId = extension.Contribution.CommandId,
+                    Arguments = args,
+                    JsonOutput = jsonOutput,
+                    Payload = currentPayload,
+                    HostApi = hostApi
+                }, token),
+                cancellationToken);
+
+            if (!result.Success)
+            {
+                return result;
+            }
+
+            if (result.Payload is not null)
+            {
+                currentPayload = result.Payload;
+            }
+        }
+
+        return new CliCommandResult
+        {
+            Success = true,
+            Payload = currentPayload
+        };
+    }
+
+    private static async Task<CliCommandResult> ExecuteWithTimeoutAsync(
+        Func<CancellationToken, Task<CliCommandResult>> executor,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(TimeSpan.FromSeconds(5));
+
+        try
+        {
+            return await executor(timeoutCts.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return new CliCommandResult
+            {
+                Success = false,
+                Error = "Plugin CLI handler timed out after 5 seconds."
+            };
+        }
+        catch (Exception exception)
+        {
+            return new CliCommandResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    private async Task WriteHelpAsync(IEnumerable<string> pluginCommands, bool jsonOutput)
+    {
+        var builtIn = new[]
+        {
+            "skycd open <file> [--format <id>] [--json]",
+            "skycd convert --in <file> --out <file> [--in-format <id>] [--format <id>] [--json]",
+            "skycd list-formats [--json]",
+            "skycd plugins list [--json]",
+            "skycd --help",
+            "skycd --version"
+        };
+
+        if (jsonOutput)
+        {
+            await stdout.WriteLineAsync(JsonSerializer.Serialize(new
+            {
+                builtInCommands = builtIn,
+                pluginCommands = pluginCommands.OrderBy(static command => command, StringComparer.OrdinalIgnoreCase).ToArray()
+            }, jsonOptions));
+            return;
+        }
+
+        await stdout.WriteLineAsync("SkyCD CLI commands:");
+        foreach (var command in builtIn)
+        {
+            await stdout.WriteLineAsync($"  {command}");
+        }
+
+        foreach (var pluginCommand in pluginCommands.OrderBy(static command => command, StringComparer.OrdinalIgnoreCase))
+        {
+            await stdout.WriteLineAsync($"  skycd {pluginCommand}");
+        }
+    }
+
+    private static bool TrySplitBuiltIn(
+        IReadOnlyList<string> args,
+        out string command,
+        out IReadOnlyList<string> remaining)
+    {
+        command = string.Empty;
+        remaining = [];
+
+        if (args.Count == 1 && IsHelpToken(args[0]))
+        {
+            command = "help";
+            return true;
+        }
+
+        if (args.Count == 1 && IsVersionToken(args[0]))
+        {
+            command = "version";
+            return true;
+        }
+
+        if (args.Count > 0 && args[0].Equals("open", StringComparison.OrdinalIgnoreCase))
+        {
+            command = "open";
+            remaining = args.Skip(1).ToArray();
+            return true;
+        }
+
+        if (args.Count > 0 && args[0].Equals("convert", StringComparison.OrdinalIgnoreCase))
+        {
+            command = "convert";
+            remaining = args.Skip(1).ToArray();
+            return true;
+        }
+
+        if (args.Count == 1 && args[0].Equals("list-formats", StringComparison.OrdinalIgnoreCase))
+        {
+            command = "list-formats";
+            return true;
+        }
+
+        if (args.Count >= 2 &&
+            args[0].Equals("plugins", StringComparison.OrdinalIgnoreCase) &&
+            args[1].Equals("list", StringComparison.OrdinalIgnoreCase))
+        {
+            command = "plugins list";
+            remaining = args.Skip(2).ToArray();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static (bool JsonOutput, IReadOnlyList<string> Tokens) ExtractJsonFlag(IReadOnlyList<string> args)
+    {
+        var json = false;
+        var tokens = new List<string>(args.Count);
+
+        foreach (var token in args)
+        {
+            if (token.Equals("--json", StringComparison.OrdinalIgnoreCase))
+            {
+                json = true;
+                continue;
+            }
+
+            tokens.Add(token);
+        }
+
+        return (json, tokens);
+    }
+
+    private static IReadOnlyList<string> Normalize(IReadOnlyList<string> args)
+    {
+        return args
+            .Where(static token => !string.IsNullOrWhiteSpace(token))
+            .Select(static token => token.Trim())
+            .ToArray();
+    }
+
+    private static bool IsHelpToken(string token)
+    {
+        return token.Equals("--help", StringComparison.OrdinalIgnoreCase)
+               || token.Equals("-h", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsVersionToken(string token)
+    {
+        return token.Equals("--version", StringComparison.OrdinalIgnoreCase)
+               || token.Equals("-v", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ResolveFormatId(
+        string? explicitFormatId,
+        string path,
+        IReadOnlyList<FileFormatRoute> routes,
+        string operation)
+    {
+        if (!string.IsNullOrWhiteSpace(explicitFormatId))
+        {
+            if (routes.Any(route => route.FormatId.Equals(explicitFormatId, StringComparison.OrdinalIgnoreCase)))
+            {
+                return explicitFormatId;
+            }
+
+            throw new InvalidOperationException($"Format '{explicitFormatId}' does not support {operation}.");
+        }
+
+        var extension = Path.GetExtension(path);
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            throw new InvalidOperationException($"Unable to infer format for '{path}'. Provide --format explicitly.");
+        }
+
+        var byExtension = routes.FirstOrDefault(route =>
+            route.Extensions.Any(candidate => candidate.Equals(extension, StringComparison.OrdinalIgnoreCase)));
+        if (byExtension is null)
+        {
+            throw new InvalidOperationException($"No format handler registered for '{extension}' ({operation}).");
+        }
+
+        return byExtension.FormatId;
+    }
+
+    private static string? ReadOption(IReadOnlyList<string> args, string name)
+    {
+        for (var index = 0; index < args.Count - 1; index++)
+        {
+            if (!args[index].Equals(name, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            return args[index + 1];
+        }
+
+        return null;
+    }
+
+    private static string GetVersionText()
+    {
+        var version = typeof(CliHost).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                      ?? typeof(CliHost).Assembly.GetName().Version?.ToString()
+                      ?? "unknown";
+        return $"SkyCD {version}";
+    }
+}

--- a/src/SkyCD.Cli/CliHost.cs
+++ b/src/SkyCD.Cli/CliHost.cs
@@ -17,7 +17,7 @@ public sealed class CliHost(
     [
         "open",
         "convert",
-        "list-formats",
+        "fileformats list",
         "plugins list"
     ];
 
@@ -130,7 +130,7 @@ public sealed class CliHost(
             {
                 "open" => await ExecuteOpenAsync(args, jsonOutput, routing, hostApi, registry, cancellationToken),
                 "convert" => await ExecuteConvertAsync(args, jsonOutput, routing, hostApi, registry, cancellationToken),
-                "list-formats" => await ExecuteListFormatsAsync(jsonOutput, routing, pluginDirectories),
+                "fileformats list" => await ExecuteListFormatsAsync(jsonOutput, routing, pluginDirectories),
                 "plugins list" => await ExecutePluginsListAsync(jsonOutput, registry, routing, discoveredPlugins, pluginDirectories),
                 _ => CliExitCodes.InvalidArguments
             };
@@ -499,13 +499,13 @@ public sealed class CliHost(
 
     private async Task WriteHelpAsync(IEnumerable<string> pluginCommands, bool jsonOutput)
     {
-        var executableName = executableNameProvider();
+        var executableName = NormalizeExecutableName(executableNameProvider());
         var builtIn = new[]
         {
             new { Name = "open", Description = "Open and validate a catalog file." },
             new { Name = "convert", Description = "Convert a catalog between supported formats." },
-            new { Name = "list-formats", Description = "List available read/write format handlers." },
-            new { Name = "plugins list", Description = "List loaded plugins, capabilities, and commands." }
+            new { Name = "fileformats", Description = "Work with file format handlers." },
+            new { Name = "plugins", Description = "Inspect loaded plugins and capabilities." }
         };
 
         if (jsonOutput)
@@ -563,7 +563,7 @@ public sealed class CliHost(
 
     private async Task WriteCommandHelpAsync(string command, bool jsonOutput)
     {
-        var executableName = executableNameProvider();
+        var executableName = NormalizeExecutableName(executableNameProvider());
         var (usage, options, notes) = command switch
         {
             "open" => (
@@ -591,13 +591,29 @@ public sealed class CliHost(
                 },
                 new[]
                 {
-                    "Format ids are listed by `skycd list-formats`."
+                    $"Format ids are listed by `{executableName} fileformats list`."
                 }),
-            "list-formats" => (
-                $"{executableName} list-formats [--json]",
+            "fileformats" => (
+                $"{executableName} fileformats <subcommand> [options]",
+                new[]
+                {
+                    "list     List available read/write format handlers",
+                    "--help   Display this help"
+                },
+                Array.Empty<string>()),
+            "fileformats list" => (
+                $"{executableName} fileformats list [--json]",
                 new[]
                 {
                     "--json   Use JSON output where supported",
+                    "--help   Display this help"
+                },
+                Array.Empty<string>()),
+            "plugins" => (
+                $"{executableName} plugins <subcommand> [options]",
+                new[]
+                {
+                    "list     List loaded plugins, capabilities, and commands",
                     "--help   Display this help"
                 },
                 Array.Empty<string>()),
@@ -683,9 +699,9 @@ public sealed class CliHost(
             return true;
         }
 
-        if (args.Count == 1 && args[0].Equals("list-formats", StringComparison.OrdinalIgnoreCase))
+        if (args.Count == 1 && args[0].Equals("plugins", StringComparison.OrdinalIgnoreCase))
         {
-            command = "list-formats";
+            command = "plugins";
             return true;
         }
 
@@ -695,6 +711,27 @@ public sealed class CliHost(
         {
             command = "plugins list";
             remaining = args.Skip(2).ToArray();
+            return true;
+        }
+
+        if (args.Count == 1 && args[0].Equals("fileformats", StringComparison.OrdinalIgnoreCase))
+        {
+            command = "fileformats";
+            return true;
+        }
+
+        if (args.Count >= 2 &&
+            args[0].Equals("fileformats", StringComparison.OrdinalIgnoreCase) &&
+            args[1].Equals("list", StringComparison.OrdinalIgnoreCase))
+        {
+            command = "fileformats list";
+            remaining = args.Skip(2).ToArray();
+            return true;
+        }
+
+        if (args.Count == 1 && args[0].Equals("list-formats", StringComparison.OrdinalIgnoreCase))
+        {
+            command = "fileformats list";
             return true;
         }
 
@@ -722,10 +759,10 @@ public sealed class CliHost(
         }
 
         if (args.Count >= 2 &&
-            args[0].Equals("list-formats", StringComparison.OrdinalIgnoreCase) &&
+            args[0].Equals("plugins", StringComparison.OrdinalIgnoreCase) &&
             ContainsOnlyHelpTokens(args.Skip(1)))
         {
-            command = "list-formats";
+            command = "plugins";
             return true;
         }
 
@@ -735,6 +772,31 @@ public sealed class CliHost(
             ContainsOnlyHelpTokens(args.Skip(2)))
         {
             command = "plugins list";
+            return true;
+        }
+
+        if (args.Count >= 2 &&
+            args[0].Equals("fileformats", StringComparison.OrdinalIgnoreCase) &&
+            ContainsOnlyHelpTokens(args.Skip(1)))
+        {
+            command = "fileformats";
+            return true;
+        }
+
+        if (args.Count >= 3 &&
+            args[0].Equals("fileformats", StringComparison.OrdinalIgnoreCase) &&
+            args[1].Equals("list", StringComparison.OrdinalIgnoreCase) &&
+            ContainsOnlyHelpTokens(args.Skip(2)))
+        {
+            command = "fileformats list";
+            return true;
+        }
+
+        if (args.Count >= 2 &&
+            args[0].Equals("list-formats", StringComparison.OrdinalIgnoreCase) &&
+            ContainsOnlyHelpTokens(args.Skip(1)))
+        {
+            command = "fileformats list";
             return true;
         }
 
@@ -799,13 +861,36 @@ public sealed class CliHost(
     private static string ResolveExecutableName()
     {
         var arg0 = Environment.GetCommandLineArgs().FirstOrDefault();
-        if (string.IsNullOrWhiteSpace(arg0))
+        return NormalizeExecutableName(arg0);
+    }
+
+    private static string NormalizeExecutableName(string? executableNameCandidate)
+    {
+        if (string.IsNullOrWhiteSpace(executableNameCandidate))
         {
             return "skycd";
         }
 
-        var executableName = Path.GetFileName(arg0);
-        return string.IsNullOrWhiteSpace(executableName) ? "skycd" : executableName;
+        var executableName = Path.GetFileName(executableNameCandidate);
+        if (string.IsNullOrWhiteSpace(executableName))
+        {
+            return "skycd";
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            if (executableName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+            {
+                return Path.ChangeExtension(executableName, ".exe");
+            }
+
+            if (!Path.HasExtension(executableName))
+            {
+                return $"{executableName}.exe";
+            }
+        }
+
+        return executableName;
     }
 
     private static string ResolveFormatId(

--- a/src/SkyCD.Cli/CliHostPluginApi.cs
+++ b/src/SkyCD.Cli/CliHostPluginApi.cs
@@ -1,0 +1,44 @@
+using SkyCD.Plugin.Abstractions.Capabilities.Cli;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Host.FileFormats;
+
+namespace SkyCD.Cli;
+
+internal sealed class CliHostPluginApi(FileFormatRoutingService fileFormatRoutingService) : IHostCliApi
+{
+    public IReadOnlyList<FileFormatDescriptor> GetReadableFormats()
+    {
+        return fileFormatRoutingService.GetOpenFormats()
+            .Select(route => new FileFormatDescriptor(
+                route.FormatId,
+                route.DisplayName,
+                route.Extensions,
+                route.CanRead,
+                route.CanWrite,
+                route.MimeType))
+            .ToList();
+    }
+
+    public IReadOnlyList<FileFormatDescriptor> GetWritableFormats()
+    {
+        return fileFormatRoutingService.GetSaveFormats()
+            .Select(route => new FileFormatDescriptor(
+                route.FormatId,
+                route.DisplayName,
+                route.Extensions,
+                route.CanRead,
+                route.CanWrite,
+                route.MimeType))
+            .ToList();
+    }
+
+    public Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+    {
+        return fileFormatRoutingService.ReadAsync(request, cancellationToken);
+    }
+
+    public Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+    {
+        return fileFormatRoutingService.WriteAsync(request, cancellationToken);
+    }
+}

--- a/src/SkyCD.Cli/CliPluginRuntime.cs
+++ b/src/SkyCD.Cli/CliPluginRuntime.cs
@@ -1,6 +1,7 @@
 using SkyCD.Plugin.Abstractions.Lifecycle;
 using SkyCD.Plugin.Runtime.Discovery;
 using SkyCD.Plugin.Runtime.Loading;
+using System.Text.Json;
 
 namespace SkyCD.Cli;
 
@@ -60,9 +61,27 @@ public sealed class CliPluginRuntime : IAsyncDisposable
 
     private static IReadOnlyList<string> GetPluginDirectories()
     {
+        var configured = Environment.GetEnvironmentVariable("SKYCD_PLUGIN_PATH");
+        var fromAppSettings = TryReadPluginPathFromAppSettings();
+        return BuildPluginDirectories(configured, fromAppSettings);
+    }
+
+    internal static IReadOnlyList<string> BuildPluginDirectories(string? configuredPluginPaths, string? appSettingsPluginPath)
+    {
         var candidates = new List<string>();
-        AddConfiguredPluginDirectories(candidates);
-        AddLocalPluginDirectories(candidates);
+
+        if (!string.IsNullOrWhiteSpace(configuredPluginPaths))
+        {
+            foreach (var segment in configuredPluginPaths.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                candidates.Add(Path.GetFullPath(segment));
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(appSettingsPluginPath))
+        {
+            candidates.Add(Path.GetFullPath(appSettingsPluginPath));
+        }
 
         return candidates
             .Where(directory => !string.IsNullOrWhiteSpace(directory))
@@ -70,33 +89,34 @@ public sealed class CliPluginRuntime : IAsyncDisposable
             .ToArray();
     }
 
-    private static void AddConfiguredPluginDirectories(ICollection<string> candidates)
+    internal static string? TryReadPluginPathFromAppSettings(string? appDataRoot = null)
     {
-        var configured = Environment.GetEnvironmentVariable("SKYCD_PLUGIN_PATH");
-        if (string.IsNullOrWhiteSpace(configured))
+        var root = appDataRoot ?? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        if (string.IsNullOrWhiteSpace(root))
         {
-            return;
+            return null;
         }
 
-        foreach (var segment in configured.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        var optionsPath = Path.Combine(root, "SkyCD", "options.json");
+        if (!File.Exists(optionsPath))
         {
-            candidates.Add(Path.GetFullPath(segment));
+            return null;
         }
-    }
 
-    private static void AddLocalPluginDirectories(ICollection<string> candidates)
-    {
-        candidates.Add(Path.Combine(AppContext.BaseDirectory, "Plugins"));
-        candidates.Add(Path.Combine(AppContext.BaseDirectory, "Plugins", "samples"));
-        candidates.Add(Path.Combine(Directory.GetCurrentDirectory(), "Plugins"));
-        candidates.Add(Path.Combine(Directory.GetCurrentDirectory(), "Plugins", "samples"));
-
-        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
-        for (var depth = 0; depth < 8 && current is not null; depth++)
+        try
         {
-            candidates.Add(Path.Combine(current.FullName, "Plugins"));
-            candidates.Add(Path.Combine(current.FullName, "Plugins", "samples"));
-            current = current.Parent;
+            using var document = JsonDocument.Parse(File.ReadAllText(optionsPath));
+            if (!document.RootElement.TryGetProperty("PluginPath", out var pluginPathElement))
+            {
+                return null;
+            }
+
+            var pluginPath = pluginPathElement.GetString();
+            return string.IsNullOrWhiteSpace(pluginPath) ? null : pluginPath.Trim();
+        }
+        catch
+        {
+            return null;
         }
     }
 }

--- a/src/SkyCD.Cli/CliPluginRuntime.cs
+++ b/src/SkyCD.Cli/CliPluginRuntime.cs
@@ -1,7 +1,6 @@
 using SkyCD.Plugin.Abstractions.Lifecycle;
 using SkyCD.Plugin.Runtime.Discovery;
 using SkyCD.Plugin.Runtime.Loading;
-using System.Reflection;
 
 namespace SkyCD.Cli;
 
@@ -18,28 +17,19 @@ public sealed class CliPluginRuntime : IAsyncDisposable
     public static async Task<CliPluginRuntime> LoadAsync(Version hostVersion, CancellationToken cancellationToken = default)
     {
         var pluginDirectories = GetPluginDirectories();
-        var loader = new PluginDirectoryLoader();
-        var loadResult = loader.LoadFromDirectories(pluginDirectories, new PluginLoadOptions
+        var discoveryService = new PluginDirectoryDiscoveryService();
+        var loadResult = discoveryService.Discover(pluginDirectories, new PluginLoadOptions
         {
             HostVersion = hostVersion,
             EnableAssemblyIsolation = false
-        });
-
-        var discoveredPlugins = loadResult.Plugins.ToList();
-        var diagnostics = loadResult.Diagnostics
-            .Select(diagnostic => $"{(diagnostic.IsError ? "error" : "info")}: {diagnostic.PluginId}: {diagnostic.Message}")
-            .ToList();
-
-        if (discoveredPlugins.Count == 0)
-        {
-            diagnostics.Add("info: <fallback>: No manifest-based plugins loaded. Falling back to assembly scan.");
-            discoveredPlugins.AddRange(DiscoverFromAssemblies(pluginDirectories, hostVersion, diagnostics));
-        }
+        }, fallbackToAssemblyScan: true);
 
         var runtime = new CliPluginRuntime
         {
-            DiscoveredPlugins = discoveredPlugins,
-            Diagnostics = diagnostics,
+            DiscoveredPlugins = loadResult.Plugins.ToList(),
+            Diagnostics = loadResult.Diagnostics
+                .Select(diagnostic => $"{(diagnostic.IsError ? "error" : "info")}: {diagnostic.PluginId}: {diagnostic.Message}")
+                .ToList(),
             PluginDirectories = pluginDirectories
         };
 
@@ -108,42 +98,5 @@ public sealed class CliPluginRuntime : IAsyncDisposable
             candidates.Add(Path.Combine(current.FullName, "Plugins", "samples"));
             current = current.Parent;
         }
-    }
-
-    private static IReadOnlyList<DiscoveredPlugin> DiscoverFromAssemblies(
-        IReadOnlyList<string> pluginDirectories,
-        Version hostVersion,
-        ICollection<string> diagnostics)
-    {
-        var discoveryService = new PluginDiscoveryService();
-        var discovered = new List<DiscoveredPlugin>();
-        var seenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var directory in pluginDirectories.Where(Directory.Exists))
-        {
-            foreach (var dllPath in Directory.GetFiles(directory, "*.dll", SearchOption.AllDirectories))
-            {
-                try
-                {
-                    var assembly = Assembly.LoadFrom(dllPath);
-                    var plugins = discoveryService.DiscoverFromAssembly(assembly, hostVersion);
-                    foreach (var plugin in plugins)
-                    {
-                        if (!seenIds.Add(plugin.Plugin.Descriptor.Id))
-                        {
-                            continue;
-                        }
-
-                        discovered.Add(plugin);
-                    }
-                }
-                catch (Exception exception)
-                {
-                    diagnostics.Add($"info: <assembly-scan>: Skipped '{dllPath}': {exception.Message}");
-                }
-            }
-        }
-
-        return discovered;
     }
 }

--- a/src/SkyCD.Cli/CliPluginRuntime.cs
+++ b/src/SkyCD.Cli/CliPluginRuntime.cs
@@ -1,0 +1,95 @@
+using SkyCD.Plugin.Abstractions.Lifecycle;
+using SkyCD.Plugin.Runtime.Discovery;
+using SkyCD.Plugin.Runtime.Loading;
+
+namespace SkyCD.Cli;
+
+public sealed class CliPluginRuntime : IAsyncDisposable
+{
+    private readonly List<IPlugin> plugins = [];
+
+    public required IReadOnlyList<DiscoveredPlugin> DiscoveredPlugins { get; init; }
+
+    public required IReadOnlyList<string> Diagnostics { get; init; }
+
+    public static async Task<CliPluginRuntime> LoadAsync(Version hostVersion, CancellationToken cancellationToken = default)
+    {
+        var loader = new PluginDirectoryLoader();
+        var loadResult = loader.LoadFromDirectories(GetPluginDirectories(), new PluginLoadOptions
+        {
+            HostVersion = hostVersion,
+            EnableAssemblyIsolation = false
+        });
+
+        var runtime = new CliPluginRuntime
+        {
+            DiscoveredPlugins = loadResult.Plugins.ToList(),
+            Diagnostics = loadResult.Diagnostics
+                .Select(diagnostic => $"{(diagnostic.IsError ? "error" : "info")}: {diagnostic.PluginId}: {diagnostic.Message}")
+                .ToList()
+        };
+
+        var context = new PluginLifecycleContext
+        {
+            HostVersion = hostVersion,
+            Services = null
+        };
+
+        foreach (var discovered in runtime.DiscoveredPlugins)
+        {
+            runtime.plugins.Add(discovered.Plugin);
+            await discovered.Plugin.OnLoadAsync(context, cancellationToken);
+            await discovered.Plugin.OnInitializeAsync(context, cancellationToken);
+            await discovered.Plugin.OnActivateAsync(context, cancellationToken);
+        }
+
+        return runtime;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        foreach (var plugin in plugins)
+        {
+            await plugin.DisposeAsync();
+        }
+    }
+
+    private static IReadOnlyList<string> GetPluginDirectories()
+    {
+        var candidates = new List<string>();
+        AddConfiguredPluginDirectories(candidates);
+        AddLocalPluginDirectories(candidates);
+
+        return candidates
+            .Where(directory => !string.IsNullOrWhiteSpace(directory))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static void AddConfiguredPluginDirectories(ICollection<string> candidates)
+    {
+        var configured = Environment.GetEnvironmentVariable("SKYCD_PLUGIN_PATH");
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            return;
+        }
+
+        foreach (var segment in configured.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            candidates.Add(Path.GetFullPath(segment));
+        }
+    }
+
+    private static void AddLocalPluginDirectories(ICollection<string> candidates)
+    {
+        candidates.Add(Path.Combine(AppContext.BaseDirectory, "Plugins"));
+        candidates.Add(Path.Combine(Directory.GetCurrentDirectory(), "Plugins"));
+
+        var current = new DirectoryInfo(Directory.GetCurrentDirectory());
+        for (var depth = 0; depth < 8 && current is not null; depth++)
+        {
+            candidates.Add(Path.Combine(current.FullName, "Plugins"));
+            current = current.Parent;
+        }
+    }
+}

--- a/src/SkyCD.Cli/CliPluginRuntime.cs
+++ b/src/SkyCD.Cli/CliPluginRuntime.cs
@@ -1,6 +1,7 @@
 using SkyCD.Plugin.Abstractions.Lifecycle;
 using SkyCD.Plugin.Runtime.Discovery;
 using SkyCD.Plugin.Runtime.Loading;
+using System.Reflection;
 
 namespace SkyCD.Cli;
 
@@ -12,21 +13,34 @@ public sealed class CliPluginRuntime : IAsyncDisposable
 
     public required IReadOnlyList<string> Diagnostics { get; init; }
 
+    public required IReadOnlyList<string> PluginDirectories { get; init; }
+
     public static async Task<CliPluginRuntime> LoadAsync(Version hostVersion, CancellationToken cancellationToken = default)
     {
+        var pluginDirectories = GetPluginDirectories();
         var loader = new PluginDirectoryLoader();
-        var loadResult = loader.LoadFromDirectories(GetPluginDirectories(), new PluginLoadOptions
+        var loadResult = loader.LoadFromDirectories(pluginDirectories, new PluginLoadOptions
         {
             HostVersion = hostVersion,
             EnableAssemblyIsolation = false
         });
 
+        var discoveredPlugins = loadResult.Plugins.ToList();
+        var diagnostics = loadResult.Diagnostics
+            .Select(diagnostic => $"{(diagnostic.IsError ? "error" : "info")}: {diagnostic.PluginId}: {diagnostic.Message}")
+            .ToList();
+
+        if (discoveredPlugins.Count == 0)
+        {
+            diagnostics.Add("info: <fallback>: No manifest-based plugins loaded. Falling back to assembly scan.");
+            discoveredPlugins.AddRange(DiscoverFromAssemblies(pluginDirectories, hostVersion, diagnostics));
+        }
+
         var runtime = new CliPluginRuntime
         {
-            DiscoveredPlugins = loadResult.Plugins.ToList(),
-            Diagnostics = loadResult.Diagnostics
-                .Select(diagnostic => $"{(diagnostic.IsError ? "error" : "info")}: {diagnostic.PluginId}: {diagnostic.Message}")
-                .ToList()
+            DiscoveredPlugins = discoveredPlugins,
+            Diagnostics = diagnostics,
+            PluginDirectories = pluginDirectories
         };
 
         var context = new PluginLifecycleContext
@@ -83,13 +97,53 @@ public sealed class CliPluginRuntime : IAsyncDisposable
     private static void AddLocalPluginDirectories(ICollection<string> candidates)
     {
         candidates.Add(Path.Combine(AppContext.BaseDirectory, "Plugins"));
+        candidates.Add(Path.Combine(AppContext.BaseDirectory, "Plugins", "samples"));
         candidates.Add(Path.Combine(Directory.GetCurrentDirectory(), "Plugins"));
+        candidates.Add(Path.Combine(Directory.GetCurrentDirectory(), "Plugins", "samples"));
 
         var current = new DirectoryInfo(Directory.GetCurrentDirectory());
         for (var depth = 0; depth < 8 && current is not null; depth++)
         {
             candidates.Add(Path.Combine(current.FullName, "Plugins"));
+            candidates.Add(Path.Combine(current.FullName, "Plugins", "samples"));
             current = current.Parent;
         }
+    }
+
+    private static IReadOnlyList<DiscoveredPlugin> DiscoverFromAssemblies(
+        IReadOnlyList<string> pluginDirectories,
+        Version hostVersion,
+        ICollection<string> diagnostics)
+    {
+        var discoveryService = new PluginDiscoveryService();
+        var discovered = new List<DiscoveredPlugin>();
+        var seenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var directory in pluginDirectories.Where(Directory.Exists))
+        {
+            foreach (var dllPath in Directory.GetFiles(directory, "*.dll", SearchOption.AllDirectories))
+            {
+                try
+                {
+                    var assembly = Assembly.LoadFrom(dllPath);
+                    var plugins = discoveryService.DiscoverFromAssembly(assembly, hostVersion);
+                    foreach (var plugin in plugins)
+                    {
+                        if (!seenIds.Add(plugin.Plugin.Descriptor.Id))
+                        {
+                            continue;
+                        }
+
+                        discovered.Add(plugin);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    diagnostics.Add($"info: <assembly-scan>: Skipped '{dllPath}': {exception.Message}");
+                }
+            }
+        }
+
+        return discovered;
     }
 }

--- a/src/SkyCD.Cli/CliRunResult.cs
+++ b/src/SkyCD.Cli/CliRunResult.cs
@@ -1,0 +1,8 @@
+namespace SkyCD.Cli;
+
+public sealed class CliRunResult
+{
+    public required bool Handled { get; init; }
+
+    public int ExitCode { get; init; }
+}

--- a/src/SkyCD.Cli/SkyCD.Cli.csproj
+++ b/src/SkyCD.Cli/SkyCD.Cli.csproj
@@ -12,4 +12,10 @@
     <ProjectReference Include="..\SkyCD.Plugin.Runtime\SkyCD.Plugin.Runtime.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>SkyCD.Cli.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/SkyCD.Cli/SkyCD.Cli.csproj
+++ b/src/SkyCD.Cli/SkyCD.Cli.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+    <ProjectReference Include="..\SkyCD.Plugin.Host\SkyCD.Plugin.Host.csproj" />
+    <ProjectReference Include="..\SkyCD.Plugin.Runtime\SkyCD.Plugin.Runtime.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/CliCommandContext.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/CliCommandContext.cs
@@ -1,0 +1,37 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.Cli;
+
+/// <summary>
+/// Runtime context passed to plugin CLI handlers.
+/// </summary>
+public sealed class CliCommandContext
+{
+    /// <summary>
+    /// Gets the command path being executed.
+    /// </summary>
+    public required string CommandPath { get; init; }
+
+    /// <summary>
+    /// Gets contribution identifier selected by host.
+    /// </summary>
+    public required string CommandId { get; init; }
+
+    /// <summary>
+    /// Gets raw command arguments not parsed by host command parser.
+    /// </summary>
+    public required IReadOnlyList<string> Arguments { get; init; }
+
+    /// <summary>
+    /// Gets whether machine-readable JSON output was requested.
+    /// </summary>
+    public bool JsonOutput { get; init; }
+
+    /// <summary>
+    /// Gets extension payload for command extension points.
+    /// </summary>
+    public object? Payload { get; init; }
+
+    /// <summary>
+    /// Gets host API surface available to CLI plugins.
+    /// </summary>
+    public required IHostCliApi HostApi { get; init; }
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/CliCommandContribution.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/CliCommandContribution.cs
@@ -1,0 +1,20 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.Cli;
+
+/// <summary>
+/// Describes a CLI contribution from a plugin.
+/// </summary>
+/// <param name="CommandPath">
+/// Command path. For example: "plugins doctor" or "convert" for an extension point.
+/// </param>
+/// <param name="CommandId">
+/// Stable plugin-local command identifier passed to execution API.
+/// </param>
+/// <param name="Description">Human-readable description.</param>
+/// <param name="ContributionType">Declares whether this is a new command or extension hook.</param>
+/// <param name="Priority">Priority for extension execution (higher runs first).</param>
+public sealed record CliCommandContribution(
+    string CommandPath,
+    string CommandId,
+    string Description,
+    CliContributionType ContributionType = CliContributionType.Command,
+    int Priority = 0);

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/CliCommandResult.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/CliCommandResult.cs
@@ -1,0 +1,18 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.Cli;
+
+/// <summary>
+/// Result contract for plugin CLI handlers.
+/// </summary>
+public sealed class CliCommandResult
+{
+    public required bool Success { get; init; }
+
+    public string? Output { get; init; }
+
+    public string? Error { get; init; }
+
+    /// <summary>
+    /// Optional payload for extension-point continuation.
+    /// </summary>
+    public object? Payload { get; init; }
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/CliCommandResult.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/CliCommandResult.cs
@@ -5,10 +5,19 @@ namespace SkyCD.Plugin.Abstractions.Capabilities.Cli;
 /// </summary>
 public sealed class CliCommandResult
 {
+    /// <summary>
+    /// Indicates whether command execution succeeded.
+    /// </summary>
     public required bool Success { get; init; }
 
+    /// <summary>
+    /// Optional plain-text output written by the command.
+    /// </summary>
     public string? Output { get; init; }
 
+    /// <summary>
+    /// Optional error message when <see cref="Success"/> is <see langword="false"/>.
+    /// </summary>
     public string? Error { get; init; }
 
     /// <summary>

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/CliContributionType.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/CliContributionType.cs
@@ -1,7 +1,17 @@
 namespace SkyCD.Plugin.Abstractions.Capabilities.Cli;
 
+/// <summary>
+/// Contribution type for a CLI plugin entry.
+/// </summary>
 public enum CliContributionType
 {
+    /// <summary>
+    /// Standalone command callable directly from CLI.
+    /// </summary>
     Command = 0,
+
+    /// <summary>
+    /// Extension hook attached to a host command pipeline.
+    /// </summary>
     Extension = 1
 }

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/CliContributionType.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/CliContributionType.cs
@@ -1,0 +1,7 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.Cli;
+
+public enum CliContributionType
+{
+    Command = 0,
+    Extension = 1
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/ICliPluginCapability.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/ICliPluginCapability.cs
@@ -1,0 +1,17 @@
+namespace SkyCD.Plugin.Abstractions.Capabilities.Cli;
+
+/// <summary>
+/// CLI capability contract for plugin command contribution and execution.
+/// </summary>
+public interface ICliPluginCapability : IPluginCapability
+{
+    /// <summary>
+    /// Gets CLI command and extension contributions.
+    /// </summary>
+    IReadOnlyCollection<CliCommandContribution> GetCliContributions();
+
+    /// <summary>
+    /// Executes a contributed command or extension hook.
+    /// </summary>
+    Task<CliCommandResult> ExecuteCliCommandAsync(CliCommandContext context, CancellationToken cancellationToken = default);
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/IHostCliApi.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/IHostCliApi.cs
@@ -1,0 +1,17 @@
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+
+namespace SkyCD.Plugin.Abstractions.Capabilities.Cli;
+
+/// <summary>
+/// Safe host operations available for CLI plugins.
+/// </summary>
+public interface IHostCliApi
+{
+    IReadOnlyList<FileFormatDescriptor> GetReadableFormats();
+
+    IReadOnlyList<FileFormatDescriptor> GetWritableFormats();
+
+    Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default);
+
+    Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/IHostCliApi.cs
+++ b/src/SkyCD.Plugin.Abstractions/Capabilities/Cli/IHostCliApi.cs
@@ -7,11 +7,23 @@ namespace SkyCD.Plugin.Abstractions.Capabilities.Cli;
 /// </summary>
 public interface IHostCliApi
 {
+    /// <summary>
+    /// Returns file formats that currently support read operations.
+    /// </summary>
     IReadOnlyList<FileFormatDescriptor> GetReadableFormats();
 
+    /// <summary>
+    /// Returns file formats that currently support write operations.
+    /// </summary>
     IReadOnlyList<FileFormatDescriptor> GetWritableFormats();
 
+    /// <summary>
+    /// Reads input using the selected format handler.
+    /// </summary>
     Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Writes output using the selected format handler.
+    /// </summary>
     Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/SkyCD.Plugin.Runtime/Loading/PluginDirectoryDiscoveryService.cs
+++ b/src/SkyCD.Plugin.Runtime/Loading/PluginDirectoryDiscoveryService.cs
@@ -1,0 +1,83 @@
+using System.Reflection;
+using SkyCD.Plugin.Runtime.Discovery;
+
+namespace SkyCD.Plugin.Runtime.Loading;
+
+/// <summary>
+/// Shared plugin discovery flow used by both UI and CLI hosts.
+/// </summary>
+public sealed class PluginDirectoryDiscoveryService
+{
+    private readonly PluginDirectoryLoader loader = new();
+    private readonly PluginDiscoveryService discoveryService = new();
+
+    public PluginLoadResult Discover(IEnumerable<string> directories, PluginLoadOptions options, bool fallbackToAssemblyScan = true)
+    {
+        var normalizedDirectories = directories
+            .Where(static path => !string.IsNullOrWhiteSpace(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var result = loader.LoadFromDirectories(normalizedDirectories, options);
+        if (!fallbackToAssemblyScan || result.Plugins.Count > 0)
+        {
+            return result;
+        }
+
+        var diagnostics = result.Diagnostics.ToList();
+        diagnostics.Add(new PluginLoadDiagnostic
+        {
+            PluginId = "<assembly-scan>",
+            IsError = false,
+            Message = "No manifest-based plugins loaded. Falling back to assembly scan."
+        });
+
+        var discovered = DiscoverByAssemblyScan(normalizedDirectories, options.HostVersion, diagnostics);
+        return new PluginLoadResult
+        {
+            Plugins = discovered,
+            Diagnostics = diagnostics
+        };
+    }
+
+    private IReadOnlyCollection<DiscoveredPlugin> DiscoverByAssemblyScan(
+        IEnumerable<string> directories,
+        Version hostVersion,
+        ICollection<PluginLoadDiagnostic> diagnostics)
+    {
+        var plugins = new List<DiscoveredPlugin>();
+        var seenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var directory in directories.Where(Directory.Exists))
+        {
+            foreach (var dllPath in Directory.GetFiles(directory, "*.dll", SearchOption.AllDirectories))
+            {
+                try
+                {
+                    var assembly = Assembly.LoadFrom(dllPath);
+                    var discovered = discoveryService.DiscoverFromAssembly(assembly, hostVersion);
+                    foreach (var plugin in discovered)
+                    {
+                        if (!seenIds.Add(plugin.Plugin.Descriptor.Id))
+                        {
+                            continue;
+                        }
+
+                        plugins.Add(plugin);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    diagnostics.Add(new PluginLoadDiagnostic
+                    {
+                        PluginId = "<assembly-scan>",
+                        IsError = false,
+                        Message = $"Skipped '{dllPath}': {exception.Message}"
+                    });
+                }
+            }
+        }
+
+        return plugins;
+    }
+}

--- a/src/SkyCD.Plugin.Runtime/Loading/PluginDirectoryDiscoveryService.cs
+++ b/src/SkyCD.Plugin.Runtime/Loading/PluginDirectoryDiscoveryService.cs
@@ -19,9 +19,14 @@ public sealed class PluginDirectoryDiscoveryService
             .ToArray();
 
         var result = loader.LoadFromDirectories(normalizedDirectories, options);
+        var deduplicatedPlugins = DeduplicateByPluginId(result.Plugins);
         if (!fallbackToAssemblyScan || result.Plugins.Count > 0)
         {
-            return result;
+            return new PluginLoadResult
+            {
+                Plugins = deduplicatedPlugins,
+                Diagnostics = result.Diagnostics
+            };
         }
 
         var diagnostics = result.Diagnostics.ToList();
@@ -35,7 +40,7 @@ public sealed class PluginDirectoryDiscoveryService
         var discovered = DiscoverByAssemblyScan(normalizedDirectories, options.HostVersion, diagnostics);
         return new PluginLoadResult
         {
-            Plugins = discovered,
+            Plugins = DeduplicateByPluginId(discovered),
             Diagnostics = diagnostics
         };
     }
@@ -79,5 +84,23 @@ public sealed class PluginDirectoryDiscoveryService
         }
 
         return plugins;
+    }
+
+    private static IReadOnlyCollection<DiscoveredPlugin> DeduplicateByPluginId(IEnumerable<DiscoveredPlugin> plugins)
+    {
+        var seenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var deduplicated = new List<DiscoveredPlugin>();
+
+        foreach (var plugin in plugins)
+        {
+            if (!seenIds.Add(plugin.Plugin.Descriptor.Id))
+            {
+                continue;
+            }
+
+            deduplicated.Add(plugin);
+        }
+
+        return deduplicated;
     }
 }

--- a/tests/SkyCD.Cli.Tests/CliHostTests.cs
+++ b/tests/SkyCD.Cli.Tests/CliHostTests.cs
@@ -14,7 +14,11 @@ public sealed class CliHostTests
     {
         var output = new StringWriter();
         var error = new StringWriter();
-        var host = new CliHost(output, error, (_, _) => throw new InvalidOperationException("Runtime should not load for help."));
+        var host = new CliHost(
+            output,
+            error,
+            (_, _) => throw new InvalidOperationException("Runtime should not load for help."),
+            () => "renamed-cli.exe");
 
         var result = await host.TryRunAsync(["--help"]);
 
@@ -22,10 +26,13 @@ public sealed class CliHostTests
         Assert.Equal(CliExitCodes.Success, result.ExitCode);
         var text = output.ToString();
         Assert.Contains("Commands:", text, StringComparison.Ordinal);
-        Assert.Contains("  open", text, StringComparison.Ordinal);
-        Assert.Contains("  convert", text, StringComparison.Ordinal);
+        Assert.Contains("renamed-cli.exe [options] [command]", text, StringComparison.Ordinal);
+        Assert.Contains("  open         Open and validate a catalog file.", text, StringComparison.Ordinal);
+        Assert.Contains("  convert      Convert a catalog between supported formats.", text, StringComparison.Ordinal);
+        Assert.Contains("  list-formats List available read/write format handlers.", text, StringComparison.Ordinal);
+        Assert.Contains("  plugins list List loaded plugins, capabilities, and commands.", text, StringComparison.Ordinal);
         Assert.DoesNotContain("open <file>", text, StringComparison.Ordinal);
-        Assert.Contains("skycd <command> --help", text, StringComparison.Ordinal);
+        Assert.Contains("renamed-cli.exe <command> --help", text, StringComparison.Ordinal);
         Assert.Equal(string.Empty, error.ToString());
     }
 
@@ -34,7 +41,11 @@ public sealed class CliHostTests
     {
         var output = new StringWriter();
         var error = new StringWriter();
-        var host = new CliHost(output, error, (_, _) => throw new InvalidOperationException("Runtime should not load for help."));
+        var host = new CliHost(
+            output,
+            error,
+            (_, _) => throw new InvalidOperationException("Runtime should not load for help."),
+            () => "renamed-cli.exe");
 
         var result = await host.TryRunAsync(["open", "--help"]);
 
@@ -42,7 +53,7 @@ public sealed class CliHostTests
         Assert.Equal(CliExitCodes.Success, result.ExitCode);
         var text = output.ToString();
         Assert.Contains("Usage:", text, StringComparison.Ordinal);
-        Assert.Contains("skycd open <file> [--format <id>] [--json]", text, StringComparison.Ordinal);
+        Assert.Contains("renamed-cli.exe open <file> [--format <id>] [--json]", text, StringComparison.Ordinal);
         Assert.Contains("--format <id>", text, StringComparison.Ordinal);
         Assert.DoesNotContain("convert --in", text, StringComparison.Ordinal);
         Assert.Equal(string.Empty, error.ToString());
@@ -53,14 +64,18 @@ public sealed class CliHostTests
     {
         var output = new StringWriter();
         var error = new StringWriter();
-        var host = new CliHost(output, error, (_, _) => throw new InvalidOperationException("Runtime should not load for help."));
+        var host = new CliHost(
+            output,
+            error,
+            (_, _) => throw new InvalidOperationException("Runtime should not load for help."),
+            () => "renamed-cli.exe");
 
         var result = await host.TryRunAsync(["convert", "--help"]);
 
         Assert.True(result.Handled);
         Assert.Equal(CliExitCodes.Success, result.ExitCode);
         var text = output.ToString();
-        Assert.Contains("skycd convert --in <file> --out <file>", text, StringComparison.Ordinal);
+        Assert.Contains("renamed-cli.exe convert --in <file> --out <file>", text, StringComparison.Ordinal);
         Assert.Contains("--in-format <id>", text, StringComparison.Ordinal);
         Assert.Contains("--format <id>", text, StringComparison.Ordinal);
         Assert.Equal(string.Empty, error.ToString());

--- a/tests/SkyCD.Cli.Tests/CliHostTests.cs
+++ b/tests/SkyCD.Cli.Tests/CliHostTests.cs
@@ -1,0 +1,189 @@
+using SkyCD.Cli;
+using SkyCD.Plugin.Abstractions.Capabilities.Cli;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Abstractions.Lifecycle;
+using SkyCD.Plugin.Runtime.Discovery;
+using System.Text;
+
+namespace SkyCD.Cli.Tests;
+
+public sealed class CliHostTests
+{
+    [Fact]
+    public async Task PluginCommand_Executes_WithoutLaunchingUiPath()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var plugin = new TestPlugin();
+        var host = CreateHost(output, error, [plugin]);
+
+        var result = await host.TryRunAsync(["tests greet"]);
+
+        Assert.True(result.Handled);
+        Assert.Equal(CliExitCodes.Success, result.ExitCode);
+        Assert.Contains("hello from plugin", output.ToString(), StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public async Task Convert_RunsExtensionPoint_AndTransformsPayload()
+    {
+        var temp = Path.Combine(Path.GetTempPath(), $"skycd-cli-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(temp);
+        try
+        {
+            var inputPath = Path.Combine(temp, "input.src");
+            var outputPath = Path.Combine(temp, "output.dst");
+            await File.WriteAllTextAsync(inputPath, "seed", Encoding.UTF8);
+
+            var output = new StringWriter();
+            var error = new StringWriter();
+            var plugin = new TestPlugin();
+            var host = CreateHost(output, error, [plugin]);
+
+            var result = await host.TryRunAsync(["convert", "--in", inputPath, "--out", outputPath, "--in-format", "tests-read", "--format", "tests-write"]);
+
+            Assert.True(result.Handled);
+            Assert.Equal(CliExitCodes.Success, result.ExitCode);
+            var converted = await File.ReadAllTextAsync(outputPath, Encoding.UTF8);
+            Assert.Equal("seed|ext", converted);
+            Assert.Equal(string.Empty, error.ToString());
+        }
+        finally
+        {
+            Directory.Delete(temp, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task DuplicatePluginCommand_ReturnsConfigurationError()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var host = CreateHost(output, error, [new TestPlugin(), new DuplicateCommandPlugin()]);
+
+        var result = await host.TryRunAsync(["tests greet"]);
+
+        Assert.True(result.Handled);
+        Assert.Equal(CliExitCodes.ConfigurationError, result.ExitCode);
+        Assert.Contains("CLI command collision", error.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliHost CreateHost(TextWriter stdout, TextWriter stderr, IEnumerable<IPlugin> plugins)
+    {
+        return new CliHost(
+            stdout,
+            stderr,
+            (_, _) => Task.FromResult(new CliPluginRuntime
+            {
+                DiscoveredPlugins = plugins.Select(ToDiscoveredPlugin).ToList(),
+                Diagnostics = []
+            }));
+    }
+
+    private static DiscoveredPlugin ToDiscoveredPlugin(IPlugin plugin)
+    {
+        var capabilities = new List<SkyCD.Plugin.Abstractions.Capabilities.IPluginCapability>();
+        if (plugin is IFileFormatPluginCapability fileFormat)
+        {
+            capabilities.Add(fileFormat);
+        }
+
+        if (plugin is ICliPluginCapability cli &&
+            capabilities.All(existing => !ReferenceEquals(existing, cli)))
+        {
+            capabilities.Add(cli);
+        }
+
+        return new DiscoveredPlugin
+        {
+            Plugin = plugin,
+            Capabilities = capabilities
+        };
+    }
+
+    private sealed class TestPlugin : IPlugin, IFileFormatPluginCapability, ICliPluginCapability
+    {
+        public PluginDescriptor Descriptor => new("tests.cli", "Tests CLI", new Version(1, 0, 0), new Version(3, 0, 0));
+
+        public IReadOnlyCollection<FileFormatDescriptor> SupportedFormats =>
+        [
+            new("tests-read", "Tests Read", [".src"], CanRead: true, CanWrite: false),
+            new("tests-write", "Tests Write", [".dst"], CanRead: false, CanWrite: true)
+        ];
+
+        public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public IReadOnlyCollection<CliCommandContribution> GetCliContributions() =>
+        [
+            new CliCommandContribution("tests greet", "greet", "Greet command"),
+            new CliCommandContribution("convert", "convert-ext", "Convert extension", CliContributionType.Extension, Priority: 10)
+        ];
+
+        public Task<CliCommandResult> ExecuteCliCommandAsync(CliCommandContext context, CancellationToken cancellationToken = default)
+        {
+            return context.CommandId switch
+            {
+                "greet" => Task.FromResult(new CliCommandResult
+                {
+                    Success = true,
+                    Output = "hello from plugin"
+                }),
+                "convert-ext" => Task.FromResult(new CliCommandResult
+                {
+                    Success = true,
+                    Payload = $"{context.Payload}|ext"
+                }),
+                _ => Task.FromResult(new CliCommandResult
+                {
+                    Success = false,
+                    Error = "Unknown command id"
+                })
+            };
+        }
+
+        public async Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request, CancellationToken cancellationToken = default)
+        {
+            using var reader = new StreamReader(request.Source, Encoding.UTF8, leaveOpen: true);
+            return new FileFormatReadResult
+            {
+                Success = true,
+                Payload = await reader.ReadToEndAsync(cancellationToken)
+            };
+        }
+
+        public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request, CancellationToken cancellationToken = default)
+        {
+            await using var writer = new StreamWriter(request.Target, Encoding.UTF8, leaveOpen: true);
+            await writer.WriteAsync(Convert.ToString(request.Payload));
+            await writer.FlushAsync(cancellationToken);
+            return new FileFormatWriteResult { Success = true };
+        }
+    }
+
+    private sealed class DuplicateCommandPlugin : IPlugin, ICliPluginCapability
+    {
+        public PluginDescriptor Descriptor => new("tests.cli.dup", "Tests CLI Dup", new Version(1, 0, 0), new Version(3, 0, 0));
+
+        public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public IReadOnlyCollection<CliCommandContribution> GetCliContributions() =>
+        [
+            new CliCommandContribution("tests greet", "greet", "Conflicting command")
+        ];
+
+        public Task<CliCommandResult> ExecuteCliCommandAsync(CliCommandContext context, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(new CliCommandResult
+            {
+                Success = true
+            });
+        }
+    }
+}

--- a/tests/SkyCD.Cli.Tests/CliHostTests.cs
+++ b/tests/SkyCD.Cli.Tests/CliHostTests.cs
@@ -146,6 +146,48 @@ public sealed class CliHostTests
     }
 
     [Fact]
+    public async Task Plugins_WithoutSubcommand_ShowsPluginsHelp()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var host = new CliHost(
+            output,
+            error,
+            (_, _) => throw new InvalidOperationException("Runtime should not load for help."),
+            () => "renamed-cli.exe");
+
+        var result = await host.TryRunAsync(["plugins"]);
+
+        Assert.True(result.Handled);
+        Assert.Equal(CliExitCodes.Success, result.ExitCode);
+        var text = output.ToString();
+        Assert.Contains("renamed-cli.exe plugins <subcommand> [options]", text, StringComparison.Ordinal);
+        Assert.Contains("list     List loaded plugins, capabilities, and commands", text, StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public async Task FileFormats_WithoutSubcommand_ShowsFileFormatsHelp()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var host = new CliHost(
+            output,
+            error,
+            (_, _) => throw new InvalidOperationException("Runtime should not load for help."),
+            () => "renamed-cli.exe");
+
+        var result = await host.TryRunAsync(["fileformats"]);
+
+        Assert.True(result.Handled);
+        Assert.Equal(CliExitCodes.Success, result.ExitCode);
+        var text = output.ToString();
+        Assert.Contains("renamed-cli.exe fileformats <subcommand> [options]", text, StringComparison.Ordinal);
+        Assert.Contains("list     List available read/write format handlers", text, StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
     public async Task PluginCommand_Executes_WithoutLaunchingUiPath()
     {
         var output = new StringWriter();

--- a/tests/SkyCD.Cli.Tests/CliHostTests.cs
+++ b/tests/SkyCD.Cli.Tests/CliHostTests.cs
@@ -77,7 +77,8 @@ public sealed class CliHostTests
             (_, _) => Task.FromResult(new CliPluginRuntime
             {
                 DiscoveredPlugins = plugins.Select(ToDiscoveredPlugin).ToList(),
-                Diagnostics = []
+                Diagnostics = [],
+                PluginDirectories = []
             }));
     }
 

--- a/tests/SkyCD.Cli.Tests/CliHostTests.cs
+++ b/tests/SkyCD.Cli.Tests/CliHostTests.cs
@@ -10,6 +10,63 @@ namespace SkyCD.Cli.Tests;
 public sealed class CliHostTests
 {
     [Fact]
+    public async Task RootHelp_ShowsConciseCommandList()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var host = new CliHost(output, error, (_, _) => throw new InvalidOperationException("Runtime should not load for help."));
+
+        var result = await host.TryRunAsync(["--help"]);
+
+        Assert.True(result.Handled);
+        Assert.Equal(CliExitCodes.Success, result.ExitCode);
+        var text = output.ToString();
+        Assert.Contains("Commands:", text, StringComparison.Ordinal);
+        Assert.Contains("  open", text, StringComparison.Ordinal);
+        Assert.Contains("  convert", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("open <file>", text, StringComparison.Ordinal);
+        Assert.Contains("skycd <command> --help", text, StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public async Task OpenHelp_ShowsCommandSpecificOptions()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var host = new CliHost(output, error, (_, _) => throw new InvalidOperationException("Runtime should not load for help."));
+
+        var result = await host.TryRunAsync(["open", "--help"]);
+
+        Assert.True(result.Handled);
+        Assert.Equal(CliExitCodes.Success, result.ExitCode);
+        var text = output.ToString();
+        Assert.Contains("Usage:", text, StringComparison.Ordinal);
+        Assert.Contains("skycd open <file> [--format <id>] [--json]", text, StringComparison.Ordinal);
+        Assert.Contains("--format <id>", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("convert --in", text, StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public async Task ConvertHelp_ShowsCommandSpecificOptions()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var host = new CliHost(output, error, (_, _) => throw new InvalidOperationException("Runtime should not load for help."));
+
+        var result = await host.TryRunAsync(["convert", "--help"]);
+
+        Assert.True(result.Handled);
+        Assert.Equal(CliExitCodes.Success, result.ExitCode);
+        var text = output.ToString();
+        Assert.Contains("skycd convert --in <file> --out <file>", text, StringComparison.Ordinal);
+        Assert.Contains("--in-format <id>", text, StringComparison.Ordinal);
+        Assert.Contains("--format <id>", text, StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
     public async Task PluginCommand_Executes_WithoutLaunchingUiPath()
     {
         var output = new StringWriter();

--- a/tests/SkyCD.Cli.Tests/CliHostTests.cs
+++ b/tests/SkyCD.Cli.Tests/CliHostTests.cs
@@ -3,6 +3,7 @@ using SkyCD.Plugin.Abstractions.Capabilities.Cli;
 using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
 using SkyCD.Plugin.Abstractions.Lifecycle;
 using SkyCD.Plugin.Runtime.Discovery;
+using System.Text.Json;
 using System.Text;
 
 namespace SkyCD.Cli.Tests;
@@ -184,6 +185,85 @@ public sealed class CliHostTests
         var text = output.ToString();
         Assert.Contains("renamed-cli.exe fileformats <subcommand> [options]", text, StringComparison.Ordinal);
         Assert.Contains("list     List available read/write format handlers", text, StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public async Task Plugins_WithoutSubcommand_WithJson_ShowsJsonHelp()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var host = new CliHost(
+            output,
+            error,
+            (_, _) => throw new InvalidOperationException("Runtime should not load for help."),
+            () => "renamed-cli.exe");
+
+        var result = await host.TryRunAsync(["plugins", "--json"]);
+
+        Assert.True(result.Handled);
+        Assert.Equal(CliExitCodes.Success, result.ExitCode);
+        using var json = JsonDocument.Parse(output.ToString());
+        Assert.Equal("plugins", json.RootElement.GetProperty("command").GetString());
+        Assert.Contains("renamed-cli.exe plugins <subcommand> [options]", json.RootElement.GetProperty("usage").GetString(), StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public async Task FileFormats_WithoutSubcommand_WithJson_ShowsJsonHelp()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var host = new CliHost(
+            output,
+            error,
+            (_, _) => throw new InvalidOperationException("Runtime should not load for help."),
+            () => "renamed-cli.exe");
+
+        var result = await host.TryRunAsync(["fileformats", "--json"]);
+
+        Assert.True(result.Handled);
+        Assert.Equal(CliExitCodes.Success, result.ExitCode);
+        using var json = JsonDocument.Parse(output.ToString());
+        Assert.Equal("fileformats", json.RootElement.GetProperty("command").GetString());
+        Assert.Contains("renamed-cli.exe fileformats <subcommand> [options]", json.RootElement.GetProperty("usage").GetString(), StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public async Task ListFormatsAlias_ResolvesToFileFormatsList()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var host = CreateHost(output, error, [new TestPlugin()]);
+
+        var result = await host.TryRunAsync(["list-formats"]);
+
+        Assert.True(result.Handled);
+        Assert.Equal(CliExitCodes.Success, result.ExitCode);
+        var text = output.ToString();
+        Assert.Contains("tests-read", text, StringComparison.Ordinal);
+        Assert.Contains("tests-write", text, StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public async Task ListFormatsAlias_Help_ShowsFileFormatsListUsage()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var host = new CliHost(
+            output,
+            error,
+            (_, _) => throw new InvalidOperationException("Runtime should not load for help."),
+            () => "renamed-cli.exe");
+
+        var result = await host.TryRunAsync(["list-formats", "--help"]);
+
+        Assert.True(result.Handled);
+        Assert.Equal(CliExitCodes.Success, result.ExitCode);
+        var text = output.ToString();
+        Assert.Contains("renamed-cli.exe fileformats list [--json]", text, StringComparison.Ordinal);
         Assert.Equal(string.Empty, error.ToString());
     }
 

--- a/tests/SkyCD.Cli.Tests/CliHostTests.cs
+++ b/tests/SkyCD.Cli.Tests/CliHostTests.cs
@@ -29,8 +29,9 @@ public sealed class CliHostTests
         Assert.Contains("renamed-cli.exe [options] [command]", text, StringComparison.Ordinal);
         Assert.Contains("  open         Open and validate a catalog file.", text, StringComparison.Ordinal);
         Assert.Contains("  convert      Convert a catalog between supported formats.", text, StringComparison.Ordinal);
-        Assert.Contains("  list-formats List available read/write format handlers.", text, StringComparison.Ordinal);
-        Assert.Contains("  plugins list List loaded plugins, capabilities, and commands.", text, StringComparison.Ordinal);
+        Assert.Contains("  fileformats  Work with file format handlers.", text, StringComparison.Ordinal);
+        Assert.Contains("  plugins      Inspect loaded plugins and capabilities.", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("plugins list", text, StringComparison.Ordinal);
         Assert.DoesNotContain("open <file>", text, StringComparison.Ordinal);
         Assert.Contains("renamed-cli.exe <command> --help", text, StringComparison.Ordinal);
         Assert.Equal(string.Empty, error.ToString());
@@ -78,6 +79,69 @@ public sealed class CliHostTests
         Assert.Contains("renamed-cli.exe convert --in <file> --out <file>", text, StringComparison.Ordinal);
         Assert.Contains("--in-format <id>", text, StringComparison.Ordinal);
         Assert.Contains("--format <id>", text, StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public async Task PluginsHelp_ShowsListSubcommand()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var host = new CliHost(
+            output,
+            error,
+            (_, _) => throw new InvalidOperationException("Runtime should not load for help."),
+            () => "renamed-cli.exe");
+
+        var result = await host.TryRunAsync(["plugins", "--help"]);
+
+        Assert.True(result.Handled);
+        Assert.Equal(CliExitCodes.Success, result.ExitCode);
+        var text = output.ToString();
+        Assert.Contains("renamed-cli.exe plugins <subcommand> [options]", text, StringComparison.Ordinal);
+        Assert.Contains("list     List loaded plugins, capabilities, and commands", text, StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public async Task FileFormatsHelp_ShowsListSubcommand()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var host = new CliHost(
+            output,
+            error,
+            (_, _) => throw new InvalidOperationException("Runtime should not load for help."),
+            () => "renamed-cli.exe");
+
+        var result = await host.TryRunAsync(["fileformats", "--help"]);
+
+        Assert.True(result.Handled);
+        Assert.Equal(CliExitCodes.Success, result.ExitCode);
+        var text = output.ToString();
+        Assert.Contains("renamed-cli.exe fileformats <subcommand> [options]", text, StringComparison.Ordinal);
+        Assert.Contains("list     List available read/write format handlers", text, StringComparison.Ordinal);
+        Assert.Equal(string.Empty, error.ToString());
+    }
+
+    [Fact]
+    public async Task RootHelp_NormalizesDllNameToExe()
+    {
+        var output = new StringWriter();
+        var error = new StringWriter();
+        var host = new CliHost(
+            output,
+            error,
+            (_, _) => throw new InvalidOperationException("Runtime should not load for help."),
+            () => "SkyCD.App.dll");
+
+        var result = await host.TryRunAsync(["--help"]);
+
+        Assert.True(result.Handled);
+        Assert.Equal(CliExitCodes.Success, result.ExitCode);
+        var text = output.ToString();
+        Assert.Contains("SkyCD.App.exe [options] [command]", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("SkyCD.App.dll [options] [command]", text, StringComparison.Ordinal);
         Assert.Equal(string.Empty, error.ToString());
     }
 

--- a/tests/SkyCD.Cli.Tests/CliHostTests.cs
+++ b/tests/SkyCD.Cli.Tests/CliHostTests.cs
@@ -141,8 +141,16 @@ public sealed class CliHostTests
         Assert.True(result.Handled);
         Assert.Equal(CliExitCodes.Success, result.ExitCode);
         var text = output.ToString();
-        Assert.Contains("SkyCD.App.exe [options] [command]", text, StringComparison.Ordinal);
-        Assert.DoesNotContain("SkyCD.App.dll [options] [command]", text, StringComparison.Ordinal);
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.Contains("SkyCD.App.exe [options] [command]", text, StringComparison.Ordinal);
+            Assert.DoesNotContain("SkyCD.App.dll [options] [command]", text, StringComparison.Ordinal);
+        }
+        else
+        {
+            Assert.Contains("SkyCD.App.dll [options] [command]", text, StringComparison.Ordinal);
+        }
+
         Assert.Equal(string.Empty, error.ToString());
     }
 

--- a/tests/SkyCD.Cli.Tests/CliPluginRuntimeTests.cs
+++ b/tests/SkyCD.Cli.Tests/CliPluginRuntimeTests.cs
@@ -1,0 +1,72 @@
+using SkyCD.Cli;
+
+using System.Text.Json;
+
+namespace SkyCD.Cli.Tests;
+
+public sealed class CliPluginRuntimeTests
+{
+    [Fact]
+    public void BuildPluginDirectories_UsesConfiguredAndAppSettingsPaths_AndDeduplicates()
+    {
+        var first = Path.Combine(Path.GetTempPath(), "skycd-cli-runtime-first");
+        var second = Path.Combine(Path.GetTempPath(), "skycd-cli-runtime-second");
+        var configured = string.Join(Path.PathSeparator, [first, second, first]);
+
+        var directories = CliPluginRuntime.BuildPluginDirectories(configured, second);
+
+        Assert.Equal(2, directories.Count);
+        Assert.Contains(Path.GetFullPath(first), directories, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains(Path.GetFullPath(second), directories, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildPluginDirectories_DoesNotAddLocalFallbackDirectories()
+    {
+        var directories = CliPluginRuntime.BuildPluginDirectories(null, null);
+
+        Assert.Empty(directories);
+    }
+
+    [Fact]
+    public void TryReadPluginPathFromAppSettings_ReadsPluginPath()
+    {
+        var appDataRoot = Path.Combine(Path.GetTempPath(), $"skycd-appdata-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(appDataRoot, "SkyCD"));
+
+        try
+        {
+            var expectedPath = Path.Combine(appDataRoot, "CustomPlugins");
+            var optionsPath = Path.Combine(appDataRoot, "SkyCD", "options.json");
+            File.WriteAllText(optionsPath, JsonSerializer.Serialize(new { PluginPath = expectedPath }));
+
+            var resolved = CliPluginRuntime.TryReadPluginPathFromAppSettings(appDataRoot);
+
+            Assert.Equal(expectedPath, resolved);
+        }
+        finally
+        {
+            Directory.Delete(appDataRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryReadPluginPathFromAppSettings_ReturnsNull_WhenFileMissingOrInvalid()
+    {
+        var appDataRoot = Path.Combine(Path.GetTempPath(), $"skycd-appdata-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(appDataRoot, "SkyCD"));
+
+        try
+        {
+            Assert.Null(CliPluginRuntime.TryReadPluginPathFromAppSettings(appDataRoot));
+
+            var optionsPath = Path.Combine(appDataRoot, "SkyCD", "options.json");
+            File.WriteAllText(optionsPath, "{ not json");
+            Assert.Null(CliPluginRuntime.TryReadPluginPathFromAppSettings(appDataRoot));
+        }
+        finally
+        {
+            Directory.Delete(appDataRoot, recursive: true);
+        }
+    }
+}

--- a/tests/SkyCD.Cli.Tests/SkyCD.Cli.Tests.csproj
+++ b/tests/SkyCD.Cli.Tests/SkyCD.Cli.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\SkyCD.Cli\SkyCD.Cli.csproj" />
+    <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\SkyCD.Plugin.Runtime\SkyCD.Plugin.Runtime.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Solves #297: Add command-line switch support with plugin-extensible CLI commands

What changed:
- Added new SkyCD.Cli host project with built-in commands: open, convert, list-formats, plugins list, plus --help and --version.
- Updated desktop entrypoint to run CLI commands without launching UI when invocation matches CLI mode.
- Added plugin CLI capability contracts (ICliPluginCapability) with command/extension contributions and safe host API.
- Implemented deterministic CLI command collision handling and extension point rules.
- Added plugin timeout/error guards for CLI command execution.
- Added docs for CLI usage and plugin SDK CLI contract.
- Added integration-style tests for plugin command execution, convert extension pipeline, and collision handling.

Validation:
- dotnet restore SkyCD.slnx
- dotnet build SkyCD.slnx --configuration Release --no-restore
- dotnet test SkyCD.slnx --configuration Release --no-build
- dotnet format SkyCD.slnx --verify-no-changes --verbosity minimal