### PR TITLE
Fix #315: Improve TomlCatalogPlugin robustness and fix failing tests

### DIFF
--- a/Plugins/SkyCD.Plugin.Toml/TomlCatalogPlugin.cs
+++ b/Plugins/SkyCD.Plugin.Toml/TomlCatalogPlugin.cs
@@ -31,8 +31,10 @@ public sealed class TomlCatalogPlugin : IFileFormatPluginCapability
                 return new FileFormatReadResult { Success = false, Error = "Invalid TOML document." };
             }
 
-            if (model["schema"] is not TomlTable schema ||
-                schema["version"]?.ToString() is not { } version ||
+            if (!model.TryGetValue("schema", out var schemaObj) ||
+                schemaObj is not TomlTable schema ||
+                !schema.TryGetValue("version", out var versionObj) ||
+                versionObj?.ToString() is not { } version ||
                 !SchemaVersion.Equals(version, StringComparison.Ordinal))
             {
                 return new FileFormatReadResult
@@ -42,7 +44,7 @@ public sealed class TomlCatalogPlugin : IFileFormatPluginCapability
                 };
             }
 
-            if (model["nodes"] is not TomlTableArray nodes)
+            if (!model.TryGetValue("nodes", out var nodesObj) || nodesObj is not TomlTableArray nodes)
             {
                 return new FileFormatReadResult { Success = true, Payload = new List<Dictionary<string, object?>>() };
             }
@@ -50,11 +52,11 @@ public sealed class TomlCatalogPlugin : IFileFormatPluginCapability
             var rows = nodes
                 .Select(node => new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
                 {
-                    ["nodeId"] = node["nodeId"]?.ToString(),
-                    ["parentId"] = node["parentId"]?.ToString(),
-                    ["kind"] = node["kind"]?.ToString(),
-                    ["name"] = node["name"]?.ToString(),
-                    ["sizeBytes"] = node["sizeBytes"]?.ToString()
+                    ["nodeId"] = node.TryGetValue("nodeId", out var nodeId) ? nodeId?.ToString() : null,
+                    ["parentId"] = node.TryGetValue("parentId", out var parentId) ? parentId?.ToString() : null,
+                    ["kind"] = node.TryGetValue("kind", out var kind) ? kind?.ToString() : null,
+                    ["name"] = node.TryGetValue("name", out var name) ? name?.ToString() : null,
+                    ["sizeBytes"] = node.TryGetValue("sizeBytes", out var sizeBytes) ? sizeBytes?.ToString() : null
                 })
                 .ToList();
 
@@ -93,14 +95,15 @@ public sealed class TomlCatalogPlugin : IFileFormatPluginCapability
             var array = new TomlTableArray();
             foreach (var row in rows.OrderBy(row => row.TryGetValue("nodeId", out var id) ? id?.ToString() : null, StringComparer.Ordinal))
             {
-                array.Add(new TomlTable
-                {
-                    ["nodeId"] = row.TryGetValue("nodeId", out var nodeId) ? nodeId?.ToString() ?? string.Empty : string.Empty,
-                    ["parentId"] = row.TryGetValue("parentId", out var parentId) ? parentId?.ToString() ?? string.Empty : string.Empty,
-                    ["kind"] = row.TryGetValue("kind", out var kind) ? kind?.ToString() ?? string.Empty : string.Empty,
-                    ["name"] = row.TryGetValue("name", out var name) ? name?.ToString() ?? string.Empty : string.Empty,
-                    ["sizeBytes"] = row.TryGetValue("sizeBytes", out var sizeBytes) ? sizeBytes?.ToString() ?? string.Empty : string.Empty
-                });
+                var nodeTable = new TomlTable();
+
+                if (row.TryGetValue("nodeId", out var nodeId) && nodeId is not null) nodeTable["nodeId"] = nodeId.ToString()!;
+                if (row.TryGetValue("parentId", out var parentId) && parentId is not null) nodeTable["parentId"] = parentId.ToString()!;
+                if (row.TryGetValue("kind", out var kind) && kind is not null) nodeTable["kind"] = kind.ToString()!;
+                if (row.TryGetValue("name", out var name) && name is not null) nodeTable["name"] = name.ToString()!;
+                if (row.TryGetValue("sizeBytes", out var sizeBytes) && sizeBytes is not null) nodeTable["sizeBytes"] = sizeBytes.ToString()!;
+
+                array.Add(nodeTable);
             }
 
             table["nodes"] = array;

--- a/tests/SkyCD.Plugin.Host.Tests/TomlCatalogPluginTests.cs
+++ b/tests/SkyCD.Plugin.Host.Tests/TomlCatalogPluginTests.cs
@@ -56,6 +56,57 @@ public class TomlCatalogPluginTests
         Assert.Contains("[[nodes]]", text);
     }
 
+    [Fact]
+    public async Task ReadAsync_WithMissingKeys_ShouldNotThrow()
+    {
+        var plugin = new TomlCatalogPlugin();
+        var toml = @"
+[schema]
+version = ""skycd.catalog.v1""
+hierarchy = ""adjacency-list""
+
+[[nodes]]
+name = ""Missing IDs""
+";
+        using var source = new MemoryStream(Encoding.UTF8.GetBytes(toml));
+        var result = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-toml",
+            Source = source
+        });
+
+        Assert.True(result.Success, $"Should be successful but got error: {result.Error}");
+        var rows = Assert.IsType<List<Dictionary<string, object?>>>(result.Payload);
+        Assert.Single(rows);
+        Assert.False(rows[0].ContainsKey("nodeId") && rows[0]["nodeId"] != null, "nodeId should be null or missing");
+    }
+
+    [Fact]
+    public async Task ReadAsync_WithIntegerSizeBytes_ShouldWork()
+    {
+        var plugin = new TomlCatalogPlugin();
+        var toml = @"
+[schema]
+version = ""skycd.catalog.v1""
+hierarchy = ""adjacency-list""
+
+[[nodes]]
+nodeId = ""1""
+name = ""Test""
+sizeBytes = 123
+";
+        using var source = new MemoryStream(Encoding.UTF8.GetBytes(toml));
+        var result = await plugin.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-toml",
+            Source = source
+        });
+
+        Assert.True(result.Success, $"Should be successful but got error: {result.Error}");
+        var rows = Assert.IsType<List<Dictionary<string, object?>>>(result.Payload);
+        Assert.Equal("123", rows[0]["sizeBytes"]);
+    }
+
     private static PluginManager CreateCatalog()
     {
         var plugin = new TomlCatalogPlugin();


### PR DESCRIPTION
Solves #315: Fix TomlCatalogPlugin tests and robustness

This PR improves the robustness of the `TomlCatalogPlugin` when reading and writing TOML files.
Key changes:
- Switched to `TryGetValue` in `ReadAsync` to prevent `KeyNotFoundException` when optional keys or nodes are missing.
- Enhanced value extraction to handle non-string TOML types (like integers for `sizeBytes`) correctly by calling `ToString()`.
- Updated `WriteAsync` to skip writing null or missing properties instead of writing them as empty strings, resulting in cleaner TOML output.
- Added unit tests in `TomlCatalogPluginTests.cs` to verify these scenarios and prevent regressions.

---
*PR created automatically by Jules for task [15631949914761788902](https://jules.google.com/task/15631949914761788902) started by @MekDrop*