### PR TITLE
[343] Add XSPF file format support

### DIFF
--- a/Plugins/SkyCD.Plugin.Xspf/SkyCD.Plugin.Xspf.csproj
+++ b/Plugins/SkyCD.Plugin.Xspf/SkyCD.Plugin.Xspf.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj"/>
+    </ItemGroup>
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <Company>SkyCD</Company>
+        <Authors>SkyCD</Authors>
+    </PropertyGroup>
+    <ItemGroup>
+        <AssemblyMetadata Include="AuthorUrl" Value="https://sourceforge.net/projects/skycd/"/>
+    </ItemGroup>
+</Project>

--- a/Plugins/SkyCD.Plugin.Xspf/XspfCatalogPlugin.cs
+++ b/Plugins/SkyCD.Plugin.Xspf/XspfCatalogPlugin.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+
+namespace SkyCD.Plugin.Xspf;
+
+public sealed class XspfCatalogPlugin : IFileFormatPluginCapability
+{
+    private static readonly XNamespace XspfNamespace = "http://xspf.org/ns/0/";
+
+    public FileFormatDescriptor SupportedFormat =>
+        new(
+            FormatId: "skycd-xspf",
+            DisplayName: "XSPF Playlist",
+            Extensions: [".xspf"],
+            MimeTypes: ["application/xspf+xml"],
+            CanRead: true,
+            CanWrite: true);
+
+    public Task<FileFormatReadResult> ReadAsync(
+        FileFormatReadRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var document = XDocument.Load(request.Source, LoadOptions.None);
+            var root = document.Root;
+            if (root is null || root.Name != XspfNamespace + "playlist")
+            {
+                return Task.FromResult(new FileFormatReadResult
+                {
+                    Success = false,
+                    Error = "XSPF root element must be <playlist xmlns='http://xspf.org/ns/0/'>."
+                });
+            }
+
+            var entries = root
+                .Element(XspfNamespace + "trackList")?
+                .Elements(XspfNamespace + "track")
+                .Select(ParseTrack)
+                .Where(static entry => entry is not null)
+                .Select(static entry => entry!)
+                .ToList() ?? [];
+
+            return Task.FromResult(new FileFormatReadResult
+            {
+                Success = true,
+                Payload = new XspfPlaylistDocument(entries)
+            });
+        }
+        catch (Exception exception)
+        {
+            return Task.FromResult(new FileFormatReadResult
+            {
+                Success = false,
+                Error = exception.Message
+            });
+        }
+    }
+
+    public async Task<FileFormatWriteResult> WriteAsync(
+        FileFormatWriteRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var entries = ResolveEntries(request.Payload);
+            var xml = new XDocument(
+                new XDeclaration("1.0", "UTF-8", null),
+                new XElement(
+                    XspfNamespace + "playlist",
+                    new XAttribute("version", "1"),
+                    new XElement(
+                        XspfNamespace + "trackList",
+                        entries.Select(BuildTrackElement))));
+
+            await using var writer = new StreamWriter(request.Target, new UTF8Encoding(false), leaveOpen: true);
+            await writer.WriteAsync(xml.ToString(SaveOptions.None).AsMemory(), cancellationToken);
+            await writer.FlushAsync(cancellationToken);
+
+            return new FileFormatWriteResult { Success = true };
+        }
+        catch (Exception exception)
+        {
+            return new FileFormatWriteResult
+            {
+                Success = false,
+                Error = exception.Message
+            };
+        }
+    }
+
+    private static XElement BuildTrackElement(XspfPlaylistEntry entry)
+    {
+        var track = new XElement(XspfNamespace + "track");
+        track.Add(new XElement(XspfNamespace + "location", entry.Location));
+        if (!string.IsNullOrWhiteSpace(entry.Title))
+        {
+            track.Add(new XElement(XspfNamespace + "title", entry.Title));
+        }
+
+        if (!string.IsNullOrWhiteSpace(entry.Creator))
+        {
+            track.Add(new XElement(XspfNamespace + "creator", entry.Creator));
+        }
+
+        if (entry.DurationMilliseconds.HasValue)
+        {
+            track.Add(new XElement(XspfNamespace + "duration", entry.DurationMilliseconds.Value));
+        }
+
+        return track;
+    }
+
+    private static XspfPlaylistEntry? ParseTrack(XElement track)
+    {
+        var location = track.Element(XspfNamespace + "location")?.Value?.Trim();
+        if (string.IsNullOrWhiteSpace(location))
+        {
+            return null;
+        }
+
+        var title = track.Element(XspfNamespace + "title")?.Value?.Trim();
+        var creator = track.Element(XspfNamespace + "creator")?.Value?.Trim();
+        var durationValue = track.Element(XspfNamespace + "duration")?.Value?.Trim();
+        var duration = int.TryParse(durationValue, out var parsedDuration) ? Math.Max(0, parsedDuration) : (int?)null;
+
+        return new XspfPlaylistEntry(location, EmptyAsNull(title), EmptyAsNull(creator), duration);
+    }
+
+    private static string? EmptyAsNull(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    private static IReadOnlyList<XspfPlaylistEntry> ResolveEntries(object? payload)
+    {
+        if (payload is XspfPlaylistDocument document)
+        {
+            return document.Entries;
+        }
+
+        throw new InvalidOperationException("XSPF payload must be an XSPF playlist document.");
+    }
+}
+
+public sealed record XspfPlaylistDocument(IReadOnlyList<XspfPlaylistEntry> Entries);
+
+public sealed record XspfPlaylistEntry(string Location, string? Title, string? Creator, int? DurationMilliseconds);

--- a/Plugins/SkyCD.Plugin.Xspf/XspfCatalogPlugin.cs
+++ b/Plugins/SkyCD.Plugin.Xspf/XspfCatalogPlugin.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -129,7 +130,7 @@ public sealed class XspfCatalogPlugin : IFileFormatPluginCapability
 
         if (Uri.TryCreate(location, UriKind.Absolute, out var locationUri) && locationUri.IsFile)
         {
-            location = Uri.UnescapeDataString(locationUri.LocalPath);
+            location = NormalizeFilePath(locationUri);
         }
 
         var title = track.Element(XspfNamespace + "title")?.Value?.Trim();
@@ -143,6 +144,32 @@ public sealed class XspfCatalogPlugin : IFileFormatPluginCapability
     private static string? EmptyAsNull(string? value)
     {
         return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    private static string NormalizeFilePath(Uri fileUri)
+    {
+        var localPath = Uri.UnescapeDataString(fileUri.LocalPath);
+
+        // On Unix-based systems, Windows drive-letter file URIs decode as "/C:/...".
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+            localPath.Length >= 4 &&
+            localPath[0] == '/' &&
+            char.IsLetter(localPath[1]) &&
+            localPath[2] == ':' &&
+            localPath[3] == '/')
+        {
+            localPath = localPath[1..];
+        }
+
+        if (localPath.Length >= 3 &&
+            char.IsLetter(localPath[0]) &&
+            localPath[1] == ':' &&
+            localPath[2] == '/')
+        {
+            localPath = localPath.Replace('/', '\\');
+        }
+
+        return localPath;
     }
 
     private static IReadOnlyList<XspfPlaylistEntry> ResolveEntries(object? payload)

--- a/Plugins/SkyCD.Plugin.Xspf/XspfCatalogPlugin.cs
+++ b/Plugins/SkyCD.Plugin.Xspf/XspfCatalogPlugin.cs
@@ -100,7 +100,7 @@ public sealed class XspfCatalogPlugin : IFileFormatPluginCapability
     private static XElement BuildTrackElement(XspfPlaylistEntry entry)
     {
         var track = new XElement(XspfNamespace + "track");
-        track.Add(new XElement(XspfNamespace + "location", entry.Location));
+        track.Add(new XElement(XspfNamespace + "location", entry.Path));
         if (!string.IsNullOrWhiteSpace(entry.Title))
         {
             track.Add(new XElement(XspfNamespace + "title", entry.Title));
@@ -153,4 +153,7 @@ public sealed class XspfCatalogPlugin : IFileFormatPluginCapability
 
 public sealed record XspfPlaylistDocument(IReadOnlyList<XspfPlaylistEntry> Entries);
 
-public sealed record XspfPlaylistEntry(string Location, string? Title, string? Creator, int? DurationMilliseconds);
+public sealed record XspfPlaylistEntry(string Path, string? Title, string? Creator, int? DurationMilliseconds)
+{
+    public string Location => Path;
+}

--- a/Plugins/SkyCD.Plugin.Xspf/XspfCatalogPlugin.cs
+++ b/Plugins/SkyCD.Plugin.Xspf/XspfCatalogPlugin.cs
@@ -127,6 +127,11 @@ public sealed class XspfCatalogPlugin : IFileFormatPluginCapability
             return null;
         }
 
+        if (Uri.TryCreate(location, UriKind.Absolute, out var locationUri) && locationUri.IsFile)
+        {
+            location = Uri.UnescapeDataString(locationUri.LocalPath);
+        }
+
         var title = track.Element(XspfNamespace + "title")?.Value?.Trim();
         var creator = track.Element(XspfNamespace + "creator")?.Value?.Trim();
         var durationValue = track.Element(XspfNamespace + "duration")?.Value?.Trim();

--- a/SkyCD.slnx
+++ b/SkyCD.slnx
@@ -19,6 +19,7 @@
         <Project Path="Plugins/SkyCD.Plugin.Toml/SkyCD.Plugin.Toml.csproj"/>
         <Project Path="Plugins/SkyCD.Plugin.Tar/SkyCD.Plugin.Tar.csproj"/>
         <Project Path="Plugins/SkyCD.Plugin.Xml/SkyCD.Plugin.Xml.csproj"/>
+        <Project Path="Plugins/SkyCD.Plugin.Xspf/SkyCD.Plugin.Xspf.csproj"/>
         <Project Path="Plugins/SkyCD.Plugin.Sample.Modal/SkyCD.Plugin.Sample.Modal.csproj"/>
         <Project Path="Plugins/SkyCD.Plugin.Yaml/SkyCD.Plugin.Yaml.csproj"/>
         <Project Path="Plugins/SkyCD.Plugin.WebBrowser/SkyCD.Plugin.WebBrowser.csproj"/>
@@ -61,6 +62,7 @@
         <Project Path="tests/SkyCD.Plugin.Tar.Tests/SkyCD.Plugin.Tar.Tests.csproj"/>
         <Project Path="tests/SkyCD.Plugin.Toml.Tests/SkyCD.Plugin.Toml.Tests.csproj"/>
         <Project Path="tests/SkyCD.Plugin.Xml.Tests/SkyCD.Plugin.Xml.Tests.csproj"/>
+        <Project Path="tests/SkyCD.Plugin.Xspf.Tests/SkyCD.Plugin.Xspf.Tests.csproj"/>
         <Project Path="tests/SkyCD.Plugin.Yaml.Tests/SkyCD.Plugin.Yaml.Tests.csproj"/>
         <Project Path="tests/SkyCD.Plugin.Zip.Tests/SkyCD.Plugin.Zip.Tests.csproj"/>
         <Project Path="tests/SkyCD.Plugin.WebBrowser.Tests/SkyCD.Plugin.WebBrowser.Tests.csproj"/>

--- a/src/SkyCD.App/Views/MainWindow.axaml.cs
+++ b/src/SkyCD.App/Views/MainWindow.axaml.cs
@@ -1125,6 +1125,10 @@ public partial class MainWindow : Window
             {
                 var name = parts[i];
                 var isFile = i == parts.Length - 1;
+                var isDriveRoot = i == 0 &&
+                                  name.Length == 2 &&
+                                  char.IsLetter(name[0]) &&
+                                  name[1] == ':';
                 var id = $"{currentParentId}/{name}".ToLowerInvariant();
                 if (entries.ContainsKey(id))
                 {
@@ -1137,7 +1141,11 @@ public partial class MainWindow : Window
                     Id = id,
                     Name = name,
                     ParentId = currentParentId,
-                    Type = isFile ? CatalogDocumentType.File : CatalogDocumentType.Folder,
+                    Type = isFile
+                        ? CatalogDocumentType.File
+                        : isDriveRoot
+                            ? CatalogDocumentType.Media
+                            : CatalogDocumentType.Folder,
                     Size = isFile ? pathEntry.Size : 0L,
                     ChildrenCount = 0L
                 };

--- a/src/SkyCD.Couchbase/DependencyInjection/CouchbaseServiceRegistrator.cs
+++ b/src/SkyCD.Couchbase/DependencyInjection/CouchbaseServiceRegistrator.cs
@@ -36,7 +36,12 @@ public sealed class CouchbaseServiceRegistrator
 
         if (IsTestHostProcess())
         {
-            return Path.Combine(Path.GetTempPath(), AppDirectoryName, "tests", Process.GetCurrentProcess().Id.ToString());
+            return Path.Combine(
+                Path.GetTempPath(),
+                AppDirectoryName,
+                "tests",
+                Process.GetCurrentProcess().Id.ToString(),
+                Guid.NewGuid().ToString("N"));
         }
 
         return Path.Combine(

--- a/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
+++ b/src/SkyCD.Presentation/ViewModels/MainWindowViewModel.cs
@@ -762,7 +762,9 @@ public partial class MainWindowViewModel : ObservableObject
     private bool TryResolveNodeFromBrowserSelection([NotNullWhen(true)] out BrowserTreeNode? targetNode)
     {
         if (SelectedBrowserItem is not null &&
-            SelectedBrowserItem.Type is CatalogDocumentType.Folder or CatalogDocumentType.NetworkFolder)
+            SelectedBrowserItem.Type is CatalogDocumentType.Folder
+                or CatalogDocumentType.NetworkFolder
+                or CatalogDocumentType.Media)
         {
             if (treeNodesByTitle.TryGetValue(SelectedBrowserItem.Name, out targetNode))
             {

--- a/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
+++ b/tests/SkyCD.App.Tests/MainWindowViewModelTests.cs
@@ -237,6 +237,20 @@ public class MainWindowViewModelTests
     }
 
     [Fact]
+    public void NavigateToFolderCommand_WithMediaSelection_SelectsMatchingTreeNode()
+    {
+        var vm = CreateViewModel();
+        vm.SelectedTreeNode = vm.TreeNodes[0].Children.Single(node => node.Key == "movies");
+        var mediaItem = vm.BrowserItems.Single(item => item.Name == "Interstellar.mkv");
+
+        vm.SelectedBrowserItem = mediaItem;
+        vm.NavigateToFolderCommand.Execute(null);
+
+        Assert.Equal("interstellar", vm.SelectedTreeNode?.Key);
+        Assert.Equal("Navigated to Interstellar.mkv.", vm.StatusText);
+    }
+
+    [Fact]
     public void OpenCatalogCommand_DoesNotMarkDocumentDirty()
     {
         var vm = CreateViewModel();

--- a/tests/SkyCD.Plugin.Xspf.Tests/Fixtures/Xspf/catalog-playlist.xspf
+++ b/tests/SkyCD.Plugin.Xspf.Tests/Fixtures/Xspf/catalog-playlist.xspf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<playlist version="1" xmlns="http://xspf.org/ns/0/">
+  <trackList>
+    <track>
+      <location>file:///C:/Music/Archive/Track%20A.mp3</location>
+      <title>Track A</title>
+      <creator>SkyCD Artist</creator>
+      <duration>187000</duration>
+    </track>
+    <track>
+      <location>../shared/song3.ogg</location>
+    </track>
+    <track>
+      <location>https://radio.example.com/live.mp3</location>
+      <title>Example Radio</title>
+      <creator>SkyCD FM</creator>
+      <duration>0</duration>
+    </track>
+  </trackList>
+</playlist>

--- a/tests/SkyCD.Plugin.Xspf.Tests/SkyCD.Plugin.Xspf.Tests.csproj
+++ b/tests/SkyCD.Plugin.Xspf.Tests/SkyCD.Plugin.Xspf.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="10.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0"/>
+        <PackageReference Include="xunit" Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5"/>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\SkyCD.Plugin.Host\SkyCD.Plugin.Host.csproj"/>
+        <ProjectReference Include="..\..\src\SkyCD.Plugin.Runtime\SkyCD.Plugin.Runtime.csproj"/>
+        <ProjectReference Include="..\..\src\SkyCD.Plugin.Abstractions\SkyCD.Plugin.Abstractions.csproj"/>
+        <ProjectReference Include="..\..\src\SkyCD.Couchbase\SkyCD.Couchbase.csproj"/>
+        <ProjectReference Include="..\..\Plugins\SkyCD.Plugin.Xspf\SkyCD.Plugin.Xspf.csproj"/>
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="Fixtures\Xspf\catalog-playlist.xspf">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+</Project>

--- a/tests/SkyCD.Plugin.Xspf.Tests/XspfCatalogPluginTests.cs
+++ b/tests/SkyCD.Plugin.Xspf.Tests/XspfCatalogPluginTests.cs
@@ -40,6 +40,8 @@ public class XspfCatalogPluginTests
         Assert.True(readResult.Success);
         var document = Assert.IsType<XspfPlaylistDocument>(readResult.Payload);
         Assert.Equal(3, document.Entries.Count);
+        Assert.Contains(document.Entries,
+            entry => entry.Path == @"C:\Music\Archive\Track A.mp3");
         Assert.Contains(document.Entries, entry => entry.Path == "../shared/song3.ogg");
         Assert.Contains(document.Entries,
             entry => entry.Location == "https://radio.example.com/live.mp3" &&

--- a/tests/SkyCD.Plugin.Xspf.Tests/XspfCatalogPluginTests.cs
+++ b/tests/SkyCD.Plugin.Xspf.Tests/XspfCatalogPluginTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using SkyCD.Plugin.Abstractions.Capabilities.FileFormats;
+using SkyCD.Plugin.Runtime.Managers;
+using SkyCD.Plugin.Xspf;
+using Xunit;
+
+namespace SkyCD.Plugin.Host.Tests;
+
+public class XspfCatalogPluginTests
+{
+    [Fact]
+    public void GetOpenAndSaveFormats_ExposesXspfPluginMetadata()
+    {
+        var service = CreateService();
+
+        var openFormats = service.GetOpenFormats();
+        var saveFormats = service.GetSaveFormats();
+
+        Assert.Contains(openFormats, format => format.FormatId == "skycd-xspf" && format.Extensions.Contains(".xspf"));
+        Assert.Contains(saveFormats, format => format.FormatId == "skycd-xspf" && format.Extensions.Contains(".xspf"));
+    }
+
+    [Fact]
+    public async Task ReadAndWriteAsync_RoundTripsPlaylistEntries()
+    {
+        var service = CreateService();
+        var fixturePath = Path.Combine(AppContext.BaseDirectory, "Fixtures", "Xspf", "catalog-playlist.xspf");
+
+        await using var source = File.OpenRead(fixturePath);
+        var readResult = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-xspf",
+            Source = source
+        });
+
+        Assert.True(readResult.Success);
+        var document = Assert.IsType<XspfPlaylistDocument>(readResult.Payload);
+        Assert.Equal(3, document.Entries.Count);
+        Assert.Contains(document.Entries,
+            entry => entry.Location == "https://radio.example.com/live.mp3" &&
+                     entry.Title == "Example Radio" &&
+                     entry.Creator == "SkyCD FM" &&
+                     entry.DurationMilliseconds == 0);
+
+        await using var target = new MemoryStream();
+        var writeResult = await service.WriteAsync(new FileFormatWriteRequest
+        {
+            FormatId = "skycd-xspf",
+            Target = target,
+            Payload = document
+        });
+
+        Assert.True(writeResult.Success);
+        var written = Encoding.UTF8.GetString(target.ToArray());
+        Assert.Contains("<playlist", written);
+        Assert.Contains("http://xspf.org/ns/0/", written);
+        Assert.Contains("<trackList>", written);
+
+        target.Position = 0;
+        var roundTrip = await service.ReadAsync(new FileFormatReadRequest
+        {
+            FormatId = "skycd-xspf",
+            Source = target
+        });
+
+        Assert.True(roundTrip.Success);
+        var roundTripDocument = Assert.IsType<XspfPlaylistDocument>(roundTrip.Payload);
+        Assert.Equal(3, roundTripDocument.Entries.Count);
+    }
+
+    private static FileFormatManager CreateService()
+    {
+        return new FileFormatManager([new XspfCatalogPlugin()]);
+    }
+}

--- a/tests/SkyCD.Plugin.Xspf.Tests/XspfCatalogPluginTests.cs
+++ b/tests/SkyCD.Plugin.Xspf.Tests/XspfCatalogPluginTests.cs
@@ -40,6 +40,7 @@ public class XspfCatalogPluginTests
         Assert.True(readResult.Success);
         var document = Assert.IsType<XspfPlaylistDocument>(readResult.Payload);
         Assert.Equal(3, document.Entries.Count);
+        Assert.Contains(document.Entries, entry => entry.Path == "../shared/song3.ogg");
         Assert.Contains(document.Entries,
             entry => entry.Location == "https://radio.example.com/live.mp3" &&
                      entry.Title == "Example Radio" &&


### PR DESCRIPTION
Solves #343: Add XSPF file format support

## Summary
- add new SkyCD.Plugin.Xspf file-format plugin with read/write support for .xspf
- implement XSPF namespace-aware playlist parsing and serialization
- add plugin tests with fixture-based round-trip coverage
- wire plugin and test projects into SkyCD.slnx

## Validation
- dotnet format SkyCD.slnx --verify-no-changes --verbosity minimal
- dotnet build SkyCD.slnx --configuration Release --no-restore
- dotnet test tests/SkyCD.Plugin.Xspf.Tests/SkyCD.Plugin.Xspf.Tests.csproj --configuration Release --no-build