### PR TITLE
Fix Save As opening duplicate modal

### DIFF
--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -50,7 +50,6 @@ public partial class MainWindow : Window
             subscribedViewModel.OpenCatalogRequested -= OnOpenCatalogRequested;
             subscribedViewModel.SaveCatalogAsRequested -= OnSaveCatalogAsRequested;
             subscribedViewModel.SaveCatalogRequested -= OnSaveCatalogRequested;
-            subscribedViewModel.SaveCatalogAsRequested -= OnSaveCatalogAsRequested;
             subscribedViewModel.AboutRequested -= OnAboutRequested;
             subscribedViewModel.OptionsRequested -= OnOptionsRequested;
             subscribedViewModel.PropertiesRequested -= OnPropertiesRequested;
@@ -66,7 +65,6 @@ public partial class MainWindow : Window
             subscribedViewModel.OpenCatalogRequested += OnOpenCatalogRequested;
             subscribedViewModel.SaveCatalogAsRequested += OnSaveCatalogAsRequested;
             subscribedViewModel.SaveCatalogRequested += OnSaveCatalogRequested;
-            subscribedViewModel.SaveCatalogAsRequested += OnSaveCatalogAsRequested;
             subscribedViewModel.AboutRequested += OnAboutRequested;
             subscribedViewModel.OptionsRequested += OnOptionsRequested;
             subscribedViewModel.PropertiesRequested += OnPropertiesRequested;

--- a/tests/SkyCD.App.Tests/SaveCatalogAsUiContractTests.cs
+++ b/tests/SkyCD.App.Tests/SaveCatalogAsUiContractTests.cs
@@ -1,0 +1,57 @@
+namespace SkyCD.App.Tests;
+
+public class SaveCatalogAsUiContractTests
+{
+    [Fact]
+    public void MainWindow_DataContextSubscription_WiresSaveCatalogAsRequestedExactlyOnce()
+    {
+        var codeBehind = ReadRepoFile("src", "SkyCD.App", "Views", "MainWindow.axaml.cs");
+
+        Assert.Equal(
+            1,
+            CountOccurrences(
+                codeBehind,
+                "subscribedViewModel.SaveCatalogAsRequested += OnSaveCatalogAsRequested;"));
+        Assert.Equal(
+            1,
+            CountOccurrences(
+                codeBehind,
+                "subscribedViewModel.SaveCatalogAsRequested -= OnSaveCatalogAsRequested;"));
+    }
+
+    private static int CountOccurrences(string text, string needle)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = text.IndexOf(needle, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += needle.Length;
+        }
+
+        return count;
+    }
+
+    private static string ReadRepoFile(params string[] parts)
+    {
+        var root = FindRepoRoot();
+        var fullPath = Path.Combine([root, .. parts]);
+        return File.ReadAllText(fullPath);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "SkyCD.slnx")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root.");
+    }
+}

--- a/tests/SkyCD.Plugin.Host.Tests/ModalExtensionServiceTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/ModalExtensionServiceTests.cs
@@ -86,7 +86,8 @@ public class ModalExtensionServiceTests
     [Fact]
     public async Task OpenAsync_RejectsReentrantOpen_WhenModalDoesNotAllowIt()
     {
-        var pluginCatalog = CreateCatalog(new NonReentrantDelayModalPlugin());
+        var plugin = new NonReentrantControlledModalPlugin();
+        var pluginCatalog = CreateCatalog(plugin);
         var service = new ModalExtensionService(pluginCatalog);
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
@@ -98,7 +99,7 @@ public class ModalExtensionServiceTests
             timeout: TimeSpan.FromSeconds(1),
             cancellationToken: cts.Token);
 
-        await Task.Delay(30, cts.Token);
+        await plugin.FirstOpenStarted.WaitAsync(cts.Token);
 
         var second = await service.OpenAsync(
             new ModalOpenRequest
@@ -110,7 +111,10 @@ public class ModalExtensionServiceTests
 
         Assert.False(second.Success);
         Assert.Contains("already active", second.Error);
-        await firstOpen;
+        plugin.AllowCompletion();
+
+        var first = await firstOpen;
+        Assert.True(first.Success);
     }
 
     [Fact]
@@ -194,14 +198,20 @@ public class ModalExtensionServiceTests
         }
     }
 
-    private sealed class NonReentrantDelayModalPlugin : IPlugin, IModalPluginCapability
+    private sealed class NonReentrantControlledModalPlugin : IPlugin, IModalPluginCapability
     {
+        private readonly TaskCompletionSource _firstOpenStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _allowCompletion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public PluginDescriptor Descriptor => new("tests.modal.locked", "Locked Modal", new Version(1, 0, 0), new Version(3, 0, 0));
+        public Task FirstOpenStarted => _firstOpenStarted.Task;
 
         public ValueTask OnLoadAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
         public ValueTask OnInitializeAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
         public ValueTask OnActivateAsync(PluginLifecycleContext context, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+        public void AllowCompletion() => _allowCompletion.TrySetResult();
 
         public IReadOnlyCollection<ModalDescriptor> GetModals() =>
         [
@@ -210,7 +220,8 @@ public class ModalExtensionServiceTests
 
         public async Task<ModalOpenResult> OpenModalAsync(ModalOpenRequest request, CancellationToken cancellationToken = default)
         {
-            await Task.Delay(TimeSpan.FromMilliseconds(120), cancellationToken);
+            _firstOpenStarted.TrySetResult();
+            await _allowCompletion.Task.WaitAsync(cancellationToken);
             return new ModalOpenResult { Success = true };
         }
     }


### PR DESCRIPTION
Solves #000: Save As opens two modals instead of one

## Summary
- Remove duplicate SaveCatalogAsRequested event subscription in MainWindow data-context wiring
- Add a regression UI contract test to ensure Save As handler is subscribed/unsubscribed exactly once

## Validation
- dotnet restore SkyCD.slnx
- dotnet build SkyCD.slnx --configuration Release --no-restore
- dotnet test tests/SkyCD.App.Tests/SkyCD.App.Tests.csproj --configuration Release --no-build