### PR TITLE
Add PLS file format support

### DIFF
--- a/Plugins/SkyCD.Plugin.Pls/PlsCatalogPlugin.cs
+++ b/Plugins/SkyCD.Plugin.Pls/PlsCatalogPlugin.cs
@@ -17,7 +17,7 @@ public sealed class PlsCatalogPlugin : IFileFormatPluginCapability
             FormatId: "skycd-pls",
             DisplayName: "PLS Playlist",
             Extensions: [".pls"],
-            MimeTypes: ["audio/x-scpls", "application/pls+xml", "application/pls"],
+            MimeTypes: ["audio/x-scpls", "audio/scpls"],
             CanRead: true,
             CanWrite: true);
 

--- a/Plugins/SkyCD.Plugin.Pls/PlsCatalogPlugin.cs
+++ b/Plugins/SkyCD.Plugin.Pls/PlsCatalogPlugin.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+
+namespace SkyCD.Plugin.Pls;
+
+public sealed class PlsCatalogPlugin : IFileFormatPluginCapability
+{
+    public FileFormatDescriptor SupportedFormat =>
+        new(
+            FormatId: "skycd-pls",
+            DisplayName: "PLS Playlist",
+            Extensions: [".pls"],
+            MimeTypes: ["audio/x-scpls", "application/pls+xml", "application/pls"],
+            CanRead: true,
+            CanWrite: true);
+
+    public async Task<FileFormatReadResult> ReadAsync(FileFormatReadRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var reader = new StreamReader(request.Source, Encoding.UTF8, detectEncodingFromByteOrderMarks: true,
+                leaveOpen: true);
+            var lines = new List<string>();
+            while (await reader.ReadLineAsync(cancellationToken) is { } line)
+            {
+                lines.Add(line);
+            }
+
+            if (lines.Count == 0 || !string.Equals(lines[0].Trim(), "[playlist]", StringComparison.OrdinalIgnoreCase))
+            {
+                return new FileFormatReadResult
+                {
+                    Success = false,
+                    Error = "PLS file must start with [playlist] header."
+                };
+            }
+
+            var values = ParseKeyValue(lines.Skip(1));
+            var entries = new List<PlsPlaylistEntry>();
+
+            foreach (var (key, value) in values)
+            {
+                if (!key.StartsWith("File", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                var suffix = key["File".Length..];
+                if (!int.TryParse(suffix, NumberStyles.Integer, CultureInfo.InvariantCulture, out var index) ||
+                    string.IsNullOrWhiteSpace(value))
+                {
+                    continue;
+                }
+
+                var title = values.TryGetValue($"Title{index}", out var titleValue) ? titleValue : null;
+                var size = 0L;
+                if (values.TryGetValue($"Length{index}", out var lengthValue) &&
+                    long.TryParse(lengthValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+                {
+                    size = Math.Max(0L, parsed);
+                }
+
+                entries.Add(new PlsPlaylistEntry(value.Trim(), title, size));
+            }
+
+            return new FileFormatReadResult
+            {
+                Success = true,
+                Payload = new PlsPlaylistDocument(entries.OrderBy(static entry => entry.Path, StringComparer.Ordinal).ToList())
+            };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatReadResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(FileFormatWriteRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var entries = ResolveEntries(request.Payload);
+            await using var writer = new StreamWriter(request.Target, new UTF8Encoding(false), leaveOpen: true);
+            await writer.WriteLineAsync("[playlist]");
+
+            var index = 1;
+            foreach (var entry in entries)
+            {
+                await writer.WriteLineAsync(FormattableString.Invariant($"File{index}={entry.Path}"));
+                if (!string.IsNullOrWhiteSpace(entry.Title))
+                {
+                    await writer.WriteLineAsync(FormattableString.Invariant($"Title{index}={entry.Title}"));
+                }
+
+                await writer.WriteLineAsync(FormattableString.Invariant($"Length{index}={entry.SizeBytes}"));
+                index++;
+            }
+
+            await writer.WriteLineAsync(FormattableString.Invariant($"NumberOfEntries={entries.Count}"));
+            await writer.WriteLineAsync("Version=2");
+            await writer.FlushAsync(cancellationToken);
+
+            return new FileFormatWriteResult { Success = true };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatWriteResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    private static Dictionary<string, string> ParseKeyValue(IEnumerable<string> lines)
+    {
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var line in lines)
+        {
+            var trimmed = line.Trim();
+            if (trimmed.Length == 0 || trimmed.StartsWith(';'))
+            {
+                continue;
+            }
+
+            var separator = trimmed.IndexOf('=');
+            if (separator <= 0 || separator == trimmed.Length - 1)
+            {
+                continue;
+            }
+
+            values[trimmed[..separator].Trim()] = trimmed[(separator + 1)..].Trim();
+        }
+
+        return values;
+    }
+
+    private static IReadOnlyList<PlsPlaylistEntry> ResolveEntries(object? payload)
+    {
+        if (payload is PlsPlaylistDocument document)
+        {
+            return document.Entries;
+        }
+
+        throw new InvalidOperationException("PLS payload must be a PLS playlist document.");
+    }
+}
+
+public sealed record PlsPlaylistDocument(IReadOnlyList<PlsPlaylistEntry> Entries);
+
+public sealed record PlsPlaylistEntry(string Path, string? Title, long SizeBytes);

--- a/Plugins/SkyCD.Plugin.Pls/SkyCD.Plugin.Pls.csproj
+++ b/Plugins/SkyCD.Plugin.Pls/SkyCD.Plugin.Pls.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj"/>
+    </ItemGroup>
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <Company>SkyCD</Company>
+        <Authors>SkyCD</Authors>
+    </PropertyGroup>
+    <ItemGroup>
+        <AssemblyMetadata Include="AuthorUrl" Value="https://sourceforge.net/projects/skycd/"/>
+    </ItemGroup>
+</Project>

--- a/SkyCD.slnx
+++ b/SkyCD.slnx
@@ -11,6 +11,7 @@
         <Project Path="Plugins/SkyCD.Plugin.Iso/SkyCD.Plugin.Iso.csproj"/>
         <Project Path="Plugins/SkyCD.Plugin.Json/SkyCD.Plugin.Json.csproj"/>
         <Project Path="Plugins/SkyCD.Plugin.Markdown/SkyCD.Plugin.Markdown.csproj"/>
+        <Project Path="Plugins/SkyCD.Plugin.Pls/SkyCD.Plugin.Pls.csproj"/>
         <Project Path="Plugins/SkyCD.Plugin.Sample.Menu/SkyCD.Plugin.Sample.Menu.csproj"/>
         <Project Path="Plugins/SkyCD.Plugin.Zip/SkyCD.Plugin.Zip.csproj"/>
         <Project Path="Plugins/SkyCD.Plugin.SevenZip/SkyCD.Plugin.SevenZip.csproj"/>
@@ -50,6 +51,7 @@
         <Project Path="tests/SkyCD.Plugin.Legacy.Cscd.Tests/SkyCD.Plugin.Legacy.Cscd.Tests.csproj"/>
         <Project Path="tests/SkyCD.Plugin.Legacy.Scd.Tests/SkyCD.Plugin.Legacy.Scd.Tests.csproj"/>
         <Project Path="tests/SkyCD.Plugin.Markdown.Tests/SkyCD.Plugin.Markdown.Tests.csproj"/>
+        <Project Path="tests/SkyCD.Plugin.Pls.Tests/SkyCD.Plugin.Pls.Tests.csproj"/>
         <Project Path="tests/SkyCD.Plugin.Sample.Menu.Tests/SkyCD.Plugin.Sample.Menu.Tests.csproj"/>
         <Project Path="tests/SkyCD.Plugin.Sample.Modal.Tests/SkyCD.Plugin.Sample.Modal.Tests.csproj"/>
         <Project Path="tests/SkyCD.Plugin.SevenZip.Tests/SkyCD.Plugin.SevenZip.Tests.csproj"/>

--- a/tests/SkyCD.Plugin.Pls.Tests/Fixtures/Pls/catalog-playlist.pls
+++ b/tests/SkyCD.Plugin.Pls.Tests/Fixtures/Pls/catalog-playlist.pls
@@ -1,0 +1,12 @@
+[playlist]
+File1=Music\Archive\Track A.mp3
+Title1=Track A
+Length1=12345
+File2=Music\Archive\Track B.mp3
+Title2=Track B
+Length2=0
+File3=Podcasts\Episode-01.mp3
+Title3=Episode 01
+Length3=777
+NumberOfEntries=3
+Version=2

--- a/tests/SkyCD.Plugin.Pls.Tests/PlsCatalogPluginTests.cs
+++ b/tests/SkyCD.Plugin.Pls.Tests/PlsCatalogPluginTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Pls;
+using SkyCD.Plugin.Runtime.Managers;
+using Xunit;
+
+namespace SkyCD.Plugin.Host.Tests;
+
+public class PlsCatalogPluginTests
+{
+    [Fact]
+    public void GetOpenAndSaveFormats_ExposesPlsPluginMetadata()
+    {
+        var service = CreateService();
+
+        var openFormats = service.GetOpenFormats();
+        var saveFormats = service.GetSaveFormats();
+
+        Assert.Contains(openFormats, format => format.FormatId == "skycd-pls" && format.Extensions.Contains(".pls"));
+        Assert.Contains(saveFormats, format => format.FormatId == "skycd-pls" && format.Extensions.Contains(".pls"));
+    }
+
+    [Fact]
+    public async Task ReadAndWriteAsync_RoundTripsPlaylistEntries()
+    {
+        var service = CreateService();
+        var fixturePath = Path.Combine(AppContext.BaseDirectory, "Fixtures", "Pls", "catalog-playlist.pls");
+
+        await using var source = File.OpenRead(fixturePath);
+        var readResult = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-pls",
+            Source = source
+        });
+
+        Assert.True(readResult.Success);
+        var document = Assert.IsType<PlsPlaylistDocument>(readResult.Payload);
+        Assert.Equal(3, document.Entries.Count);
+        Assert.Contains(document.Entries, entry => entry.Path == @"Music\Archive\Track A.mp3");
+
+        await using var target = new MemoryStream();
+        var writeResult = await service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "skycd-pls",
+            Target = target,
+            Payload = document
+        });
+
+        Assert.True(writeResult.Success);
+        var written = Encoding.UTF8.GetString(target.ToArray());
+        Assert.Contains("[playlist]", written);
+        Assert.Contains("NumberOfEntries=3", written);
+        Assert.Contains("Version=2", written);
+
+        target.Position = 0;
+        var roundTrip = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-pls",
+            Source = target
+        });
+
+        Assert.True(roundTrip.Success);
+        var roundTripDocument = Assert.IsType<PlsPlaylistDocument>(roundTrip.Payload);
+        Assert.Equal(3, roundTripDocument.Entries.Count);
+    }
+
+    private static FileFormatManager CreateService()
+    {
+        return new FileFormatManager([new PlsCatalogPlugin()]);
+    }
+}

--- a/tests/SkyCD.Plugin.Pls.Tests/SkyCD.Plugin.Pls.Tests.csproj
+++ b/tests/SkyCD.Plugin.Pls.Tests/SkyCD.Plugin.Pls.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="10.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\SkyCD.Plugin.Host\SkyCD.Plugin.Host.csproj"/>
+        <ProjectReference Include="..\..\src\SkyCD.Plugin.Runtime\SkyCD.Plugin.Runtime.csproj"/>
+        <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj"/>
+        <ProjectReference Include="..\..\src\SkyCD.Couchbase\SkyCD.Couchbase.csproj"/>
+        <ProjectReference Include="..\..\Plugins\SkyCD.Plugin.Pls\SkyCD.Plugin.Pls.csproj"/>
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="Fixtures\Pls\catalog-playlist.pls">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+</Project>


### PR DESCRIPTION
Solves #344: Add PLS file format support

Summary:
- add new SkyCD.Plugin.Pls file format plugin for .pls playlists
- support reading PLS files into Entries payload with Path, Title, and SizeBytes
- support writing valid PLS v2 playlists from plugin payload
- add SkyCD.Plugin.Pls.Tests with fixture-based roundtrip coverage
- include plugin and tests in SkyCD.slnx

Validation:
- dotnet format SkyCD.slnx --verify-no-changes --verbosity minimal
- dotnet build SkyCD.slnx --configuration Release --no-restore
- dotnet test SkyCD.slnx --configuration Release --no-build